### PR TITLE
feat(config): ForwardConfig に UpstreamTLS 追加 + TLS/UpstreamTLS 意味論の確定

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -374,6 +374,32 @@ func isValidProjectNameRune(r rune) bool {
 // ForwardConfig holds the configuration for a single TCP forward entry.
 // It specifies the upstream target address and optional protocol/TLS hints
 // for L7 parsing on forwarded connections.
+//
+// # TLS vs UpstreamTLS semantics
+//
+// TLS and UpstreamTLS are independent boolean fields that control two
+// separate concerns and are never inferred from Target's scheme or port:
+//
+//   - TLS: client-side TLS MITM termination on the forwarded listen port.
+//     When true, the proxy presents a dynamically-issued certificate to the
+//     local client and terminates TLS before applying L7 parsing.
+//   - UpstreamTLS: upstream-dial TLS encryption to Target.
+//     When true, the proxy wraps the upstream-direction connection in TLS
+//     (with TLS fingerprint / SNI / verify settings from the global config)
+//     before forwarding bytes / L7 messages.
+//
+// The four combinations and their typical scenarios:
+//
+//	| TLS   | UpstreamTLS | Client wire | Upstream wire | Typical use case                              |
+//	|-------|-------------|-------------|---------------|-----------------------------------------------|
+//	| false | false       | plaintext   | plaintext     | Raw L4/L7 forwarding (default; USK-711)       |
+//	| true  | false       | TLS         | plaintext     | TLS termination only (downstream offload)     |
+//	| false | true        | plaintext   | TLS           | Plaintext client → TLS-only upstream          |
+//	| true  | true        | TLS         | TLS           | Full MITM: terminate then re-encrypt upstream |
+//
+// Both fields default to false, which preserves the existing raw-forward
+// behavior. Target's scheme/port are advisory only; they do not change the
+// effective TLS / UpstreamTLS values.
 type ForwardConfig struct {
 	// Target is the upstream address (e.g. "api.example.com:50051").
 	Target string `json:"target"`
@@ -384,10 +410,23 @@ type ForwardConfig struct {
 	// Empty is treated as "auto".
 	Protocol string `json:"protocol,omitempty"`
 
-	// TLS enables TLS MITM termination on the forwarded port.
+	// TLS enables TLS MITM termination on the forwarded port (client-side).
 	// When true, the proxy terminates TLS using the target hostname
 	// for certificate generation, then applies L7 parsing.
+	//
+	// This field controls ONLY the client-direction (listen-port) TLS state.
+	// For upstream-dial TLS encryption, see UpstreamTLS.
 	TLS bool `json:"tls,omitempty"`
+
+	// UpstreamTLS enables TLS encryption on the upstream-dial connection.
+	// When true, the proxy connects to Target over TLS (using the global
+	// TLS fingerprint, SNI derived from Target, and the configured
+	// verification / client-cert settings).
+	//
+	// This field controls ONLY the upstream-direction TLS state. It is
+	// independent of TLS and is not inferred from Target's scheme/port.
+	// See the type-level godoc for the full TLS × UpstreamTLS matrix.
+	UpstreamTLS bool `json:"upstream_tls,omitempty"`
 }
 
 // validForwardProtocols is the set of valid protocol values for ForwardConfig.

--- a/internal/config/forward_config_test.go
+++ b/internal/config/forward_config_test.go
@@ -50,6 +50,126 @@ func TestProxyConfig_UnmarshalJSON_StructuredFormat(t *testing.T) {
 	if !fc.TLS {
 		t.Error("TLS should be true")
 	}
+	if fc.UpstreamTLS {
+		t.Error("UpstreamTLS should default to false when omitted")
+	}
+}
+
+// TestForwardConfig_UnmarshalJSON_TLSUpstreamTLSMatrix exercises every
+// combination of (tls, upstream_tls) across the JSON unmarshal path so
+// the four scenarios described in the ForwardConfig godoc are
+// independently verified. USK-911.
+func TestForwardConfig_UnmarshalJSON_TLSUpstreamTLSMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		json     string
+		wantTLS  bool
+		wantUTLS bool
+	}{
+		{
+			name:     "both false (default raw forwarding)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "raw"}}}`,
+			wantTLS:  false,
+			wantUTLS: false,
+		},
+		{
+			name:     "tls only (client-side termination)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "tls": true}}}`,
+			wantTLS:  true,
+			wantUTLS: false,
+		},
+		{
+			name:     "upstream_tls only (plaintext client to TLS upstream)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "upstream_tls": true}}}`,
+			wantTLS:  false,
+			wantUTLS: true,
+		},
+		{
+			name:     "both true (full MITM with re-encryption)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "tls": true, "upstream_tls": true}}}`,
+			wantTLS:  true,
+			wantUTLS: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg ProxyConfig
+			if err := json.Unmarshal([]byte(tc.json), &cfg); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			fc := cfg.TCPForwards["9000"]
+			if fc == nil {
+				t.Fatal("TCPForwards[9000] is nil")
+			}
+			if fc.TLS != tc.wantTLS {
+				t.Errorf("TLS = %v, want %v", fc.TLS, tc.wantTLS)
+			}
+			if fc.UpstreamTLS != tc.wantUTLS {
+				t.Errorf("UpstreamTLS = %v, want %v", fc.UpstreamTLS, tc.wantUTLS)
+			}
+		})
+	}
+}
+
+// TestForwardConfig_MarshalJSON_OmitEmptyDefaults verifies that the
+// omitempty tag on UpstreamTLS prevents the field from leaking false
+// defaults into the serialized output, matching the existing TLS
+// behavior. USK-911.
+func TestForwardConfig_MarshalJSON_OmitEmptyDefaults(t *testing.T) {
+	fc := &ForwardConfig{Target: "h:9000", Protocol: "raw"}
+	data, err := json.Marshal(fc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "upstream_tls") {
+		t.Errorf("Marshal output should omit upstream_tls when false, got %s", s)
+	}
+	if strings.Contains(s, `"tls"`) {
+		t.Errorf("Marshal output should omit tls when false, got %s", s)
+	}
+
+	fc2 := &ForwardConfig{Target: "h:9000", Protocol: "raw", UpstreamTLS: true}
+	data2, err := json.Marshal(fc2)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data2), `"upstream_tls":true`) {
+		t.Errorf("Marshal output should include upstream_tls=true, got %s", string(data2))
+	}
+}
+
+// TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations confirms the
+// (tls, upstream_tls) bits survive a Marshal → Unmarshal cycle in every
+// combination. USK-911.
+func TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations(t *testing.T) {
+	cases := []struct {
+		name string
+		fc   ForwardConfig
+	}{
+		{"both false", ForwardConfig{Target: "h:9000", Protocol: "raw"}},
+		{"tls only", ForwardConfig{Target: "h:9000", Protocol: "http", TLS: true}},
+		{"upstream_tls only", ForwardConfig{Target: "h:9000", Protocol: "http", UpstreamTLS: true}},
+		{"both true", ForwardConfig{Target: "h:9000", Protocol: "http", TLS: true, UpstreamTLS: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.fc)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got ForwardConfig
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got.TLS != tc.fc.TLS {
+				t.Errorf("TLS round-trip = %v, want %v (json=%s)", got.TLS, tc.fc.TLS, string(data))
+			}
+			if got.UpstreamTLS != tc.fc.UpstreamTLS {
+				t.Errorf("UpstreamTLS round-trip = %v, want %v (json=%s)", got.UpstreamTLS, tc.fc.UpstreamTLS, string(data))
+			}
+		})
+	}
 }
 
 func TestProxyConfig_UnmarshalJSON_MixedFormat(t *testing.T) {
@@ -215,6 +335,16 @@ func TestValidateForwardConfig(t *testing.T) {
 			name: "tls with raw emits warning but no error",
 			port: "3306",
 			fc:   &ForwardConfig{Target: "db:3306", Protocol: "raw", TLS: true},
+		},
+		{
+			name: "upstream_tls with raw is accepted (warn happens at MCP layer)",
+			port: "3306",
+			fc:   &ForwardConfig{Target: "db:3306", Protocol: "raw", UpstreamTLS: true},
+		},
+		{
+			name: "tls and upstream_tls both true is valid (full MITM re-encrypt)",
+			port: "443",
+			fc:   &ForwardConfig{Target: "h:443", Protocol: "http", TLS: true, UpstreamTLS: true},
 		},
 		{
 			name: "valid http",

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -82,9 +82,11 @@ type proxyStartInput struct {
 
 	// TCPForwards maps local listen ports to forwarding configurations.
 	// Values can be strings (legacy: "host:port") or ForwardConfig objects
-	// ({target, protocol, tls}). Uses map[string]any to accept both formats
-	// in the MCP JSON schema; parsed into *config.ForwardConfig by parseTCPForwardsAny.
-	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string or {target, protocol, tls} object"`
+	// ({target, protocol, tls, upstream_tls}). Uses map[string]any to accept
+	// both formats in the MCP JSON schema; parsed into *config.ForwardConfig
+	// by parseTCPForwardsAny. See yorishiro://help/proxy_start for the full
+	// TLS × upstream_tls matrix.
+	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string or {target, protocol, tls, upstream_tls} object; tls=client-side termination, upstream_tls=upstream-dial encryption (independent)"`
 
 	// SOCKS5Auth specifies the SOCKS5 authentication method.
 	// Valid values: "none" (default), "password".
@@ -138,8 +140,9 @@ type proxyStartInput struct {
 }
 
 // parseTCPForwardsAny parses TCP forward values from the MCP input into structured ForwardConfig.
-// Each value can be a string (legacy: "host:port") or an object with {target, protocol, tls}.
-// Legacy string values are converted to ForwardConfig{Target: value, Protocol: "raw"}.
+// Each value can be a string (legacy: "host:port") or an object with
+// {target, protocol, tls, upstream_tls}. Legacy string values are converted
+// to ForwardConfig{Target: value, Protocol: "raw"}.
 func parseTCPForwardsAny(raw map[string]any) (map[string]*config.ForwardConfig, error) {
 	if len(raw) == 0 {
 		return nil, nil
@@ -162,6 +165,9 @@ func parseTCPForwardsAny(raw map[string]any) (map[string]*config.ForwardConfig, 
 			}
 			if tls, ok := v["tls"].(bool); ok {
 				fc.TLS = tls
+			}
+			if utls, ok := v["upstream_tls"].(bool); ok {
+				fc.UpstreamTLS = utls
 			}
 			result[port] = fc
 		default:
@@ -739,6 +745,22 @@ func validateTCPForwardsConfig(forwards map[string]*config.ForwardConfig) error 
 		if fc.TLS && fc.Protocol == "raw" {
 			slog.Warn("TCP forward: tls=true with protocol=raw means TLS termination without L7 parsing",
 				"port", port, "target", fc.Target)
+		}
+		// Warn about unusual but valid combination: upstream TLS encryption
+		// wrapping an opaque byte stream (USK-911). Permitted, but typically
+		// the operator wants L7 parsing in front of upstream TLS too.
+		if fc.UpstreamTLS && fc.Protocol == "raw" {
+			slog.Warn("TCP forward: upstream_tls=true with protocol=raw means upstream TLS encryption without L7 parsing",
+				"port", port, "target", fc.Target)
+		}
+		// Inform operators that the TLS field's semantics are now strictly
+		// scoped to client-side termination (USK-911). Users who previously
+		// set tls=true expecting upstream encryption must now also set
+		// upstream_tls=true. Emitted per-entry whenever TLS=true so the
+		// notice reliably reaches operators of any matching config.
+		if fc.TLS {
+			slog.Info("TCP forward: tls now means client-side termination only; for upstream TLS use upstream_tls=true",
+				"port", port, "target", fc.Target, "upstream_tls", fc.UpstreamTLS)
 		}
 		// Validate target is host:port format.
 		host, p, err := net.SplitHostPort(fc.Target)

--- a/internal/mcp/proxy_start_tool_test.go
+++ b/internal/mcp/proxy_start_tool_test.go
@@ -1038,6 +1038,77 @@ func TestApplyProxyDefaults_TCPForwards(t *testing.T) {
 	})
 }
 
+// TestParseTCPForwardsAny_UpstreamTLS verifies the MCP input parser
+// extracts the upstream_tls boolean field independently of the existing
+// tls field, covering all four (tls, upstream_tls) combinations. USK-911.
+func TestParseTCPForwardsAny_UpstreamTLS(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    map[string]any
+		wantTLS  bool
+		wantUTLS bool
+	}{
+		{
+			name: "neither flag set",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "raw"},
+			},
+			wantTLS:  false,
+			wantUTLS: false,
+		},
+		{
+			name: "tls only",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "http", "tls": true},
+			},
+			wantTLS:  true,
+			wantUTLS: false,
+		},
+		{
+			name: "upstream_tls only",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "http", "upstream_tls": true},
+			},
+			wantTLS:  false,
+			wantUTLS: true,
+		},
+		{
+			name: "both flags",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "http", "tls": true, "upstream_tls": true},
+			},
+			wantTLS:  true,
+			wantUTLS: true,
+		},
+		{
+			name: "upstream_tls non-bool is ignored (defensive: field stays false)",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "http", "upstream_tls": "yes"},
+			},
+			wantTLS:  false,
+			wantUTLS: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseTCPForwardsAny(tc.input)
+			if err != nil {
+				t.Fatalf("parseTCPForwardsAny: %v", err)
+			}
+			fc := parsed["9000"]
+			if fc == nil {
+				t.Fatal("parsed[9000] is nil")
+			}
+			if fc.TLS != tc.wantTLS {
+				t.Errorf("TLS = %v, want %v", fc.TLS, tc.wantTLS)
+			}
+			if fc.UpstreamTLS != tc.wantUTLS {
+				t.Errorf("UpstreamTLS = %v, want %v", fc.UpstreamTLS, tc.wantUTLS)
+			}
+		})
+	}
+}
+
 func TestApplyProxyDefaults_InterceptRules(t *testing.T) {
 	rulesJSON := json.RawMessage(`[{
 		"id": "default-rule",

--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -50,8 +50,19 @@ Each entry maps a local port number (string key) to either:
   - **target** (string, required): Upstream address in `"host:port"` format (e.g. `"api.example.com:50051"`)
   - **protocol** (string, optional): Expected protocol for L7 parsing. Default: `"auto"` (peek-based detection).
     Valid values: `"auto"`, `"raw"`, `"http"`, `"http2"`, `"grpc"`, `"websocket"`
-  - **tls** (boolean, optional): Enable TLS MITM termination on the forwarded port. Default: `false`.
-    When true, the proxy terminates TLS using the target hostname for certificate generation, then applies L7 parsing.
+  - **tls** (boolean, optional): Enable client-side TLS MITM termination on the forwarded listen port. Default: `false`.
+    When true, the proxy presents a dynamically-issued certificate to the local client and terminates TLS before applying L7 parsing.
+  - **upstream_tls** (boolean, optional): Enable upstream-dial TLS encryption to `target`. Default: `false`.
+    When true, the proxy wraps the upstream-direction connection in TLS (using the global TLS fingerprint, SNI derived from `target`, and the configured verification / client-cert settings).
+
+`tls` and `upstream_tls` are **independent** and are never inferred from `target`'s scheme or port:
+
+| tls   | upstream_tls | Client wire | Upstream wire | Typical use case                              |
+|-------|--------------|-------------|---------------|-----------------------------------------------|
+| false | false        | plaintext   | plaintext     | Raw L4/L7 forwarding (default)                |
+| true  | false        | TLS         | plaintext     | TLS termination only (downstream offload)     |
+| false | true         | plaintext   | TLS           | Plaintext client → TLS-only upstream          |
+| true  | true         | TLS         | TLS           | Full MITM: terminate then re-encrypt upstream |
 
 - If omitted, TCP forwarding is not configured
 - Both legacy string format and structured ForwardConfig can be mixed in the same object

--- a/internal/mcp/resources/schema_proxy_start.json
+++ b/internal/mcp/resources/schema_proxy_start.json
@@ -37,7 +37,7 @@
     },
     "tcp_forwards": {
       "type": "object",
-      "description": "Maps local listen ports to upstream forwarding configurations. Values can be strings (legacy: host:port) or ForwardConfig objects ({target, protocol, tls}).",
+      "description": "Maps local listen ports to upstream forwarding configurations. Values can be strings (legacy: host:port) or ForwardConfig objects ({target, protocol, tls, upstream_tls}). tls=client-side termination, upstream_tls=upstream-dial encryption (independent fields).",
       "additionalProperties": {
         "oneOf": [
           {
@@ -46,7 +46,7 @@
           },
           {
             "type": "object",
-            "description": "ForwardConfig with target, protocol, and TLS options.",
+            "description": "ForwardConfig with target, protocol, client-side TLS, and upstream TLS options.",
             "required": ["target"],
             "properties": {
               "target": {
@@ -60,7 +60,11 @@
               },
               "tls": {
                 "type": "boolean",
-                "description": "Enable TLS MITM termination on the forwarded port. Default: false."
+                "description": "Enable client-side TLS MITM termination on the forwarded listen port. Default: false."
+              },
+              "upstream_tls": {
+                "type": "boolean",
+                "description": "Enable upstream-dial TLS encryption to target. Independent of tls; not inferred from target scheme. Default: false."
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
## Summary
- Add `UpstreamTLS bool` (`json:"upstream_tls,omitempty"`) to `ForwardConfig` (foundation #1 of the L7 TCP forward re-implementation split).
- Lock semantics in godoc + MCP help: `TLS` = client-side termination, `UpstreamTLS` = upstream-dial encryption. Independent fields; never inferred from `Target` scheme/port. Both default to `false`, preserving the existing raw-forward behavior (USK-711).
- MCP control-plane wiring: `parseTCPForwardsAny` extracts `upstream_tls`; `proxyStartInput` jsonschema, `schema_proxy_start.json`, and `help_proxy_start.md` document the new field + the 4-combination matrix.
- `validateTCPForwardsConfig` Warns on `UpstreamTLS=true && Protocol="raw"` (mirroring the existing TLS+raw Warn) and emits a per-entry Info log whenever `TLS=true` explaining the meaning shift ("TLS now means client-side termination only; for upstream TLS use upstream_tls=true").
- Data-path wiring (upstream-TLS-aware dial) is deliberately deferred to USK-916; `internal/proxybuild/tcp_forward.go` remains untouched and continues to runtime-reject non-raw + TLS exactly as USK-711 left it.

## TLS × UpstreamTLS matrix
| tls   | upstream_tls | Client wire | Upstream wire | Use case                                      |
|-------|--------------|-------------|---------------|-----------------------------------------------|
| false | false        | plaintext   | plaintext     | Raw L4/L7 forwarding (default)                |
| true  | false        | TLS         | plaintext     | TLS termination only (downstream offload)     |
| false | true         | plaintext   | TLS           | Plaintext client → TLS-only upstream          |
| true  | true         | TLS         | TLS           | Full MITM: terminate then re-encrypt upstream |

## Test plan
- [x] `make lint` (gofmt + go vet + staticcheck + ineffassign + gocyclo)
- [x] `make build`
- [x] `make test` — all packages pass
- [x] New `TestForwardConfig_UnmarshalJSON_TLSUpstreamTLSMatrix` (4 cases)
- [x] New `TestForwardConfig_MarshalJSON_OmitEmptyDefaults`
- [x] New `TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations` (4 cases)
- [x] Extended `TestValidateForwardConfig` with upstream_tls cases
- [x] New `TestParseTCPForwardsAny_UpstreamTLS` (5 cases including defensive non-bool)
- [x] Existing `internal/mcp` test suite untouched and green (resource files updated for new field)

Resolves USK-911
Linear: https://linear.app/usk6666/issue/USK-911

🤖 Generated with [Claude Code](https://claude.com/claude-code)