### PR TITLE
feat(connector): stack builder を target-override 化して TCP forward から再利用可能にする

### DIFF
--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -1,0 +1,389 @@
+package connector
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+
+	"github.com/google/uuid"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/bytechunk"
+)
+
+// ForwardProtocol selects the L7 wire shape a caller of
+// BuildConnectionStackWithTarget expects to flow through the assembled stack.
+// It mirrors the ForwardConfig.Protocol semantic from internal/config so the
+// MCP-facing forward selector and the connector-side stack builder share one
+// vocabulary.
+//
+// Only ForwardProtocolRaw is wired in USK-912; the other variants are
+// reserved for the L7 dispatch / TLS-terminate / upstream-TLS dial Issues
+// (USK-913/914/915/916). Passing a reserved variant to
+// BuildConnectionStackWithTarget returns a "not yet wired" error so the
+// API surface for downstream Issues is locked in but the implementation
+// can land incrementally.
+type ForwardProtocol string
+
+const (
+	// ForwardProtocolAuto requests peek-based inner-protocol detection on
+	// the accepted connection. The auto-detection wire-up is owned by
+	// USK-913 and is NOT implemented by USK-912; passing this value
+	// currently returns a "not yet wired" error.
+	ForwardProtocolAuto ForwardProtocol = "auto"
+
+	// ForwardProtocolRaw builds a [bytechunk → bytechunk] stack — the
+	// only protocol fully wired in USK-912. Equivalent to the bytechunk
+	// case of buildStackFromRoute but with the target supplied verbatim
+	// by the caller (no CONNECT/SNI derivation).
+	ForwardProtocolRaw ForwardProtocol = "raw"
+
+	// ForwardProtocolHTTP requests a plain HTTP/1.x stack. Reserved for
+	// USK-913 (L7 dispatch); currently returns a "not yet wired" error.
+	ForwardProtocolHTTP ForwardProtocol = "http"
+
+	// ForwardProtocolHTTP2 requests an h2c stack. Reserved for USK-913;
+	// currently returns a "not yet wired" error.
+	ForwardProtocolHTTP2 ForwardProtocol = "http2"
+
+	// ForwardProtocolGRPC requests an h2c + gRPC stack. Reserved for
+	// USK-914; currently returns a "not yet wired" error.
+	ForwardProtocolGRPC ForwardProtocol = "grpc"
+
+	// ForwardProtocolWebSocket requests an HTTP/1.x stack that may
+	// Upgrade to WebSocket. Reserved for USK-914; currently returns a
+	// "not yet wired" error.
+	ForwardProtocolWebSocket ForwardProtocol = "websocket"
+
+	// ForwardProtocolSSE requests an HTTP/1.x stack that may switch to
+	// SSE on response. Reserved for USK-914; currently returns a "not
+	// yet wired" error.
+	ForwardProtocolSSE ForwardProtocol = "sse"
+)
+
+// validForwardProtocols enumerates the protocol selectors
+// BuildConnectionStackWithTarget will accept (without erroring on the
+// validation step). The set mirrors the config.validForwardProtocols set
+// plus "sse" to anticipate USK-915's split. Unknown values are rejected
+// at validation time with a clear error.
+var validForwardProtocols = map[ForwardProtocol]bool{
+	ForwardProtocolAuto:      true,
+	ForwardProtocolRaw:       true,
+	ForwardProtocolHTTP:      true,
+	ForwardProtocolHTTP2:     true,
+	ForwardProtocolGRPC:      true,
+	ForwardProtocolWebSocket: true,
+	ForwardProtocolSSE:       true,
+}
+
+// TargetOverrideParams bundles the inputs to BuildConnectionStackWithTarget.
+// It is a struct rather than a positional argument list because the parameter
+// set is expected to grow (TLS SNI, cert.Issuer, plugin engine, etc.) when
+// USK-913/914/915/916 wire in the deferred branches; new fields are then
+// additive and do not force a callsite churn pass on USK-912's diff.
+//
+// The "Target" is operator-declared: the L7 TCP forward listener is told by
+// config (or by an MCP tool) what host:port to send the accepted connection
+// to. This differs from BuildConnectionStack, which derives Target from
+// CONNECT (the client picked the target) or SOCKS5. Both shapes have
+// legitimate use cases — see RFC-001 §3.3 and CLAUDE.md MITM Principle 2
+// (do not unify protocols / call paths into one shared representation).
+type TargetOverrideParams struct {
+	// Target is the upstream "host:port" the assembled stack will be
+	// connected to. Required and non-empty. Caller supplies this verbatim
+	// from operator config; no CONNECT-host or SNI derivation happens
+	// here.
+	Target string
+
+	// Protocol selects the L7 wire shape. See ForwardProtocol* constants.
+	// An empty string is treated as ForwardProtocolAuto. Unknown values
+	// are rejected with an error.
+	Protocol ForwardProtocol
+
+	// ALPNOffers is the verbatim ALPN advertisement list the caller wants
+	// to send on the upstream TLS handshake (when UpstreamTLS=true) or
+	// on the client-facing MITM handshake (when TLSTerminate=true). An
+	// empty / nil slice means "no ALPN extension on the wire", matching
+	// the dialUpstreamWithALPN / performClientMITM existing semantic.
+	//
+	// Caller-supplied because forward callers have an explicit policy
+	// (operator declared which protocol to advertise) rather than the
+	// MITM-side "advertise the upstream-negotiated list to the client"
+	// heuristic owned by stack_builder.go.
+	ALPNOffers []string
+
+	// TLSTerminate, when true, indicates the caller wants the accepted
+	// client connection's TLS handshake to be terminated by this builder
+	// (with a MITM cert issued via cfg.Issuer). The TLS terminate wire-up
+	// is owned by USK-915 and is NOT implemented by USK-912; setting
+	// TLSTerminate=true currently returns a "not yet wired" error.
+	TLSTerminate bool
+
+	// UpstreamTLS, when true, indicates the caller wants the upstream
+	// dial to perform a TLS handshake. The upstream-TLS dial wire-up is
+	// owned by USK-916 and is NOT implemented by USK-912; setting
+	// UpstreamTLS=true currently returns a "not yet wired" error.
+	UpstreamTLS bool
+}
+
+// validate sanity-checks the params before any I/O. Returns a wrapped error
+// on failure so callsites can compare via errors.Is once specific sentinel
+// values are introduced by USK-913+.
+func (p *TargetOverrideParams) validate() error {
+	if p == nil {
+		return fmt.Errorf("connector: BuildConnectionStackWithTarget: nil params")
+	}
+	if p.Target == "" {
+		return fmt.Errorf("connector: BuildConnectionStackWithTarget: empty Target")
+	}
+	if _, _, err := net.SplitHostPort(p.Target); err != nil {
+		return fmt.Errorf("connector: BuildConnectionStackWithTarget: invalid Target %q: %w", p.Target, err)
+	}
+	protocol := p.Protocol
+	if protocol == "" {
+		protocol = ForwardProtocolAuto
+	}
+	if !validForwardProtocols[protocol] {
+		return fmt.Errorf("connector: BuildConnectionStackWithTarget: invalid protocol %q (valid: auto, raw, http, http2, grpc, websocket, sse)", p.Protocol)
+	}
+	return nil
+}
+
+// BuildConnectionStackWithTarget assembles a per-connection ConnectionStack
+// for an operator-declared "target" — the L7 TCP forward use case, where the
+// listener was configured to forward accepted connections to a fixed upstream
+// host:port rather than CONNECT-deriving the target from the client. It is
+// the forward-side sibling of BuildConnectionStack and shares stack_builder.go's
+// private helpers (PerformClientMITM, DialUpstreamWithALPN) for the branches
+// that perform TLS.
+//
+// Contract (USK-912 minimum-viable surface):
+//
+//   - target is fixed by the caller. This function does NOT consult CONNECT
+//     headers, SOCKS5 negotiation results, or any other source of "what host
+//     does the client want to reach". The caller obtained the target from
+//     operator config (config.ForwardConfig.Target).
+//
+//   - No SNI is derived from target. When USK-915 wires in TLS termination,
+//     the caller will pass the SNI value separately (likely as an additional
+//     field on TargetOverrideParams) — the operator-declared target may be
+//     an IP literal or a name that differs from the SNI the client would
+//     present.
+//
+//   - ALPN advertise list is caller-supplied verbatim. An empty / nil
+//     ALPNOffers slice means "no ALPN extension on the wire" (no defaulting
+//     to [h2, http/1.1] like BuildConnectionStack does for the MITM-routed
+//     case). Forward callers know what protocol they declared and what they
+//     want to advertise to the client / upstream.
+//
+//   - Protocol selectors other than "raw" return a "not yet wired" error
+//     citing the responsible follow-up Issue (USK-913 for L7 dispatch,
+//     USK-914 for protocol-specific dispatch, USK-915 for TLS terminate,
+//     USK-916 for upstream TLS dial). The signature and the validation pass
+//     are real today so downstream Issues can wire in their branch without
+//     re-litigating the API surface.
+//
+//   - upstreamConn must be a dialed, plain (or TLS, when the caller has its
+//     own dial path) net.Conn. This builder does NOT dial; it takes the
+//     pre-dialed conn so callers retain control of dial timeouts,
+//     upstream-proxy resolution, and per-host TLS material (consistent with
+//     BuildPlainHTTPStack / BuildPlainH2CStack / BuildBytechunkStack).
+//
+//   - Returns *ConnectionStack only (vs. the MITM builder's three-value
+//     return) because there are no TLS snapshots to surface in the raw case.
+//     When USK-915 / USK-916 add TLS termination this signature will be
+//     extended (or a sibling builder added — see the seam discipline in
+//     CLAUDE.md MITM Principle 2).
+//
+// Ownership: the returned ConnectionStack owns clientConn and upstreamConn
+// via its Layers; callers must defer stack.Close() exactly as the existing
+// sibling builders document.
+//
+// USK-912 implementation scope: the function validates inputs, returns a
+// bytechunk stack for ForwardProtocolRaw, and errors for every other
+// branch. No client-side TLS terminate happens; no L7 protocol dispatch
+// happens; no upstream TLS handshake happens. The "API ready, not yet
+// wired" stance is intentional — see the design review record on USK-912.
+func BuildConnectionStackWithTarget(
+	ctx context.Context,
+	clientConn net.Conn,
+	upstreamConn net.Conn,
+	params TargetOverrideParams,
+	cfg *BuildConfig,
+) (*ConnectionStack, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: nil config")
+	}
+	if clientConn == nil || upstreamConn == nil {
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: nil conn")
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	if params.TLSTerminate {
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: TLSTerminate=true not yet wired (deferred to USK-915)")
+	}
+	if params.UpstreamTLS {
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: UpstreamTLS=true not yet wired (deferred to USK-916)")
+	}
+
+	protocol := params.Protocol
+	if protocol == "" {
+		protocol = ForwardProtocolAuto
+	}
+
+	switch protocol {
+	case ForwardProtocolRaw:
+		return buildTargetOverrideRawStack(ctx, clientConn, upstreamConn, params.Target, cfg)
+	case ForwardProtocolAuto:
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (auto-detection deferred to USK-913)", protocol)
+	case ForwardProtocolHTTP, ForwardProtocolHTTP2:
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (L7 dispatch deferred to USK-913/USK-914)", protocol)
+	case ForwardProtocolGRPC, ForwardProtocolWebSocket, ForwardProtocolSSE:
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (protocol-specific dispatch deferred to USK-914/USK-915)", protocol)
+	default:
+		// Unreachable: params.validate already rejects unknown values.
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: unhandled protocol %q", protocol)
+	}
+}
+
+// buildTargetOverrideRawStack builds the [bytechunk client → bytechunk upstream]
+// stack used by ForwardProtocolRaw. It is the target-override counterpart of
+// BuildBytechunkStack (connect_inner_dispatch.go); BuildBytechunkStack stays
+// the entry point for CONNECT-inner / SOCKS5-inner callers so that the seam
+// between MITM-derived and operator-declared targets remains visible in the
+// code structure (CLAUDE.md MITM Principle 2).
+//
+// _ ctx is retained on the signature to give downstream Issues a stable
+// callsite shape when they add ctx-aware behaviour (e.g. ctx-cancel-aware
+// dial in USK-916). The current bytechunk path performs no I/O so ctx is
+// not consulted today.
+func buildTargetOverrideRawStack(
+	_ context.Context,
+	clientConn, upstreamConn net.Conn,
+	target string,
+	_ *BuildConfig,
+) (*ConnectionStack, error) {
+	connID := uuid.New().String()
+	stack := NewConnectionStack(connID)
+
+	clientLayer := bytechunk.New(clientConn, connID+"/client", envelope.Send)
+	stack.PushClient(clientLayer)
+
+	upstreamLayer := bytechunk.New(upstreamConn, connID+"/upstream", envelope.Receive)
+	stack.PushUpstream(upstreamLayer)
+
+	_ = target // bytechunk does not stamp target into envelopes; field is informational
+	return stack, nil
+}
+
+// PerformClientMITM is the exported wrapper for the package-private
+// performClientMITM helper. It performs the client-side TLS MITM handshake,
+// issuing a certificate for the given host and offering the specified ALPN
+// protocols. The returned TLS-wrapped connection MUST be used for subsequent
+// I/O instead of the original plain connection.
+//
+// Contract for forward callers (USK-912 minimum-viable export):
+//
+//   - host is the SNI-equivalent name the proxy issues the MITM cert for.
+//     Forward callers supply this themselves — there is no SNI to observe
+//     because the accepted connection's first TLS bytes are about to be
+//     consumed by tlslayer.Server here.
+//
+//   - alpnOffers is verbatim. An empty / nil slice leaves NextProtos unset
+//     so the client never sees the ALPN extension. Forward callers that
+//     declared a specific protocol in config (e.g. "http") should pass
+//     [http/1.1]; callers that declared "auto" should pass [h2, http/1.1].
+//
+//   - cfg supplies the cert Issuer and the (tls, on_handshake) PluginV2Engine
+//     wiring. It is the same BuildConfig used elsewhere in the package.
+//
+//   - Observability: this wrapper preserves the test-only
+//     ClientMITMHandshakeCount counter incremented by performClientMITM
+//     (USK-813). Forward callers that drive their own test harness can
+//     read the counter via cfg.ClientMITMHandshakeCount() just like the
+//     MITM path does.
+//
+// USK-912 deliberately does NOT export the lower-level helpers
+// (resolvePerHostTLS, alpnRoute, buildStackFromRoute) — they will be
+// exported on demand by USK-913/USK-914/USK-915 as actual callsites land,
+// not pre-emptively.
+func PerformClientMITM(
+	ctx context.Context,
+	clientConn net.Conn,
+	host string,
+	alpnOffers []string,
+	cfg *BuildConfig,
+) (net.Conn, *envelope.TLSSnapshot, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("connector: PerformClientMITM: nil config")
+	}
+	if cfg.Issuer == nil {
+		return nil, nil, fmt.Errorf("connector: PerformClientMITM: nil issuer")
+	}
+	if clientConn == nil {
+		return nil, nil, fmt.Errorf("connector: PerformClientMITM: nil clientConn")
+	}
+	if host == "" {
+		return nil, nil, fmt.Errorf("connector: PerformClientMITM: empty host")
+	}
+	return performClientMITM(ctx, clientConn, host, alpnOffers, cfg)
+}
+
+// DialUpstreamWithALPN is the exported wrapper for the package-private
+// dialUpstreamWithALPN helper. It dials upstream and performs TLS, returning
+// the connection plus the TLS snapshot whose ALPN field carries the
+// negotiated protocol.
+//
+// Contract for forward callers (USK-912 minimum-viable export):
+//
+//   - target is the operator-declared "host:port". No SNI is derived from
+//     target; pass host (the SNI name) separately. Caller obtained both
+//     from operator config (config.ForwardConfig.Target plus future SNI
+//     field expected in USK-915).
+//
+//   - offerALPN is verbatim. An empty / nil slice still produces a TLS
+//     handshake (no ALPN extension on the wire) — useful for forward
+//     callers that declared "raw" but still want upstream TLS termination.
+//
+//   - insecureSkip, clientCert, rootCAsConfig are per-call overrides; the
+//     caller resolves these against its own per-host policy. Forward
+//     callers will typically read them from
+//     cfg.ResolvePerHostTLS(target) — which remains private until a
+//     downstream Issue (USK-915) needs it.
+//
+//   - cfg.EffectiveTLSFingerprint and cfg.EffectiveUpstreamProxyForCtx
+//     continue to govern uTLS profile selection and upstream-proxy
+//     traversal exactly as in the BuildConnectionStack callsite.
+//
+//   - Observability: the (tls, on_handshake) hook fires for the "client"
+//     side (proxy dialing upstream) when snap is non-nil. Forward callers
+//     get plugin hook dispatch for free.
+//
+// USK-912 deliberately does NOT export DialUpstreamRaw at this seam — the
+// MITM helper is the right export because it bundles the snapshot-handling
+// and plugin-hook-firing in one place. Forward callers that need plain
+// TCP dial without TLS continue to use DialUpstreamRaw directly (it is
+// already exported).
+func DialUpstreamWithALPN(
+	ctx context.Context,
+	target, host string,
+	offerALPN []string,
+	insecureSkip bool,
+	clientCert *tls.Certificate,
+	rootCAsConfig *tls.Config,
+	cfg *BuildConfig,
+) (net.Conn, *envelope.TLSSnapshot, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("connector: DialUpstreamWithALPN: nil config")
+	}
+	if target == "" {
+		return nil, nil, fmt.Errorf("connector: DialUpstreamWithALPN: empty target")
+	}
+	if host == "" {
+		return nil, nil, fmt.Errorf("connector: DialUpstreamWithALPN: empty host")
+	}
+	return dialUpstreamWithALPN(ctx, target, host, offerALPN, insecureSkip, clientCert, rootCAsConfig, cfg)
+}

--- a/internal/connector/stack_builder_target_override_test.go
+++ b/internal/connector/stack_builder_target_override_test.go
@@ -1,0 +1,375 @@
+package connector
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/bytechunk"
+)
+
+// newTestBuildConfig constructs a minimal *BuildConfig for the target-override
+// builder tests. Mirrors the shape used by plain_http_stack_test.go.
+func newTestBuildConfig(t *testing.T) *BuildConfig {
+	t.Helper()
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca.Generate: %v", err)
+	}
+	return &BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             cert.NewIssuer(ca),
+		InsecureSkipVerify: true,
+	}
+}
+
+// pipePair returns a (local, peer) pair from net.Pipe whose lifecycle is
+// hooked into t.Cleanup. The peer end is what callers pass to the stack
+// builder; the local end stays alive for the test duration so the bytechunk
+// Layer's reader has a peer to read from.
+func pipePair(t *testing.T) (local, peer net.Conn) {
+	t.Helper()
+	local, peer = net.Pipe()
+	t.Cleanup(func() {
+		_ = local.Close()
+		_ = peer.Close()
+	})
+	return local, peer
+}
+
+// TestBuildConnectionStackWithTarget_RawSuccess verifies the only fully-wired
+// protocol branch of USK-912: ForwardProtocolRaw assembles a
+// [bytechunk → bytechunk] stack with both Layers as *bytechunk.Layer.
+func TestBuildConnectionStackWithTarget_RawSuccess(t *testing.T) {
+	_, clientPeer := pipePair(t)
+	_, upstreamPeer := pipePair(t)
+
+	cfg := newTestBuildConfig(t)
+	params := TargetOverrideParams{
+		Target:   "api.example.com:50051",
+		Protocol: ForwardProtocolRaw,
+	}
+
+	stack, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+	if err != nil {
+		t.Fatalf("BuildConnectionStackWithTarget(raw): %v", err)
+	}
+	t.Cleanup(func() { _ = stack.Close() })
+
+	if stack.ConnID == "" {
+		t.Error("stack.ConnID is empty")
+	}
+
+	if _, ok := stack.ClientTopmost().(*bytechunk.Layer); !ok {
+		t.Errorf("client topmost = %T, want *bytechunk.Layer", stack.ClientTopmost())
+	}
+	if _, ok := stack.UpstreamTopmost().(*bytechunk.Layer); !ok {
+		t.Errorf("upstream topmost = %T, want *bytechunk.Layer", stack.UpstreamTopmost())
+	}
+	if stack.UpstreamH2Layer() != nil {
+		t.Error("upstreamH2 should be nil for raw target-override stack")
+	}
+}
+
+// TestBuildConnectionStackWithTarget_RawEmptyProtocol verifies that an
+// empty Protocol string is NOT treated as ForwardProtocolRaw at this point
+// — empty collapses to auto, which is the deferred branch. This is a
+// guardrail: forward callers that forget to populate the field should not
+// silently get a bytechunk stack; they should see the explicit
+// "auto not yet wired" error.
+func TestBuildConnectionStackWithTarget_EmptyProtocolDeferred(t *testing.T) {
+	_, clientPeer := pipePair(t)
+	_, upstreamPeer := pipePair(t)
+
+	cfg := newTestBuildConfig(t)
+	params := TargetOverrideParams{
+		Target: "api.example.com:50051",
+		// Protocol unset — exercises the empty → auto collapse.
+	}
+
+	_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error for empty Protocol (deferred to auto), got nil")
+	}
+	if !strings.Contains(err.Error(), "USK-913") {
+		t.Errorf("expected error to cite USK-913, got %q", err.Error())
+	}
+}
+
+// TestBuildConnectionStackWithTarget_DeferredProtocols enumerates every
+// non-raw protocol selector and confirms each returns a "not yet wired"
+// error mentioning the responsible follow-up Issue. This is the
+// signature-locking test: downstream Issues (USK-913+) will replace each
+// case body with the real implementation, but the validation +
+// dispatch surface is already in place today.
+func TestBuildConnectionStackWithTarget_DeferredProtocols(t *testing.T) {
+	cases := []struct {
+		name      string
+		protocol  ForwardProtocol
+		wantIssue string
+	}{
+		{name: "auto", protocol: ForwardProtocolAuto, wantIssue: "USK-913"},
+		{name: "http", protocol: ForwardProtocolHTTP, wantIssue: "USK-913"},
+		{name: "http2", protocol: ForwardProtocolHTTP2, wantIssue: "USK-913"},
+		{name: "grpc", protocol: ForwardProtocolGRPC, wantIssue: "USK-914"},
+		{name: "websocket", protocol: ForwardProtocolWebSocket, wantIssue: "USK-914"},
+		{name: "sse", protocol: ForwardProtocolSSE, wantIssue: "USK-914"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, clientPeer := pipePair(t)
+			_, upstreamPeer := pipePair(t)
+			cfg := newTestBuildConfig(t)
+			params := TargetOverrideParams{
+				Target:   "api.example.com:50051",
+				Protocol: tc.protocol,
+			}
+			_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+			if err == nil {
+				t.Fatalf("protocol %q: expected non-nil deferred error, got nil", tc.protocol)
+			}
+			if !strings.Contains(err.Error(), tc.wantIssue) {
+				t.Errorf("protocol %q: error %q does not cite %q", tc.protocol, err.Error(), tc.wantIssue)
+			}
+		})
+	}
+}
+
+// TestBuildConnectionStackWithTarget_TLSTerminateDeferred confirms
+// TLSTerminate=true short-circuits with a USK-915 reference rather than
+// silently doing nothing.
+func TestBuildConnectionStackWithTarget_TLSTerminateDeferred(t *testing.T) {
+	_, clientPeer := pipePair(t)
+	_, upstreamPeer := pipePair(t)
+	cfg := newTestBuildConfig(t)
+	params := TargetOverrideParams{
+		Target:       "api.example.com:443",
+		Protocol:     ForwardProtocolRaw,
+		TLSTerminate: true,
+	}
+	_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error for TLSTerminate=true, got nil")
+	}
+	if !strings.Contains(err.Error(), "USK-915") {
+		t.Errorf("expected error to cite USK-915, got %q", err.Error())
+	}
+}
+
+// TestBuildConnectionStackWithTarget_UpstreamTLSDeferred confirms
+// UpstreamTLS=true short-circuits with a USK-916 reference.
+func TestBuildConnectionStackWithTarget_UpstreamTLSDeferred(t *testing.T) {
+	_, clientPeer := pipePair(t)
+	_, upstreamPeer := pipePair(t)
+	cfg := newTestBuildConfig(t)
+	params := TargetOverrideParams{
+		Target:      "api.example.com:443",
+		Protocol:    ForwardProtocolRaw,
+		UpstreamTLS: true,
+	}
+	_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error for UpstreamTLS=true, got nil")
+	}
+	if !strings.Contains(err.Error(), "USK-916") {
+		t.Errorf("expected error to cite USK-916, got %q", err.Error())
+	}
+}
+
+// TestBuildConnectionStackWithTarget_ALPNOffersAccepted verifies that
+// the ALPNOffers field is accepted in raw mode (no error from validation
+// or dispatch) even though raw does not actually use ALPN. This locks in
+// the "ALPN is caller-supplied, empty means no extension" semantic for
+// downstream Issues.
+func TestBuildConnectionStackWithTarget_ALPNOffersAccepted(t *testing.T) {
+	cases := []struct {
+		name   string
+		offers []string
+	}{
+		{name: "nil", offers: nil},
+		{name: "empty", offers: []string{}},
+		{name: "single", offers: []string{"http/1.1"}},
+		{name: "multi", offers: []string{"h2", "http/1.1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, clientPeer := pipePair(t)
+			_, upstreamPeer := pipePair(t)
+			cfg := newTestBuildConfig(t)
+			params := TargetOverrideParams{
+				Target:     "api.example.com:50051",
+				Protocol:   ForwardProtocolRaw,
+				ALPNOffers: tc.offers,
+			}
+			stack, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+			if err != nil {
+				t.Fatalf("ALPNOffers=%v: unexpected error: %v", tc.offers, err)
+			}
+			t.Cleanup(func() { _ = stack.Close() })
+		})
+	}
+}
+
+// TestBuildConnectionStackWithTarget_Validation covers input-validation
+// failure modes: nil config, nil conn, empty / malformed target, unknown
+// protocol. Each must surface a clear error rather than panic.
+func TestBuildConnectionStackWithTarget_Validation(t *testing.T) {
+	t.Run("nil_config", func(t *testing.T) {
+		_, clientPeer := pipePair(t)
+		_, upstreamPeer := pipePair(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer,
+			TargetOverrideParams{Target: "api.example.com:80", Protocol: ForwardProtocolRaw}, nil)
+		if err == nil {
+			t.Fatal("expected error for nil config")
+		}
+	})
+
+	t.Run("nil_client_conn", func(t *testing.T) {
+		_, upstreamPeer := pipePair(t)
+		cfg := newTestBuildConfig(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), nil, upstreamPeer,
+			TargetOverrideParams{Target: "api.example.com:80", Protocol: ForwardProtocolRaw}, cfg)
+		if err == nil {
+			t.Fatal("expected error for nil clientConn")
+		}
+	})
+
+	t.Run("nil_upstream_conn", func(t *testing.T) {
+		_, clientPeer := pipePair(t)
+		cfg := newTestBuildConfig(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, nil,
+			TargetOverrideParams{Target: "api.example.com:80", Protocol: ForwardProtocolRaw}, cfg)
+		if err == nil {
+			t.Fatal("expected error for nil upstreamConn")
+		}
+	})
+
+	t.Run("empty_target", func(t *testing.T) {
+		_, clientPeer := pipePair(t)
+		_, upstreamPeer := pipePair(t)
+		cfg := newTestBuildConfig(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer,
+			TargetOverrideParams{Target: "", Protocol: ForwardProtocolRaw}, cfg)
+		if err == nil {
+			t.Fatal("expected error for empty target")
+		}
+	})
+
+	t.Run("malformed_target", func(t *testing.T) {
+		_, clientPeer := pipePair(t)
+		_, upstreamPeer := pipePair(t)
+		cfg := newTestBuildConfig(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer,
+			TargetOverrideParams{Target: "no-port-here", Protocol: ForwardProtocolRaw}, cfg)
+		if err == nil {
+			t.Fatal("expected error for malformed target (no port)")
+		}
+	})
+
+	t.Run("unknown_protocol", func(t *testing.T) {
+		_, clientPeer := pipePair(t)
+		_, upstreamPeer := pipePair(t)
+		cfg := newTestBuildConfig(t)
+		_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer,
+			TargetOverrideParams{Target: "api.example.com:80", Protocol: ForwardProtocol("quic")}, cfg)
+		if err == nil {
+			t.Fatal("expected error for unknown protocol")
+		}
+		if !strings.Contains(err.Error(), "invalid protocol") {
+			t.Errorf("expected 'invalid protocol' substring, got %q", err.Error())
+		}
+	})
+}
+
+// TestPerformClientMITM_Validation confirms the exported wrapper rejects
+// nil arguments before invoking the package-private helper. The wire-level
+// MITM behaviour itself is exercised end-to-end by existing
+// stack_builder_test.go and the MITM integration suite; this test only
+// guards the new exported surface.
+func TestPerformClientMITM_Validation(t *testing.T) {
+	cfg := newTestBuildConfig(t)
+	_, clientPeer := pipePair(t)
+
+	t.Run("nil_cfg", func(t *testing.T) {
+		_, _, err := PerformClientMITM(context.Background(), clientPeer, "example.com", nil, nil)
+		if err == nil {
+			t.Fatal("expected error for nil cfg")
+		}
+	})
+	t.Run("nil_issuer", func(t *testing.T) {
+		emptyCfg := &BuildConfig{ProxyConfig: &config.ProxyConfig{}}
+		_, _, err := PerformClientMITM(context.Background(), clientPeer, "example.com", nil, emptyCfg)
+		if err == nil {
+			t.Fatal("expected error for nil issuer")
+		}
+	})
+	t.Run("nil_conn", func(t *testing.T) {
+		_, _, err := PerformClientMITM(context.Background(), nil, "example.com", nil, cfg)
+		if err == nil {
+			t.Fatal("expected error for nil clientConn")
+		}
+	})
+	t.Run("empty_host", func(t *testing.T) {
+		_, _, err := PerformClientMITM(context.Background(), clientPeer, "", nil, cfg)
+		if err == nil {
+			t.Fatal("expected error for empty host")
+		}
+	})
+}
+
+// TestDialUpstreamWithALPN_Validation confirms the exported wrapper
+// rejects nil arguments before invoking the dial. End-to-end TLS
+// behaviour is exercised by the existing MITM integration suite.
+func TestDialUpstreamWithALPN_Validation(t *testing.T) {
+	cfg := newTestBuildConfig(t)
+
+	t.Run("nil_cfg", func(t *testing.T) {
+		_, _, err := DialUpstreamWithALPN(context.Background(), "api.example.com:443", "api.example.com", nil, true, nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for nil cfg")
+		}
+	})
+	t.Run("empty_target", func(t *testing.T) {
+		_, _, err := DialUpstreamWithALPN(context.Background(), "", "api.example.com", nil, true, nil, nil, cfg)
+		if err == nil {
+			t.Fatal("expected error for empty target")
+		}
+	})
+	t.Run("empty_host", func(t *testing.T) {
+		_, _, err := DialUpstreamWithALPN(context.Background(), "api.example.com:443", "", nil, true, nil, nil, cfg)
+		if err == nil {
+			t.Fatal("expected error for empty host")
+		}
+	})
+}
+
+// TestBuildConnectionStackWithTarget_PreservesConnIDUniqueness verifies
+// that two calls produce distinct ConnIDs — important because the live
+// path keys per-connection state on this ID.
+func TestBuildConnectionStackWithTarget_PreservesConnIDUniqueness(t *testing.T) {
+	cfg := newTestBuildConfig(t)
+	params := TargetOverrideParams{Target: "api.example.com:50051", Protocol: ForwardProtocolRaw}
+
+	_, c1 := pipePair(t)
+	_, u1 := pipePair(t)
+	s1, err := BuildConnectionStackWithTarget(context.Background(), c1, u1, params, cfg)
+	if err != nil {
+		t.Fatalf("first build: %v", err)
+	}
+	t.Cleanup(func() { _ = s1.Close() })
+
+	_, c2 := pipePair(t)
+	_, u2 := pipePair(t)
+	s2, err := BuildConnectionStackWithTarget(context.Background(), c2, u2, params, cfg)
+	if err != nil {
+		t.Fatalf("second build: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	if s1.ConnID == s2.ConnID {
+		t.Errorf("expected distinct ConnIDs, both got %q", s1.ConnID)
+	}
+}


### PR DESCRIPTION
## Summary

- New `BuildConnectionStackWithTarget` in `internal/connector/` — target-fixed sibling of `BuildConnectionStack`. Takes a `TargetOverrideParams` struct (Target, Protocol, ALPNOffers, TLSTerminate, UpstreamTLS).
- New `ForwardProtocol` enum (auto / raw / http / http2 / grpc / websocket / sse) mirrors `config.ForwardConfig.Protocol`.
- `ForwardProtocolRaw` is fully wired (bytechunk client + bytechunk upstream). Every other selector and both TLS flags return a clear "not yet wired" error that cites the responsible follow-up Issue (USK-913 / USK-914 / USK-915 / USK-916), locking the API surface today.
- New `PerformClientMITM` and `DialUpstreamWithALPN` exported wrappers for the existing private helpers. Minimum-viable export scope — `ResolvePerHostTLS`, `ALPNRoute`, `BuildStackFromRoute` stay private until USK-913/914/915 actually need them.
- godoc on every exported surface documents the operator-declared-target contract: target fixed by caller, no SNI derivation, caller-supplied ALPN advertise list (empty = no ALPN extension on the wire), callers retain dial control.
- No changes to `handleTCPForwardConn`. The new builder is stand-alone with a unit test exercising it, per design review decision U4. L7 callsite wiring belongs to USK-913+.

## Design decisions (from Phase 1.5 design review)

- U1 — Naming: `BuildConnectionStackWithTarget` (caller-agnostic).
- U2 — ALPN API: `[]string` verbatim offers, matching `dialUpstreamWithALPN`.
- U3 — Helper export scope: minimum-viable (PerformClientMITM + DialUpstreamWithALPN only).
- U4 — Callsite shape: stand-alone with unit test, `handleTCPForwardConn` unchanged.

`BuildConnectionStack` signature is unchanged; `BuildPlainHTTPStack` / `BuildPlainH2CStack` / `BuildBytechunkStack` are unchanged.

## Test plan

- [x] `make lint` green (gofmt, go vet, staticcheck, ineffassign, gocyclo)
- [x] `make build` green
- [x] `make test` green — all existing tests pass, new tests pass
- [x] New tests cover: raw-success, every deferred protocol branch (each cites the right Issue), TLSTerminate→USK-915, UpstreamTLS→USK-916, ALPN offer permutations (nil / empty / single / multi), validation failures (nil config / nil conn / empty / malformed target / unknown protocol), `PerformClientMITM` + `DialUpstreamWithALPN` wrapper nil-input guards, ConnID uniqueness
- [ ] Reviewer check: `BuildConnectionStack` signature unchanged
- [ ] Reviewer check: MITM Principle #2 (no force-unification) — confirm raw target-override builder is a true sibling of `BuildBytechunkStack`, not an absorbed mega-function

Resolves USK-912
Linear: https://linear.app/usk6666/issue/USK-912

🤖 Generated with [Claude Code](https://claude.com/claude-code)