### PR TITLE
feat(proxybuild,connector): L7 TCP forward — http2 (h2c) + gRPC dispatch (USK-914)

### DIFF
--- a/internal/connector/h2_dispatch.go
+++ b/internal/connector/h2_dispatch.go
@@ -294,6 +294,27 @@ func extractContentType(evt *http2.H2HeadersEvent) string {
 	return ""
 }
 
+// IsGRPCContentType is the exported wrapper for isGRPCContentType. It
+// reports whether the given Content-Type value is a native-gRPC media
+// type (application/grpc[+suffix]; does NOT match application/grpc-web*).
+// Used by forward callers (USK-914 proxybuild.runTCPForwardH2Loop) that
+// must apply a Protocol="grpc" content-type filter on the first envelope
+// of each accepted stream — the filter has to fire BEFORE
+// DispatchH2StreamFull (which consumes the peek), so an exported helper
+// is needed rather than re-using the dispatcher's inline check.
+func IsGRPCContentType(ct string) bool {
+	return isGRPCContentType(ct)
+}
+
+// ExtractH2ContentType is the exported wrapper for extractContentType.
+// Returns the first content-type header value found on evt (case-
+// insensitive name match), or "" if none is present. Used by forward
+// callers that peek the first envelope of an h2 stream before
+// dispatching — see IsGRPCContentType for the use case.
+func ExtractH2ContentType(evt *http2.H2HeadersEvent) string {
+	return extractContentType(evt)
+}
+
 // isGRPCContentType reports whether ct is a native-gRPC media type:
 // exactly application/grpc, or application/grpc with a structured-syntax
 // suffix (application/grpc+proto, application/grpc+json, ...). Parameters

--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/layer/bytechunk"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
 )
 
 // ForwardProtocol selects the L7 wire shape a caller of
@@ -43,12 +45,19 @@ const (
 	// USK-913 (L7 dispatch); currently returns a "not yet wired" error.
 	ForwardProtocolHTTP ForwardProtocol = "http"
 
-	// ForwardProtocolHTTP2 requests an h2c stack. Reserved for USK-913;
-	// currently returns a "not yet wired" error.
+	// ForwardProtocolHTTP2 requests an h2c stack. Wired by USK-914 —
+	// builds [http2 ServerRole client → http2 ClientRole upstream] with
+	// scheme="http" and SETTINGS_ENABLE_CONNECT_PROTOCOL mirrored from
+	// upstream. Both gRPC and gRPC-Web auto-route via DispatchH2Stream at
+	// the per-stream proxybuild dispatch layer (no filter).
 	ForwardProtocolHTTP2 ForwardProtocol = "http2"
 
-	// ForwardProtocolGRPC requests an h2c + gRPC stack. Reserved for
-	// USK-914; currently returns a "not yet wired" error.
+	// ForwardProtocolGRPC requests an h2c + gRPC content-type filter
+	// stack. Wired by USK-914 — assembles the same h2c stack as
+	// ForwardProtocolHTTP2; the per-stream dispatch layer additionally
+	// validates each stream's content-type against application/grpc[+...]
+	// and rejects non-gRPC traffic (including gRPC-Web) with
+	// RST_STREAM(REFUSED_STREAM).
 	ForwardProtocolGRPC ForwardProtocol = "grpc"
 
 	// ForwardProtocolWebSocket requests an HTTP/1.x stack that may
@@ -237,12 +246,18 @@ func BuildConnectionStackWithTarget(
 	switch protocol {
 	case ForwardProtocolRaw:
 		return buildTargetOverrideRawStack(ctx, clientConn, upstreamConn, params.Target, cfg)
+	case ForwardProtocolHTTP2, ForwardProtocolGRPC:
+		// USK-914: h2c forward stack. The GRPC selector reuses the same
+		// h2c stack assembly; the gRPC content-type filter is applied at
+		// the per-stream proxybuild dispatch layer (see
+		// internal/proxybuild/tcp_forward_h2.go).
+		return buildTargetOverrideH2CStack(ctx, clientConn, upstreamConn, params.Target, cfg)
 	case ForwardProtocolAuto:
 		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (auto-detection deferred to USK-913)", protocol)
-	case ForwardProtocolHTTP, ForwardProtocolHTTP2:
-		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (L7 dispatch deferred to USK-913/USK-914)", protocol)
-	case ForwardProtocolGRPC, ForwardProtocolWebSocket, ForwardProtocolSSE:
-		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (protocol-specific dispatch deferred to USK-914/USK-915)", protocol)
+	case ForwardProtocolHTTP:
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (L7 dispatch deferred to USK-913)", protocol)
+	case ForwardProtocolWebSocket, ForwardProtocolSSE:
+		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: protocol %q not yet wired (protocol-specific dispatch deferred to USK-913)", protocol)
 	default:
 		// Unreachable: params.validate already rejects unknown values.
 		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: unhandled protocol %q", protocol)
@@ -276,6 +291,110 @@ func buildTargetOverrideRawStack(
 	stack.PushUpstream(upstreamLayer)
 
 	_ = target // bytechunk does not stamp target into envelopes; field is informational
+	return stack, nil
+}
+
+// targetOverrideH2CPrefaceReadDeadline bounds how long the ServerRole HTTP/2
+// Layer's preface validation waits for the 24-byte client preface
+// ("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", RFC 9113 §3.4). Forward callers
+// accept arbitrary TCP and pass it straight to http2.New(ServerRole) when
+// Protocol="http2" or "grpc"; without a read deadline a slow or never-
+// sending client could pin the per-conn goroutine indefinitely. Defensive
+// default; future Issues may surface this as a config knob.
+const targetOverrideH2CPrefaceReadDeadline = 30 * time.Second
+
+// buildTargetOverrideH2CStack assembles the [http2 ServerRole client →
+// http2 ClientRole upstream] h2c stack used by ForwardProtocolHTTP2 and
+// ForwardProtocolGRPC. Modelled on BuildPlainH2CStack (the
+// CONNECT-inner-h2c sibling) with two operational adjustments for the
+// forward path:
+//
+//  1. clientConn carries a 30 s read deadline across the ServerRole
+//     preface validation (slow-handshake DoS defence — the CONNECT-inner
+//     path is already protected by the inner-byte peek timeout).
+//  2. SETTINGS_ENABLE_CONNECT_PROTOCOL mirror runs the same way; advertising
+//     1 to the client is harmless when extended-CONNECT is unused.
+//
+// The gRPC content-type filter that distinguishes ForwardProtocolHTTP2
+// from ForwardProtocolGRPC is applied at the per-stream proxybuild
+// dispatch layer (proxybuild.runTCPForwardH2Loop). This builder is
+// protocol-agnostic between the two.
+//
+// Ownership: the returned stack owns both conns; callers must defer
+// stack.Close(). On any constructor failure both conns are closed.
+func buildTargetOverrideH2CStack(
+	ctx context.Context,
+	clientConn, upstreamConn net.Conn,
+	target string,
+	cfg *BuildConfig,
+) (*ConnectionStack, error) {
+	connID := uuid.New().String()
+
+	clientEnvCtx := envelope.EnvelopeContext{
+		ConnID:     connID,
+		TargetHost: target,
+		// TLS intentionally nil: h2c — no handshake on either side.
+	}
+	upstreamEnvCtx := envelope.EnvelopeContext{
+		ConnID:     connID,
+		TargetHost: target,
+	}
+
+	stack := NewConnectionStack(connID)
+
+	// Upstream first so we can sniff its SETTINGS_ENABLE_CONNECT_PROTOCOL
+	// value (mirrors BuildPlainH2CStack USK-871 commentary).
+	upstreamLayer, err := http2.New(upstreamConn, connID+"/upstream", http2.ClientRole,
+		http2.WithScheme("http"),
+		http2.WithEnvelopeContext(upstreamEnvCtx),
+		http2.WithBodySpillDir(cfg.BodySpillDir),
+		http2.WithBodySpillThreshold(cfg.BodySpillThreshold),
+		http2.WithMaxBodySize(cfg.MaxBodySize),
+		http2.WithStateReleaser(cfg.PluginV2Engine),
+	)
+	if err != nil {
+		// http2.New already closed upstreamConn on failure; close the
+		// client conn to release resources.
+		_ = clientConn.Close()
+		return nil, fmt.Errorf("connector: buildTargetOverrideH2CStack: upstream h2 layer: %w", err)
+	}
+
+	enableConnectProtocol := resolveEnableConnectProtocol(ctx, upstreamLayer, false, connID, target)
+
+	// Apply a bounded read deadline across the ServerRole preface
+	// validation. Cleared before the function returns so the Layer's
+	// own reads behave normally afterwards. This is the forward-path
+	// equivalent of the CONNECT inner-byte peek timeout (which already
+	// protects the CONNECT-inner h2c path before BuildPlainH2CStack
+	// runs).
+	if conn, ok := clientConn.(interface {
+		SetReadDeadline(time.Time) error
+	}); ok {
+		_ = conn.SetReadDeadline(time.Now().Add(targetOverrideH2CPrefaceReadDeadline))
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	}
+
+	clientH2Opts := []http2.Option{
+		http2.WithScheme("http"),
+		http2.WithEnvelopeContext(clientEnvCtx),
+		http2.WithBodySpillDir(cfg.BodySpillDir),
+		http2.WithBodySpillThreshold(cfg.BodySpillThreshold),
+		http2.WithMaxBodySize(cfg.MaxBodySize),
+		http2.WithStateReleaser(cfg.PluginV2Engine),
+		http2.WithEnableConnectProtocol(enableConnectProtocol),
+	}
+	if mcsOpt := clientH2MaxConcurrentStreamsOption(cfg); mcsOpt != nil {
+		clientH2Opts = append(clientH2Opts, mcsOpt)
+	}
+	clientLayer, err := http2.New(clientConn, connID+"/client", http2.ServerRole, clientH2Opts...)
+	if err != nil {
+		_ = upstreamLayer.Close()
+		_ = clientConn.Close()
+		return nil, fmt.Errorf("connector: buildTargetOverrideH2CStack: client h2 layer: %w", err)
+	}
+	stack.PushClient(clientLayer)
+	stack.PushUpstream(upstreamLayer)
+
 	return stack, nil
 }
 

--- a/internal/connector/stack_builder_target_override_test.go
+++ b/internal/connector/stack_builder_target_override_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
@@ -113,10 +114,11 @@ func TestBuildConnectionStackWithTarget_DeferredProtocols(t *testing.T) {
 	}{
 		{name: "auto", protocol: ForwardProtocolAuto, wantIssue: "USK-913"},
 		{name: "http", protocol: ForwardProtocolHTTP, wantIssue: "USK-913"},
-		{name: "http2", protocol: ForwardProtocolHTTP2, wantIssue: "USK-913"},
-		{name: "grpc", protocol: ForwardProtocolGRPC, wantIssue: "USK-914"},
-		{name: "websocket", protocol: ForwardProtocolWebSocket, wantIssue: "USK-914"},
-		{name: "sse", protocol: ForwardProtocolSSE, wantIssue: "USK-914"},
+		// http2 and grpc are wired by USK-914 (this Issue) — see
+		// TestBuildConnectionStackWithTarget_H2CSuccess /
+		// TestBuildConnectionStackWithTarget_GRPCSuccess below.
+		{name: "websocket", protocol: ForwardProtocolWebSocket, wantIssue: "USK-913"},
+		{name: "sse", protocol: ForwardProtocolSSE, wantIssue: "USK-913"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,6 +135,83 @@ func TestBuildConnectionStackWithTarget_DeferredProtocols(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.wantIssue) {
 				t.Errorf("protocol %q: error %q does not cite %q", tc.protocol, err.Error(), tc.wantIssue)
+			}
+		})
+	}
+}
+
+// TestBuildConnectionStackWithTarget_H2CDispatch verifies that the
+// HTTP2 / GRPC selector reach the h2c builder branch by feeding closed
+// connections and asserting the wrap error cites the expected sub-stage.
+// A full positive-path test of the assembled stack (with a real h2 client
+// preface) lives in proxybuild's e2e suite — see
+// internal/proxybuild/tcp_forward_h2_integration_test.go and
+// internal/proxybuild/tcp_forward_grpc_integration_test.go.
+func TestBuildConnectionStackWithTarget_H2CDispatch(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol ForwardProtocol
+	}{
+		{name: "http2", protocol: ForwardProtocolHTTP2},
+		{name: "grpc", protocol: ForwardProtocolGRPC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Construct conns whose Reads return EOF immediately so the
+			// upstream http2.New ClientRole preface-write succeeds but the
+			// reader goroutine sees EOF on the very next frame read. We only
+			// need the dispatcher to route into the h2c builder branch — the
+			// builder may then fail at either the upstream or client Layer
+			// construction; both outcomes indicate the dispatch reached the
+			// h2 branch (not the "not yet wired" error path).
+			clientLocal, clientPeer := net.Pipe()
+			t.Cleanup(func() { _ = clientLocal.Close(); _ = clientPeer.Close() })
+			upstreamLocal, upstreamPeer := net.Pipe()
+			t.Cleanup(func() { _ = upstreamLocal.Close(); _ = upstreamPeer.Close() })
+
+			// Drain the conns asynchronously: discard whatever the http2
+			// Layer writes (preface + SETTINGS frame on the upstream side;
+			// SETTINGS on the client side after preface read). Close on
+			// drain end so subsequent reads return EOF.
+			drainAndClose := func(c net.Conn) {
+				go func() {
+					buf := make([]byte, 4096)
+					for {
+						if _, err := c.Read(buf); err != nil {
+							return
+						}
+					}
+				}()
+			}
+			drainAndClose(clientLocal)
+			drainAndClose(upstreamLocal)
+
+			// Close the peers' read direction so the http2.New's preface
+			// validation surfaces a deterministic error. net.Pipe does not
+			// support CloseRead, so closing the whole conn after a short
+			// delay achieves the same outcome.
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				_ = clientLocal.Close()
+				_ = upstreamLocal.Close()
+			}()
+
+			cfg := newTestBuildConfig(t)
+			params := TargetOverrideParams{
+				Target:   "api.example.com:50051",
+				Protocol: tc.protocol,
+			}
+			_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+			// The interesting assertion is the error path — it must NOT
+			// be the "not yet wired" sentinel. Either the upstream or
+			// client h2 layer construction surfaces a wrap error citing
+			// "buildTargetOverrideH2CStack" or the connector's
+			// "BuildConnectionStackWithTarget" prefix.
+			if err == nil {
+				t.Fatalf("protocol %q: expected error from closed peer dispatch (no real h2 handshake), got success", tc.protocol)
+			}
+			if strings.Contains(err.Error(), "not yet wired") {
+				t.Errorf("protocol %q: dispatch returned 'not yet wired' (%q); h2c branch was not reached", tc.protocol, err.Error())
 			}
 		})
 	}

--- a/internal/proxybuild/tcp_forward.go
+++ b/internal/proxybuild/tcp_forward.go
@@ -55,6 +55,12 @@ type tcpForwardEntry struct {
 	netLn   net.Listener
 	wgConns sync.WaitGroup // tracks per-connection handler goroutines
 
+	// fc retains the originating ForwardConfig so per-conn dispatch can
+	// route on Protocol / TLS / UpstreamTLS. Kept as a pointer to the
+	// caller's value — TCPForwardParams.Forwards lifetime exceeds the
+	// listener's, and the per-conn handler treats this as read-only.
+	fc *config.ForwardConfig
+
 	// activeConns and maxConns implement an atomic per-forward connection
 	// cap. activeConns is incremented on accept and decremented when the
 	// handler returns; if activeConns would exceed maxConns the new conn is
@@ -87,16 +93,23 @@ func (m *Manager) startTCPForwardListener(
 	}
 
 	// First iteration: only "raw", "auto" (with no detector → raw fallback),
-	// and "" are wired. Other modes return an explicit error so callers know
-	// they have to wait for the L7-mode follow-up.
+	// and "" are wired. USK-914 adds "http2" and "grpc" (h2c forward).
+	// Other modes return an explicit error so callers know they have to
+	// wait for the L7-mode follow-up (USK-913 owns http/websocket/sse/auto
+	// dispatch arms).
 	switch fc.Protocol {
 	case "", "raw", "auto":
-		// supported
+		// supported (USK-711)
+	case "http2", "grpc":
+		// supported (USK-914 — h2c forward dispatch in tcp_forward_h2.go)
 	default:
-		return nil, fmt.Errorf("tcp forward port %s: protocol %q not yet supported (USK-711 implements raw/auto; L7 modes deferred)", port, fc.Protocol)
+		return nil, fmt.Errorf("tcp forward port %s: protocol %q not yet supported (USK-711 implements raw/auto; USK-914 implements http2/grpc; remaining L7 modes deferred)", port, fc.Protocol)
 	}
 	if fc.TLS {
-		return nil, fmt.Errorf("tcp forward port %s: tls=true not yet supported (USK-711 implements raw forwarding only)", port)
+		return nil, fmt.Errorf("tcp forward port %s: tls=true not yet supported (USK-915 owns client-side TLS terminate)", port)
+	}
+	if fc.UpstreamTLS {
+		return nil, fmt.Errorf("tcp forward port %s: upstream_tls=true not yet supported (USK-916 owns upstream-dial TLS)", port)
 	}
 
 	bindAddr := fmt.Sprintf("127.0.0.1:%s", port)
@@ -115,6 +128,7 @@ func (m *Manager) startTCPForwardListener(
 		cancel: cancel,
 		done:   make(chan struct{}),
 		netLn:  ln,
+		fc:     fc,
 	}
 	// Seed the per-forward connection cap from the manager-level setting so
 	// SetMaxConnections fan-out reaches forward listeners. 0 = unlimited.
@@ -205,6 +219,18 @@ func (m *Manager) runTCPForwardAcceptLoop(
 			defer entry.wgConns.Done()
 			if counted {
 				defer entry.activeConns.Add(-1)
+			}
+			// USK-914: route http2 / grpc to the h2-aware handler. All
+			// other supported values (raw / auto / "") stay on the raw
+			// bytechunk path. The protocol gating happens at
+			// startTCPForwardListener so the switch here is just a
+			// dispatch — invalid values cannot reach this code.
+			if entry.fc != nil {
+				switch entry.fc.Protocol {
+				case "http2", "grpc":
+					m.handleTCPForwardH2Conn(ctx, parentListenerName, entry, entry.fc, c)
+					return
+				}
 			}
 			m.handleTCPForwardConn(ctx, parentListenerName, entry, c)
 		}(conn, counted)

--- a/internal/proxybuild/tcp_forward_grpc_integration_test.go
+++ b/internal/proxybuild/tcp_forward_grpc_integration_test.go
@@ -1,0 +1,478 @@
+//go:build e2e && !e2e_smoke
+
+// Package proxybuild_test exhaustive tier — USK-914 gRPC over h2c forward
+// proxy. Validates the ForwardConfig.Protocol="grpc" arm (h2c stack +
+// per-stream content-type filter) round-trips unary / server-streaming /
+// bidi RPCs and rejects non-gRPC streams.
+//
+// The harness duplicates the minimum-needed gRPC fixtures from
+// internal/layer/grpc/grpc_integration_test.go (echoServer, rawCodec) so
+// this file does not cross-package import an _test fixture.
+package proxybuild_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	gohttp "net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/status"
+)
+
+// rawCodecName / rawCodec — duplicated from internal/layer/grpc/grpc_integration_test.go.
+// Registers as "rawforward" so the codec name does not collide with the
+// "raw" codec the source-of-truth fixture registers in its own test
+// binary (Go test caches package binaries per build-tag set, but the
+// safety belt is cheap).
+const rawCodecName = "rawforward"
+
+type rawCodec struct{}
+
+func (rawCodec) Name() string { return rawCodecName }
+
+func (rawCodec) Marshal(v any) ([]byte, error) {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("rawCodec: Marshal: want *[]byte, got %T", v)
+	}
+	if b == nil {
+		return nil, nil
+	}
+	out := make([]byte, len(*b))
+	copy(out, *b)
+	return out, nil
+}
+
+func (rawCodec) Unmarshal(data []byte, v any) error {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("rawCodec: Unmarshal: want *[]byte, got %T", v)
+	}
+	*b = make([]byte, len(data))
+	copy(*b, data)
+	return nil
+}
+
+func init() {
+	encoding.RegisterCodec(rawCodec{})
+}
+
+// echoServer / echoServiceDesc — duplicated from
+// internal/layer/grpc/grpc_integration_test.go. Implements Unary,
+// ServerStream, and BidiStream (ClientStream omitted — not exercised
+// here).
+const (
+	fwdEchoServiceName        = "yorishiro.forward.test.Echo"
+	fwdEchoMethodUnary        = "Unary"
+	fwdEchoMethodServerStream = "ServerStream"
+	fwdEchoMethodBidiStream   = "BidiStream"
+)
+
+type echoHandler interface{}
+
+type echoServer struct {
+	unary        func(ctx context.Context, req []byte) ([]byte, error)
+	serverStream func(req []byte, stream grpc.ServerStream) error
+	bidiStream   func(stream grpc.ServerStream) error
+}
+
+var echoServiceDesc = grpc.ServiceDesc{
+	ServiceName: fwdEchoServiceName,
+	HandlerType: (*echoHandler)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: fwdEchoMethodUnary,
+			Handler: func(srv any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				var req []byte
+				if err := dec(&req); err != nil {
+					return nil, err
+				}
+				h := srv.(*echoServer)
+				if h.unary == nil {
+					return nil, status.Error(codes.Unimplemented, "Unary not set")
+				}
+				resp, err := h.unary(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return &resp, nil
+			},
+		},
+	},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName: fwdEchoMethodServerStream,
+			Handler: func(srv any, stream grpc.ServerStream) error {
+				var req []byte
+				if err := stream.RecvMsg(&req); err != nil {
+					return err
+				}
+				h := srv.(*echoServer)
+				if h.serverStream == nil {
+					return status.Error(codes.Unimplemented, "ServerStream not set")
+				}
+				return h.serverStream(req, stream)
+			},
+			ServerStreams: true,
+		},
+		{
+			StreamName:    fwdEchoMethodBidiStream,
+			ServerStreams: true,
+			ClientStreams: true,
+			Handler: func(srv any, stream grpc.ServerStream) error {
+				h := srv.(*echoServer)
+				if h.bidiStream == nil {
+					return status.Error(codes.Unimplemented, "BidiStream not set")
+				}
+				return h.bidiStream(stream)
+			},
+		},
+	},
+	Metadata: "yorishiro.forward.test.Echo",
+}
+
+func fwdEchoFullMethod(method string) string {
+	return "/" + fwdEchoServiceName + "/" + method
+}
+
+// startH2CGRPCUpstream starts a gRPC server speaking h2c (cleartext).
+// Returns (addr, shutdown).
+func startH2CGRPCUpstream(t *testing.T, srv *echoServer) (addr string, shutdown func()) {
+	t.Helper()
+	gs := grpc.NewServer(grpc.ForceServerCodec(rawCodec{}))
+	gs.RegisterService(&echoServiceDesc, srv)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	go func() { _ = gs.Serve(ln) }()
+	return ln.Addr().String(), func() {
+		gs.GracefulStop()
+		_ = ln.Close()
+	}
+}
+
+// dialGRPCViaForward opens a gRPC client connection that targets the
+// forward listener directly (h2c, no TLS, no CONNECT). The proxy is
+// transparent — the gRPC client sees the forward port as a normal h2c
+// endpoint and the proxy hands the streams to the upstream gRPC server.
+func dialGRPCViaForward(t *testing.T, fwdAddr string) *grpc.ClientConn {
+	t.Helper()
+	cc, err := grpc.NewClient(fwdAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	return cc
+}
+
+// TestProxybuild_TCPForward_GRPC_UnaryRoundtrip exercises a unary RPC via
+// the gRPC forward listener: client sends echo:hello → server replies
+// echo:hello → flows are recorded with Protocol=grpc.
+func TestProxybuild_TCPForward_GRPC_UnaryRoundtrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	srv := &echoServer{
+		unary: func(_ context.Context, req []byte) ([]byte, error) {
+			out := append([]byte("echo:"), req...)
+			return out, nil
+		},
+	}
+	upAddr, upStop := startH2CGRPCUpstream(t, srv)
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "grpc")
+	defer mgr.StopAll(context.Background())
+
+	cc := dialGRPCViaForward(t, fwdAddr)
+	defer cc.Close()
+
+	req := []byte("hello-usk-914-grpc")
+	var resp []byte
+	if err := cc.Invoke(ctx, fwdEchoFullMethod(fwdEchoMethodUnary), &req, &resp); err != nil {
+		t.Fatalf("Invoke Unary: %v", err)
+	}
+	if want := []byte("echo:hello-usk-914-grpc"); string(resp) != string(want) {
+		t.Errorf("Unary resp=%q want %q", resp, want)
+	}
+
+	// Wait for recordings to settle.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasGRPCStream(store) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !hasGRPCStream(store) {
+		t.Errorf("expected at least one Stream with Protocol=grpc, got %+v", store.Streams())
+	}
+}
+
+// TestProxybuild_TCPForward_GRPC_ServerStreaming exercises the
+// server-streaming RPC variant (1 request → N responses).
+func TestProxybuild_TCPForward_GRPC_ServerStreaming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const n = 3
+	srv := &echoServer{
+		serverStream: func(req []byte, stream grpc.ServerStream) error {
+			for i := 0; i < n; i++ {
+				msg := append([]byte(fmt.Sprintf("%d:", i)), req...)
+				if err := stream.SendMsg(&msg); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	upAddr, upStop := startH2CGRPCUpstream(t, srv)
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "grpc")
+	defer mgr.StopAll(context.Background())
+
+	cc := dialGRPCViaForward(t, fwdAddr)
+	defer cc.Close()
+
+	desc := &grpc.StreamDesc{StreamName: fwdEchoMethodServerStream, ServerStreams: true}
+	stream, err := cc.NewStream(ctx, desc, fwdEchoFullMethod(fwdEchoMethodServerStream))
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := []byte("svr-stream")
+	if err := stream.SendMsg(&req); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+	var got [][]byte
+	for {
+		var msg []byte
+		if rerr := stream.RecvMsg(&msg); rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				break
+			}
+			t.Fatalf("RecvMsg: %v", rerr)
+		}
+		got = append(got, msg)
+	}
+	if len(got) != n {
+		t.Errorf("server-stream got %d messages, want %d", len(got), n)
+	}
+	for i, m := range got {
+		want := fmt.Sprintf("%d:svr-stream", i)
+		if string(m) != want {
+			t.Errorf("msg %d = %q, want %q", i, m, want)
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasGRPCStream(store) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !hasGRPCStream(store) {
+		t.Errorf("expected at least one Stream with Protocol=grpc, got %+v", store.Streams())
+	}
+}
+
+// TestProxybuild_TCPForward_GRPC_BidiStreaming exercises a bidi-streaming
+// RPC: client sends 3 messages → server echoes each → client closes.
+func TestProxybuild_TCPForward_GRPC_BidiStreaming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	srv := &echoServer{
+		bidiStream: func(stream grpc.ServerStream) error {
+			for {
+				var msg []byte
+				if rerr := stream.RecvMsg(&msg); rerr != nil {
+					if errors.Is(rerr, io.EOF) {
+						return nil
+					}
+					return rerr
+				}
+				echo := append([]byte("bidi:"), msg...)
+				if serr := stream.SendMsg(&echo); serr != nil {
+					return serr
+				}
+			}
+		},
+	}
+	upAddr, upStop := startH2CGRPCUpstream(t, srv)
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "grpc")
+	defer mgr.StopAll(context.Background())
+
+	cc := dialGRPCViaForward(t, fwdAddr)
+	defer cc.Close()
+
+	desc := &grpc.StreamDesc{StreamName: fwdEchoMethodBidiStream, ServerStreams: true, ClientStreams: true}
+	stream, err := cc.NewStream(ctx, desc, fwdEchoFullMethod(fwdEchoMethodBidiStream))
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+
+	send := [][]byte{[]byte("one"), []byte("two"), []byte("three")}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var recvErr error
+	got := make([][]byte, 0, len(send))
+	go func() {
+		defer wg.Done()
+		for {
+			var msg []byte
+			if rerr := stream.RecvMsg(&msg); rerr != nil {
+				if !errors.Is(rerr, io.EOF) {
+					recvErr = rerr
+				}
+				return
+			}
+			got = append(got, msg)
+		}
+	}()
+
+	for _, m := range send {
+		mc := m // local copy for SendMsg's pointer arg
+		if serr := stream.SendMsg(&mc); serr != nil {
+			t.Fatalf("SendMsg: %v", serr)
+		}
+	}
+	if cerr := stream.CloseSend(); cerr != nil {
+		t.Fatalf("CloseSend: %v", cerr)
+	}
+	wg.Wait()
+	if recvErr != nil {
+		t.Fatalf("RecvMsg: %v", recvErr)
+	}
+	if len(got) != len(send) {
+		t.Errorf("bidi got %d messages, want %d", len(got), len(send))
+	}
+	for i, m := range got {
+		want := "bidi:" + string(send[i])
+		if string(m) != want {
+			t.Errorf("bidi msg %d = %q, want %q", i, m, want)
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasGRPCStream(store) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !hasGRPCStream(store) {
+		t.Errorf("expected at least one Stream with Protocol=grpc, got %+v", store.Streams())
+	}
+}
+
+// TestProxybuild_TCPForward_GRPC_FilterRejectsNonGRPC asserts the
+// Protocol="grpc" content-type filter rejects a stream whose
+// content-type is not application/grpc[+suffix]. The reject path records
+// a state="error" Stream tagged with
+// forward_protocol_mismatch=non_grpc_under_grpc_filter.
+func TestProxybuild_TCPForward_GRPC_FilterRejectsNonGRPC(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Upstream is the gRPC server (irrelevant — the request never reaches
+	// it because the proxy rejects the stream at the filter).
+	srv := &echoServer{}
+	upAddr, upStop := startH2CGRPCUpstream(t, srv)
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "grpc")
+	defer mgr.StopAll(context.Background())
+
+	// Send a plain HTTP/2 (h2c) GET request — content-type will be empty
+	// (or text/plain after stdlib defaults), which the filter rejects.
+	var dialed []net.Conn
+	var mu sync.Mutex
+	cli := h2cForwardClient(fwdAddr, &dialed, &mu)
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fwdAddr+"/not-grpc", nil)
+	resp, err := cli.Do(req)
+	if err == nil && resp != nil {
+		// The proxy emitted RST_STREAM(REFUSED_STREAM); the stdlib h2
+		// client surfaces that as an error on the response body read.
+		_, rErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		// Either Do or body-read MUST surface an error — successful
+		// response means the filter did not fire.
+		if rErr == nil {
+			t.Errorf("expected RST_STREAM error on non-gRPC stream, got status=%d body read OK", resp.StatusCode)
+		}
+	}
+	// Drain conn handles so the test does not race the listener teardown.
+	cli.CloseIdleConnections()
+	mu.Lock()
+	dialSnap := append([]net.Conn{}, dialed...)
+	mu.Unlock()
+	closeDialedConns(dialSnap)
+
+	// Wait for the reject Stream to be recorded.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasForwardProtocolMismatch(store) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !hasForwardProtocolMismatch(store) {
+		var dump []string
+		for _, s := range store.Streams() {
+			dump = append(dump, fmt.Sprintf("%s[%s tags=%v]", s.ID, s.State, s.Tags))
+		}
+		t.Errorf("expected a state=error Stream tagged forward_protocol_mismatch, got %v", dump)
+	}
+}
+
+// hasGRPCStream reports whether any recorded Stream carries Protocol=grpc.
+func hasGRPCStream(store *flowStoreCapture) bool {
+	for _, st := range store.Streams() {
+		if st.Protocol == "grpc" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasForwardProtocolMismatch reports whether any recorded Stream is
+// tagged with the gRPC-filter reject marker. The tag is appended via
+// UpdateStream.AppendTags, so we also scan StreamUpdates as a fallback
+// (the in-test flowStoreCapture does not merge AppendTags into Stream.Tags).
+func hasForwardProtocolMismatch(store *flowStoreCapture) bool {
+	for _, st := range store.Streams() {
+		if v, ok := st.Tags["forward_protocol_mismatch"]; ok && v == "non_grpc_under_grpc_filter" {
+			return true
+		}
+		for _, upd := range store.StreamUpdates(st.ID) {
+			if upd.AppendTags == nil {
+				continue
+			}
+			if v := upd.AppendTags["forward_protocol_mismatch"]; v == "non_grpc_under_grpc_filter" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/proxybuild/tcp_forward_h2.go
+++ b/internal/proxybuild/tcp_forward_h2.go
@@ -1,0 +1,475 @@
+package proxybuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	grpclayer "github.com/usk6666/yorishiro-proxy/internal/layer/grpc"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/grpcweb"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/httpaggregator"
+	"github.com/usk6666/yorishiro-proxy/internal/session"
+)
+
+// handleTCPForwardH2Conn is the per-accepted-connection handler for
+// ForwardConfig.Protocol="http2" and "grpc" (USK-914). It dials upstream
+// plain TCP, assembles an h2c ConnectionStack via
+// connector.BuildConnectionStackWithTarget (HTTP2 / GRPC arm), and runs
+// the per-stream dispatch loop against the assembled client + upstream
+// HTTP/2 Layers.
+//
+// Sibling of handleTCPForwardConn (raw bytechunk path, tcp_forward.go).
+// Kept in this file so the h2-specific concerns (per-stream goroutines,
+// DispatchH2StreamFull wiring, gRPC content-type filter) stay isolated
+// from the raw forward path's per-connection session loop.
+//
+// Lifecycle:
+//   - Dial → BuildConnectionStackWithTarget HTTP2/GRPC arm → stack.Close
+//     deferred.
+//   - ctx-cancellation watcher closes the stack so per-stream goroutines
+//     parked in conn.Read are unblocked when the listener shuts down.
+//     Pattern mirrors handleTCPForwardConn.
+//   - runTCPForwardH2Loop waits for every per-stream goroutine via a
+//     sync.WaitGroup before returning.
+func (m *Manager) handleTCPForwardH2Conn(
+	ctx context.Context,
+	parentListenerName string,
+	entry *tcpForwardEntry,
+	fc *config.ForwardConfig,
+	clientConn net.Conn,
+) {
+	defer clientConn.Close()
+
+	connID := connector.GenerateConnID()
+	clientAddr := clientConn.RemoteAddr().String()
+	connLogger := m.logger.With(
+		"conn_id", connID,
+		"remote_addr", clientAddr,
+		"name", parentListenerName,
+		"port", entry.port,
+		"target", entry.target,
+		"protocol", fc.Protocol,
+		"via", "tcp-forward-h2",
+	)
+
+	connCtx := connector.ContextWithConnID(ctx, connID)
+	connCtx = connector.ContextWithClientAddr(connCtx, clientAddr)
+	connCtx = connector.ContextWithListenerName(connCtx, parentListenerName)
+	connCtx = connector.ContextWithLogger(connCtx, connLogger)
+	connCtx = connector.ContextWithForwardTarget(connCtx, entry.target)
+
+	parentStack := m.Stack(parentListenerName)
+	if parentStack == nil {
+		connLogger.Debug("tcp forward h2 parent listener no longer running; dropping connection")
+		return
+	}
+
+	// Dial upstream plain TCP. USK-915/USK-916 will introduce TLS dialing;
+	// for now the h2 forward stack is h2c (cleartext on both sides).
+	dialOpts := connector.DialRawOpts{
+		DialTimeout: tcpForwardDialTimeout,
+	}
+	if parentStack.BuildConfig != nil {
+		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(connCtx)
+	}
+	upstreamConn, _, derr := connector.DialUpstreamRaw(connCtx, entry.target, dialOpts)
+	if derr != nil {
+		connLogger.Debug("tcp forward h2 upstream dial failed", "error", derr)
+		return
+	}
+
+	// Map ForwardConfig.Protocol → connector.ForwardProtocol.
+	var fwdProto connector.ForwardProtocol
+	switch fc.Protocol {
+	case "http2":
+		fwdProto = connector.ForwardProtocolHTTP2
+	case "grpc":
+		fwdProto = connector.ForwardProtocolGRPC
+	default:
+		// Caller (startTCPForwardListener) routes only http2 / grpc here;
+		// defensive guard.
+		_ = upstreamConn.Close()
+		connLogger.Warn("tcp forward h2 dispatched with unexpected protocol", "protocol", fc.Protocol)
+		return
+	}
+
+	stack, berr := connector.BuildConnectionStackWithTarget(connCtx, clientConn, upstreamConn, connector.TargetOverrideParams{
+		Target:   entry.target,
+		Protocol: fwdProto,
+	}, parentStack.BuildConfig)
+	if berr != nil {
+		connLogger.Debug("tcp forward h2 stack build failed", "error", berr)
+		// BuildConnectionStackWithTarget closes both conns on construction
+		// failure; no additional close needed here.
+		return
+	}
+	defer stack.Close()
+
+	// ctx-cancellation watcher. Pattern mirrors handleTCPForwardConn.
+	doneCh := make(chan struct{})
+	var watcherWG sync.WaitGroup
+	watcherWG.Add(1)
+	go func() {
+		defer watcherWG.Done()
+		select {
+		case <-connCtx.Done():
+			_ = stack.Close()
+		case <-doneCh:
+		}
+	}()
+	defer func() {
+		close(doneCh)
+		watcherWG.Wait()
+	}()
+
+	isGRPCFilter := fwdProto == connector.ForwardProtocolGRPC
+	runTCPForwardH2Loop(connCtx, parentStack, stack, entry.target, connLogger, isGRPCFilter)
+}
+
+// runTCPForwardH2Loop iterates the client HTTP/2 Layer's Channels()
+// (one per stream) and spawns one goroutine per stream running the
+// session loop against the upstream HTTP/2 Layer via OpenStream.
+//
+// Modelled on buildOnHTTP2Stack (the CONNECT-routed h2 dispatcher) with
+// these adjustments:
+//
+//   - Upstream is dialed per-conn (no h2_pool integration — forward
+//     dials fresh per accepted client TCP conn by design).
+//   - No redial machinery (pool staleness is a MITM-only concern).
+//   - When isGRPCFilter is true, the first envelope of each stream is
+//     peeked and its content-type validated; non-gRPC streams are
+//     refused with RST_STREAM(REFUSED_STREAM) and a state="error" Stream
+//     is recorded with Tags["forward_protocol_mismatch"]=
+//     "non_grpc_under_grpc_filter".
+//
+// Per-stream wire-record callbacks mirror buildOnHTTP2Stack so recording
+// parity is preserved (h2-frame, grpc-lpm-frame, grpc-h2-frame,
+// grpc-web-base64).
+func runTCPForwardH2Loop(
+	ctx context.Context,
+	parentStack *Stack,
+	stack *connector.ConnectionStack,
+	target string,
+	logger *slog.Logger,
+	isGRPCFilter bool,
+) {
+	clientL, ok := stack.ClientTopmost().(*http2.Layer)
+	if !ok {
+		logger.Debug("tcp forward h2: client topmost is not *http2.Layer",
+			"target", target, "type", fmt.Sprintf("%T", stack.ClientTopmost()))
+		return
+	}
+	upstreamH2, ok := stack.UpstreamTopmost().(*http2.Layer)
+	if !ok {
+		logger.Debug("tcp forward h2: upstream topmost is not *http2.Layer",
+			"target", target, "type", fmt.Sprintf("%T", stack.UpstreamTopmost()))
+		return
+	}
+
+	sessOpts := tcpForwardH2SessionOpts(parentStack, ctx)
+	grpcOpts := connector.GRPCOptionsFromBuildConfig(parentStack.BuildConfig)
+	grpcwebOpts := connector.GRPCWebOptionsFromBuildConfig(parentStack.BuildConfig)
+	clientLOpts := httpaggregator.OptionsFromLayer(clientL)
+	clientLOpts.StateReleaser = parentStack.PluginV2Engine
+	upstreamLOpts := httpaggregator.OptionsFromLayer(upstreamH2)
+	upstreamLOpts.StateReleaser = parentStack.PluginV2Engine
+
+	var wg sync.WaitGroup
+	for {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case clientCh, alive := <-clientL.Channels():
+			if !alive {
+				wg.Wait()
+				return
+			}
+			wg.Add(1)
+			go func(ch layer.Channel) {
+				defer wg.Done()
+				dispatchForwardH2Stream(
+					ctx, parentStack, stack, ch, upstreamH2,
+					target, logger, isGRPCFilter,
+					sessOpts, clientLOpts, upstreamLOpts,
+					grpcOpts, grpcwebOpts,
+				)
+			}(clientCh)
+		}
+	}
+}
+
+// dispatchForwardH2Stream runs the per-stream dispatch + session loop.
+// Split from runTCPForwardH2Loop so the parent stays under the gocyclo
+// threshold and the per-stream callback wiring is readable.
+func dispatchForwardH2Stream(
+	ctx context.Context,
+	parentStack *Stack,
+	stack *connector.ConnectionStack,
+	ch layer.Channel,
+	upstreamH2 *http2.Layer,
+	target string,
+	logger *slog.Logger,
+	isGRPCFilter bool,
+	sessOpts session.SessionOptions,
+	clientLOpts httpaggregator.WrapOptions,
+	upstreamLOpts httpaggregator.WrapOptions,
+	grpcOpts []grpclayer.Option,
+	grpcwebOpts []grpcweb.Option,
+) {
+	p := parentStack.PipelineH2
+	streamFlowCtx := envelope.EnvelopeContext{ConnID: stack.ConnID, TargetHost: target}
+
+	// gRPC content-type filter (Protocol="grpc" only). Must run BEFORE
+	// DispatchH2StreamFull, which consumes the first envelope. The filter
+	// peeks the first envelope, validates content-type, and either:
+	//   - rejects non-gRPC (RST_STREAM(REFUSED_STREAM) + error Stream)
+	//   - re-feeds gRPC envelopes via a small replay wrapper
+	dispatchCh := ch
+	if isGRPCFilter {
+		filtered, ok := applyGRPCFilter(ctx, ch, parentStack, target, streamFlowCtx, logger)
+		if !ok {
+			return
+		}
+		dispatchCh = filtered
+	}
+
+	// Per-stream wire-record callbacks (matches buildOnHTTP2Stack).
+	lpmOpt := session.GRPCLPMRecordOption(ctx, p, ch.StreamID(), streamFlowCtx)
+	grpcH2FrameOpt := session.GRPCH2DataFrameRecordOption(ctx, p, ch.StreamID(), streamFlowCtx)
+	streamGRPCOpts := make([]grpclayer.Option, 0, len(grpcOpts)+2)
+	streamGRPCOpts = append(streamGRPCOpts, grpcOpts...)
+	streamGRPCOpts = append(streamGRPCOpts, lpmOpt, grpcH2FrameOpt)
+
+	aggH2FrameOpt := session.AggregatorH2FrameRecordOption(ctx, p, ch.StreamID(), streamFlowCtx)
+	streamAggOpts := []httpaggregator.WrapOption{aggH2FrameOpt}
+
+	grpcWebBase64Opt := session.GRPCWebBase64RecordOption(ctx, p, ch.StreamID(), streamFlowCtx)
+	streamGRPCWebOpts := make([]grpcweb.Option, 0, len(grpcwebOpts)+1)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, grpcwebOpts...)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, grpcWebBase64Opt)
+
+	aggCh, derr := connector.DispatchH2StreamFull(
+		ctx, dispatchCh, httpaggregator.RoleServer,
+		clientLOpts, logger, streamGRPCOpts, streamGRPCWebOpts, streamAggOpts,
+	)
+	if derr != nil {
+		logger.Debug("tcp forward h2 dispatch failed",
+			"target", target, "stream_id", ch.StreamID(), "error", derr)
+		_ = ch.Close()
+		return
+	}
+
+	dial := func(dctx context.Context, env *envelope.Envelope) (layer.Channel, error) {
+		upCh, oerr := upstreamH2.OpenStream(dctx)
+		if oerr != nil {
+			return nil, oerr
+		}
+		var reqProto envelope.Protocol
+		if env != nil {
+			reqProto = env.Protocol
+		}
+		return connector.WrapH2UpstreamForDispatchFull(
+			upCh, reqProto, upstreamLOpts, streamGRPCOpts, streamGRPCWebOpts, streamAggOpts,
+		), nil
+	}
+
+	if err := session.RunStackSessionExchange(ctx, stack, aggCh, dial, p, sessOpts); err != nil &&
+		!errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+		logger.Debug("tcp forward h2 stream exchange ended with error",
+			"target", target, "stream_id", ch.StreamID(), "error", err)
+	}
+}
+
+// applyGRPCFilter implements the Protocol="grpc" content-type filter on
+// the first envelope of an h2 stream. Returns (filtered-channel, true)
+// when the stream is gRPC-eligible — the returned Channel replays the
+// peeked first envelope so DispatchH2StreamFull's own peek succeeds.
+// Returns (nil, false) when the stream is rejected (RST_STREAM emitted,
+// error Stream recorded); the caller should return without further work.
+//
+// Reject criteria (rejected → state="error" Stream with
+// Tags["forward_protocol_mismatch"]="non_grpc_under_grpc_filter"):
+//   - first envelope is not an H2HeadersEvent (malformed stream)
+//   - content-type is missing
+//   - content-type matches grpc-web (rejected — Protocol="grpc" is a
+//     crisper semantic; gRPC-Web routes via Protocol="http2")
+//   - content-type is not native gRPC (application/grpc[+suffix])
+func applyGRPCFilter(
+	ctx context.Context,
+	ch layer.Channel,
+	parentStack *Stack,
+	target string,
+	streamFlowCtx envelope.EnvelopeContext,
+	logger *slog.Logger,
+) (layer.Channel, bool) {
+	firstEnv, err := ch.Next(ctx)
+	if err != nil {
+		logger.Debug("tcp forward grpc filter: peek failed",
+			"target", target, "stream_id", ch.StreamID(), "error", err)
+		_ = ch.Close()
+		return nil, false
+	}
+	evt, ok := firstEnv.Message.(*http2.H2HeadersEvent)
+	if !ok {
+		logger.Debug("tcp forward grpc filter: first envelope is not H2HeadersEvent",
+			"target", target, "stream_id", ch.StreamID(), "type", fmt.Sprintf("%T", firstEnv.Message))
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		rejectGRPCStream(ch)
+		return nil, false
+	}
+	ct := connector.ExtractH2ContentType(evt)
+	if grpcweb.IsGRPCWebContentType(ct) {
+		logger.Debug("tcp forward grpc filter: rejected grpc-web under Protocol=grpc",
+			"target", target, "stream_id", ch.StreamID(), "content_type", ct)
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		rejectGRPCStream(ch)
+		return nil, false
+	}
+	if !connector.IsGRPCContentType(ct) {
+		logger.Debug("tcp forward grpc filter: rejected non-gRPC content-type",
+			"target", target, "stream_id", ch.StreamID(), "content_type", ct)
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		rejectGRPCStream(ch)
+		return nil, false
+	}
+	return newReplayChannel(ch, firstEnv), true
+}
+
+// rejectGRPCStream emits RST_STREAM(REFUSED_STREAM) on the client
+// channel when the underlying type supports the explicit termination
+// API; falls back to a plain Close otherwise.
+func rejectGRPCStream(ch layer.Channel) {
+	type rstCloser interface {
+		MarkTerminatedWithRST(code uint32, err error)
+	}
+	if rc, ok := ch.(rstCloser); ok {
+		rc.MarkTerminatedWithRST(http2.ErrCodeRefusedStream,
+			errors.New("tcp forward grpc filter: non-gRPC content-type rejected"))
+		return
+	}
+	_ = ch.Close()
+}
+
+// recordGRPCFilterReject records a state="error" Stream for a stream
+// rejected by the gRPC content-type filter. The Stream is tagged with
+// forward_protocol_mismatch so MCP queries can surface the rejection
+// without grovelling through Flow rows.
+func recordGRPCFilterReject(
+	ctx context.Context,
+	parentStack *Stack,
+	streamID string,
+	streamFlowCtx envelope.EnvelopeContext,
+	mismatchKind string,
+) {
+	if parentStack == nil || parentStack.FlowStore == nil || streamID == "" {
+		return
+	}
+	st := &flow.Stream{
+		ID:       streamID,
+		ConnID:   streamFlowCtx.ConnID,
+		Protocol: "grpc",
+		State:    "error",
+	}
+	_ = parentStack.FlowStore.SaveStream(ctx, st)
+	_ = parentStack.FlowStore.UpdateStream(ctx, streamID, flow.StreamUpdate{
+		State:         "error",
+		FailureReason: "forward_protocol_mismatch",
+		AppendTags: map[string]string{
+			"forward_protocol_mismatch": mismatchKind,
+		},
+	})
+}
+
+// tcpForwardH2SessionOpts builds session.SessionOptions for an h2 TCP
+// forward session. Sibling of tcpForwardSessionOpts (raw path); kept
+// here so the h2 dispatch file is the single touch-point for h2-specific
+// concerns.
+//
+// OnComplete behaviour mirrors the raw sibling — listener-shutdown
+// (ctx-cancel) classifies state="complete" so a forward listener stop
+// mid-stream does not flag every active stream as state="error".
+func tcpForwardH2SessionOpts(parent *Stack, connCtx context.Context) session.SessionOptions {
+	opts := session.SessionOptions{}
+	if parent == nil {
+		return opts
+	}
+	if parent.PluginV2Engine != nil {
+		opts.LifecycleEngine = parent.PluginV2Engine
+		opts.StateReleaser = parent.PluginV2Engine
+		opts.PluginEngine = parent.PluginV2Engine
+	}
+	if parent.FlowStore != nil {
+		store := parent.FlowStore
+		opts.OnComplete = func(ctx context.Context, streamID string, err error) {
+			if streamID == "" {
+				return
+			}
+			state := "complete"
+			if err != nil && !errors.Is(err, io.EOF) {
+				if (errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed)) && connCtx.Err() != nil {
+					// Listener-shutdown path: keep state="complete".
+				} else {
+					state = "error"
+				}
+			}
+			_ = store.UpdateStream(ctx, streamID, flow.StreamUpdate{
+				State:         state,
+				FailureReason: session.ClassifyError(err),
+			})
+		}
+	}
+	return opts
+}
+
+// replayChannel wraps a layer.Channel and replays a single pre-peeked
+// envelope on the first Next call. Used by the gRPC content-type filter
+// path: we must peek the first envelope to inspect content-type, then
+// hand the channel to DispatchH2StreamFull which itself calls Next.
+//
+// The wrapper is single-use: after the first Next returns the replayed
+// envelope, subsequent Next/Send/Close/Closed/Err calls delegate to the
+// wrapped channel verbatim.
+type replayChannel struct {
+	inner     layer.Channel
+	first     *envelope.Envelope
+	consumed  bool
+	consumeMu sync.Mutex
+}
+
+func newReplayChannel(inner layer.Channel, first *envelope.Envelope) *replayChannel {
+	return &replayChannel{inner: inner, first: first}
+}
+
+func (r *replayChannel) StreamID() string { return r.inner.StreamID() }
+
+func (r *replayChannel) Next(ctx context.Context) (*envelope.Envelope, error) {
+	r.consumeMu.Lock()
+	if !r.consumed {
+		r.consumed = true
+		env := r.first
+		r.first = nil
+		r.consumeMu.Unlock()
+		return env, nil
+	}
+	r.consumeMu.Unlock()
+	return r.inner.Next(ctx)
+}
+
+func (r *replayChannel) Send(ctx context.Context, env *envelope.Envelope) error {
+	return r.inner.Send(ctx, env)
+}
+
+func (r *replayChannel) Close() error            { return r.inner.Close() }
+func (r *replayChannel) Closed() <-chan struct{} { return r.inner.Closed() }
+func (r *replayChannel) Err() error              { return r.inner.Err() }

--- a/internal/proxybuild/tcp_forward_h2.go
+++ b/internal/proxybuild/tcp_forward_h2.go
@@ -176,7 +176,7 @@ func runTCPForwardH2Loop(
 		return
 	}
 
-	sessOpts := tcpForwardH2SessionOpts(parentStack, ctx)
+	sessOpts := tcpForwardH2SessionOpts(parentStack, ctx, logger)
 	grpcOpts := connector.GRPCOptionsFromBuildConfig(parentStack.BuildConfig)
 	grpcwebOpts := connector.GRPCWebOptionsFromBuildConfig(parentStack.BuildConfig)
 	clientLOpts := httpaggregator.OptionsFromLayer(clientL)
@@ -237,7 +237,7 @@ func dispatchForwardH2Stream(
 	//   - re-feeds gRPC envelopes via a small replay wrapper
 	dispatchCh := ch
 	if isGRPCFilter {
-		filtered, ok := applyGRPCFilter(ctx, ch, parentStack, target, streamFlowCtx, logger)
+		filtered, ok := applyGRPCFilter(ctx, ch, parentStack, target, stack.ConnID, logger)
 		if !ok {
 			return
 		}
@@ -303,14 +303,18 @@ func dispatchForwardH2Stream(
 //   - first envelope is not an H2HeadersEvent (malformed stream)
 //   - content-type is missing
 //   - content-type matches grpc-web (rejected — Protocol="grpc" is a
-//     crisper semantic; gRPC-Web routes via Protocol="http2")
-//   - content-type is not native gRPC (application/grpc[+suffix])
+//     crisper semantic; gRPC-Web routes via Protocol="http2"). The
+//     audit Stream stamps Protocol="grpc-web" so MCP queries by Protocol
+//     can find the rejection without the tag scan.
+//   - content-type is not native gRPC (application/grpc[+suffix]). Audit
+//     Stream stamps Protocol="grpc" (the configured forward protocol —
+//     the actual content-type may not map to any known Protocol).
 func applyGRPCFilter(
 	ctx context.Context,
 	ch layer.Channel,
 	parentStack *Stack,
 	target string,
-	streamFlowCtx envelope.EnvelopeContext,
+	connID string,
 	logger *slog.Logger,
 ) (layer.Channel, bool) {
 	firstEnv, err := ch.Next(ctx)
@@ -324,7 +328,7 @@ func applyGRPCFilter(
 	if !ok {
 		logger.Debug("tcp forward grpc filter: first envelope is not H2HeadersEvent",
 			"target", target, "stream_id", ch.StreamID(), "type", fmt.Sprintf("%T", firstEnv.Message))
-		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), connID, "grpc", "non_grpc_under_grpc_filter")
 		rejectGRPCStream(ch)
 		return nil, false
 	}
@@ -332,14 +336,18 @@ func applyGRPCFilter(
 	if grpcweb.IsGRPCWebContentType(ct) {
 		logger.Debug("tcp forward grpc filter: rejected grpc-web under Protocol=grpc",
 			"target", target, "stream_id", ch.StreamID(), "content_type", ct)
-		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		// USK-914 review F-2: record the observed wire protocol on the
+		// audit Stream so Protocol-filtered MCP queries surface the
+		// distinction. The forward_protocol_mismatch tag stays identical
+		// so the meta-class is one queryable label.
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), connID, "grpc-web", "non_grpc_under_grpc_filter")
 		rejectGRPCStream(ch)
 		return nil, false
 	}
 	if !connector.IsGRPCContentType(ct) {
 		logger.Debug("tcp forward grpc filter: rejected non-gRPC content-type",
 			"target", target, "stream_id", ch.StreamID(), "content_type", ct)
-		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), streamFlowCtx, "non_grpc_under_grpc_filter")
+		recordGRPCFilterReject(ctx, parentStack, ch.StreamID(), connID, "grpc", "non_grpc_under_grpc_filter")
 		rejectGRPCStream(ch)
 		return nil, false
 	}
@@ -364,21 +372,28 @@ func rejectGRPCStream(ch layer.Channel) {
 // recordGRPCFilterReject records a state="error" Stream for a stream
 // rejected by the gRPC content-type filter. The Stream is tagged with
 // forward_protocol_mismatch so MCP queries can surface the rejection
-// without grovelling through Flow rows.
+// without grovelling through Flow rows. observedProtocol distinguishes
+// the wire-observed Protocol family (e.g. "grpc-web" when the client
+// sent grpc-web under a Protocol="grpc" forward; "grpc" when the
+// content-type matched none of the gRPC families).
 func recordGRPCFilterReject(
 	ctx context.Context,
 	parentStack *Stack,
 	streamID string,
-	streamFlowCtx envelope.EnvelopeContext,
+	connID string,
+	observedProtocol string,
 	mismatchKind string,
 ) {
 	if parentStack == nil || parentStack.FlowStore == nil || streamID == "" {
 		return
 	}
+	if observedProtocol == "" {
+		observedProtocol = "grpc"
+	}
 	st := &flow.Stream{
 		ID:       streamID,
-		ConnID:   streamFlowCtx.ConnID,
-		Protocol: "grpc",
+		ConnID:   connID,
+		Protocol: observedProtocol,
 		State:    "error",
 	}
 	_ = parentStack.FlowStore.SaveStream(ctx, st)
@@ -399,7 +414,15 @@ func recordGRPCFilterReject(
 // OnComplete behaviour mirrors the raw sibling — listener-shutdown
 // (ctx-cancel) classifies state="complete" so a forward listener stop
 // mid-stream does not flag every active stream as state="error".
-func tcpForwardH2SessionOpts(parent *Stack, connCtx context.Context) session.SessionOptions {
+//
+// OnPipelineDrop wiring mirrors the raw sibling (USK-782): the parent
+// Stack's PipelineH2 includes scope / safety / intercept Steps that may
+// emit a BlockedBy attribution against forwarded h2 traffic. Without
+// this hook, blocked envelopes would never produce an audit Stream and
+// MCP queries could not surface the rejection. The `blocked` set is
+// shared between OnPipelineDrop and OnComplete so the latter does not
+// overwrite a `State="error"+BlockedBy=*` audit row with `State="complete"`.
+func tcpForwardH2SessionOpts(parent *Stack, connCtx context.Context, logger *slog.Logger) session.SessionOptions {
 	opts := session.SessionOptions{}
 	if parent == nil {
 		return opts
@@ -411,8 +434,18 @@ func tcpForwardH2SessionOpts(parent *Stack, connCtx context.Context) session.Ses
 	}
 	if parent.FlowStore != nil {
 		store := parent.FlowStore
+		blocked := newBlockedStreamSet()
 		opts.OnComplete = func(ctx context.Context, streamID string, err error) {
 			if streamID == "" {
+				return
+			}
+			if blocked.contains(streamID) {
+				// USK-782: skip terminal-state finalisation for streams
+				// already finalised by the audit recorder. Without this
+				// the normal-EOF state="complete" overwrite would clobber
+				// the BlockedBy attribution. Evict for consistency with
+				// the raw sibling and the live-path recorder.
+				blocked.remove(streamID)
 				return
 			}
 			state := "complete"
@@ -428,6 +461,13 @@ func tcpForwardH2SessionOpts(parent *Stack, connCtx context.Context) session.Ses
 				FailureReason: session.ClassifyError(err),
 			})
 		}
+		// USK-782 parity: persist Pipeline-Drop audit Streams for the h2
+		// forward session as well. The empty listenerName falls through
+		// to DefaultListenerName inside buildPipelineDropRecorder —
+		// forward listeners do not own a top-level listenerName the way
+		// the live-path Deps do, so DefaultListenerName matches the raw
+		// forward sibling's behaviour.
+		opts.OnPipelineDrop = buildPipelineDropRecorder(store, "", logger, blocked)
 	}
 	return opts
 }

--- a/internal/proxybuild/tcp_forward_h2_integration_test.go
+++ b/internal/proxybuild/tcp_forward_h2_integration_test.go
@@ -1,0 +1,369 @@
+//go:build e2e && !e2e_smoke
+
+// Package proxybuild_test exhaustive tier — USK-914 h2c (HTTP/2 over
+// cleartext) forward proxy. Validates the new ForwardConfig.Protocol="http2"
+// arm wires DispatchH2StreamFull per stream with per-stream wire-record
+// callbacks; the stand-alone gRPC suite lives in
+// tcp_forward_grpc_integration_test.go.
+package proxybuild_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	gohttp "net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/testutil"
+)
+
+// h2cEchoUpstream starts an h2c upstream server using the standard
+// golang.org/x/net/http2 + h2c shim. Returns (addr, shutdown).
+func h2cEchoUpstream(t *testing.T, handler gohttp.Handler) (addr string, shutdown func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	h2s := &http2.Server{}
+	srv := &gohttp.Server{
+		Handler: h2c.NewHandler(handler, h2s),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return ln.Addr().String(), func() {
+		_ = srv.Close()
+		_ = ln.Close()
+	}
+}
+
+// h2cForwardClient builds an http.Client speaking h2c directly to addr
+// (bypasses TLS via AllowHTTP+plain dial). The returned *gohttp.Client
+// carries a single shared http2.Transport whose connection captures into
+// dialedConns — the test's force-close-on-teardown pattern needs the
+// caller-side conn handle to avoid the xhttp2.Transport.CloseIdleConnections
+// race (race-flake memory item #6).
+func h2cForwardClient(addr string, dialedConns *[]net.Conn, mu *sync.Mutex) *gohttp.Client {
+	tr := &http2.Transport{
+		AllowHTTP: true,
+		DialTLS: func(network, _ string, _ *tls.Config) (net.Conn, error) {
+			c, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if dialedConns != nil {
+				mu.Lock()
+				*dialedConns = append(*dialedConns, c)
+				mu.Unlock()
+			}
+			return c, nil
+		},
+	}
+	return &gohttp.Client{Transport: tr, Timeout: 30 * time.Second}
+}
+
+// newH2ForwardTestManager constructs a *proxybuild.Manager for the h2
+// forward path tests. Mirrors newForwardTestManager (see
+// tcp_forward_integration_test.go) but accepts a custom BuildConfig so
+// h2-specific settings (body spill, max body size, max concurrent streams)
+// can be overridden when needed.
+func newH2ForwardTestManager(t *testing.T, store *flowStoreCapture) *proxybuild.Manager {
+	t.Helper()
+	logger := testutil.DiscardLogger()
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca.Generate: %v", err)
+	}
+	buildCfg := &connector.BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             cert.NewIssuer(ca),
+		InsecureSkipVerify: true,
+	}
+	factory := func(ctx context.Context, name, addr string) (*proxybuild.Stack, error) {
+		return proxybuild.BuildLiveStack(ctx, proxybuild.Deps{
+			Logger:       logger,
+			ListenerName: name,
+			ListenAddr:   addr,
+			FlowStore:    store,
+			BuildConfig:  buildCfg,
+		})
+	}
+	mgr, err := proxybuild.NewManager(proxybuild.ManagerConfig{
+		Logger:       logger,
+		StackFactory: factory,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.StopAll(context.Background()) })
+	return mgr
+}
+
+// startH2ForwardListener spins up the proxy with one TCP forward entry
+// targeting upstreamAddr with Protocol="http2" or "grpc". Returns the
+// bound forward address and the FlowStore.
+func startH2ForwardListener(t *testing.T, ctx context.Context, upstreamAddr, protocol string) (
+	mgr *proxybuild.Manager, fwdAddr string, store *flowStoreCapture,
+) {
+	t.Helper()
+	store = &flowStoreCapture{}
+	mgr = newH2ForwardTestManager(t, store)
+
+	if err := mgr.Start(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatalf("manager.Start: %v", err)
+	}
+	if err := mgr.StartTCPForwards(ctx, proxybuild.TCPForwardParams{
+		Forwards: map[string]*config.ForwardConfig{
+			"0": {Target: upstreamAddr, Protocol: protocol},
+		},
+	}); err != nil {
+		t.Fatalf("StartTCPForwards(%s): %v", protocol, err)
+	}
+	addrs := mgr.TCPForwardAddrs()
+	fwdAddr = addrs["0"]
+	if fwdAddr == "" {
+		t.Fatalf("TCPForwardAddrs missing port 0: %v", addrs)
+	}
+	return mgr, fwdAddr, store
+}
+
+// closeDialedConns force-closes every captured client-side TCP conn.
+// Required by the xhttp2.Transport.CloseIdleConnections race workaround
+// documented in feedback_h2_concurrency_flake_patterns.md item #6.
+func closeDialedConns(dialedConns []net.Conn) {
+	for _, c := range dialedConns {
+		_ = c.Close()
+	}
+}
+
+// TestProxybuild_TCPForward_H2C_BasicRoundtrip is the minimum viable
+// h2c forward proof: a single GET / round-trips end-to-end via the
+// forward listener with Protocol="http2".
+func TestProxybuild_TCPForward_H2C_BasicRoundtrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, upStop := h2cEchoUpstream(t, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		w.Header().Set("X-Echo-Path", r.URL.Path)
+		_, _ = fmt.Fprintf(w, "h2c-echo:%s", r.URL.Path)
+	}))
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "http2")
+	defer mgr.StopAll(context.Background())
+
+	var dialedConns []net.Conn
+	var mu sync.Mutex
+	cli := h2cForwardClient(fwdAddr, &dialedConns, &mu)
+
+	req, err := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fwdAddr+"/hello", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatalf("client Do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if got, want := resp.StatusCode, gohttp.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := string(body), "h2c-echo:/hello"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if got := resp.Header.Get("X-Echo-Path"); got != "/hello" {
+		t.Errorf("X-Echo-Path = %q, want /hello", got)
+	}
+
+	// Wait for recording to settle, then assert at least one Stream
+	// recorded under Protocol=http and observable Flows.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.Streams()) >= 1 && len(store.Flows()) >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cli.CloseIdleConnections()
+	mu.Lock()
+	dial := append([]net.Conn{}, dialedConns...)
+	mu.Unlock()
+	closeDialedConns(dial)
+
+	streams := store.Streams()
+	if len(streams) < 1 {
+		t.Fatalf("expected at least 1 stream recorded, got %d", len(streams))
+	}
+	// h2 forward path produces Protocol=http (semantic) streams; gRPC-Web
+	// auto-routing would produce grpc-web, but this handler returns plain
+	// bytes.
+	sawHTTP := false
+	for _, st := range streams {
+		if st.Protocol == "http" {
+			sawHTTP = true
+			break
+		}
+	}
+	if !sawHTTP {
+		t.Errorf("expected at least one stream with Protocol=http, got %+v", streams)
+	}
+}
+
+// TestProxybuild_TCPForward_H2C_ConcurrentStreams_RecordingIsolation
+// exercises ≥10 parallel streams through the h2 forward listener and
+// asserts each stream's recorded flows reflect its own X-Stream-Id (no
+// cross-contamination). USK-739 / USK-740 race-flake lessons applied:
+// warm-up first, sync.WaitGroup drain, force-close dialed conns before
+// assertions.
+func TestProxybuild_TCPForward_H2C_ConcurrentStreams_RecordingIsolation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	upAddr, upStop := h2cEchoUpstream(t, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		id := r.Header.Get("X-Stream-Id")
+		_, _ = fmt.Fprintf(w, "stream-%s", id)
+	}))
+	defer upStop()
+
+	mgr, fwdAddr, store := startH2ForwardListener(t, ctx, upAddr, "http2")
+	defer mgr.StopAll(context.Background())
+
+	var dialedConns []net.Conn
+	var mu sync.Mutex
+	cli := h2cForwardClient(fwdAddr, &dialedConns, &mu)
+
+	// Warm-up establishes the single shared TCP conn so the n parallel
+	// requests multiplex over the same h2 connection.
+	warm, _ := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fwdAddr+"/warm", nil)
+	warm.Header.Set("X-Stream-Id", "warm")
+	if wResp, wErr := cli.Do(warm); wErr == nil {
+		_, _ = io.ReadAll(wResp.Body)
+		_ = wResp.Body.Close()
+	} else {
+		t.Fatalf("warm-up request: %v", wErr)
+	}
+
+	const n = 10
+	var wg sync.WaitGroup
+	var failed atomic.Int64
+	results := make([]string, n)
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := strconv.Itoa(i)
+			req, _ := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fwdAddr+"/concurrent/"+id, nil)
+			req.Header.Set("X-Stream-Id", id)
+			resp, rerr := cli.Do(req)
+			if rerr != nil {
+				failed.Add(1)
+				return
+			}
+			b, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			results[i] = string(b)
+		}()
+	}
+	wg.Wait()
+
+	if failed.Load() > 0 {
+		t.Fatalf("%d requests failed", failed.Load())
+	}
+	for i, body := range results {
+		want := "stream-" + strconv.Itoa(i)
+		if body != want {
+			t.Errorf("stream %d body=%q want %q (response cross-contamination)", i, body, want)
+		}
+	}
+
+	// Wait for recordings to settle.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.Streams()) >= n+1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Force-close client conns before reading store (race memory item #6).
+	cli.CloseIdleConnections()
+	mu.Lock()
+	dial := append([]net.Conn{}, dialedConns...)
+	mu.Unlock()
+	closeDialedConns(dial)
+
+	// Recording isolation invariant: each concurrent stream (excluding the
+	// warm-up) must show send+receive flows with matching X-Stream-Id.
+	streams := store.Streams()
+	linked := 0
+	for _, st := range streams {
+		flows := store.Flows()
+		var sendF, recvF *flowFlowAlias
+		for _, f := range flows {
+			if f.StreamID != st.ID {
+				continue
+			}
+			ff := &flowFlowAlias{Direction: f.Direction, Headers: f.Headers, RawBytes: f.RawBytes, Body: f.Body}
+			if f.Direction == "send" && sendF == nil {
+				sendF = ff
+			} else if f.Direction == "receive" && recvF == nil {
+				recvF = ff
+			}
+		}
+		if sendF == nil || recvF == nil {
+			continue
+		}
+		sent := ""
+		for k, v := range sendF.Headers {
+			if (k == "X-Stream-Id" || k == "x-stream-id") && len(v) > 0 {
+				sent = v[0]
+				break
+			}
+		}
+		if sent == "warm" {
+			continue
+		}
+		linked++
+		// Cross-contamination check.
+		if sent != "" {
+			body := string(recvF.Body)
+			if body == "" {
+				body = string(recvF.RawBytes)
+			}
+			wantSub := "stream-" + sent
+			if !bytes.Contains([]byte(body), []byte(wantSub)) {
+				t.Errorf("stream id=%s recv body=%q does not contain %q (cross-contamination)", sent, body, wantSub)
+			}
+		}
+	}
+	if linked < n {
+		t.Errorf("expected ≥%d linked concurrent-stream send+recv pairs, got %d (streams=%d)", n, linked, len(streams))
+	}
+}
+
+// flowFlowAlias is a thin projection of flow.Flow used to keep the
+// recording-isolation loop above readable. The only fields the assertion
+// needs are Direction, Headers, RawBytes, Body — projecting them avoids
+// passing the full flow.Flow shape around.
+type flowFlowAlias struct {
+	Direction string
+	Headers   map[string][]string
+	RawBytes  []byte
+	Body      []byte
+}


### PR DESCRIPTION
## Summary
- BuildConnectionStackWithTarget HTTP2 + GRPC arms; clones BuildPlainH2CStack shape (SETTINGS_ENABLE_CONNECT_PROTOCOL mirror, ServerRole MaxConcurrentStreams)
- New file `internal/proxybuild/tcp_forward_h2.go` owns `runTCPForwardH2Loop` + `tcpForwardH2SessionOpts` (sibling to existing `tcpForwardSessionOpts`)
- Per-stream dispatch via `DispatchH2StreamFull` (native gRPC / gRPC-Web / HTTPMessage routing)
- Per-stream wire-record callbacks for `h2-frame` / `grpc-lpm-frame` / `grpc-h2-frame` parity with MITM path
- `Protocol="grpc"` filter: content-type validator on first envelope; mismatch → RST_STREAM(REFUSED_STREAM) + error flow with `Tags["forward_protocol_mismatch"]`
- gRPC-Web rejected under `Protocol="grpc"` (crisper semantic; gRPC-Web routes via `Protocol="http2"`)
- h2c preface read deadline added (defence vs slow-handshake DoS — the MITM path gets this via the inner-byte-peek timeout; forward callers need explicit floor)
- e2e: `tcp_forward_h2_integration_test.go` (HEADERS/DATA, 10 parallel streams with recording isolation) + `tcp_forward_grpc_integration_test.go` (unary, server-stream, bidi, filter reject)
- Race-flake checklist applied; OnComplete classification reused unchanged

## Out of scope
- `TLS=true` (USK-915), `UpstreamTLS=true` (USK-916), gRPC-Web explicit selector, h2 pool sharing, graceful drain

## Note: parallel with USK-913
USK-913 owns http / ws / sse / auto arms (same files). This PR will need to rebase on USK-913 before merge. Conflict surface is bounded — only the dispatch switches in `BuildConnectionStackWithTarget` and `startTCPForwardListener`.

## Test plan
- [x] `make lint`
- [x] `make build`
- [x] `make test`
- [x] `make test-e2e-smoke` (no regression)
- [x] `go test -tags e2e -race -v -run 'TestProxybuild_TCPForward' ./internal/proxybuild/...`
- [x] Concurrent-stream test run 5x under -race (zero flakes)
- [x] Existing `TestProxybuild_TCPForward_RawBytesFlowRecording` still passes (raw path regression check)
- [x] Existing `TestH2C_BasicRoundtrip` + `TestMultipleConcurrentStreams_RecordingIsolation` still pass (MITM h2 regression check)

Resolves USK-914
Linear: https://linear.app/usk6666/issue/USK-914

🤖 Generated with [Claude Code](https://claude.com/claude-code)