### PR TITLE
feat(proxybuild,connector): TCP forward — UpstreamTLS dial + ALPN propagation (USK-916)

### DIFF
--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -148,11 +148,34 @@ type TargetOverrideParams struct {
 	// CLAUDE.md MITM Principle 2.
 	TLSTerminate bool
 
-	// UpstreamTLS, when true, indicates the caller wants the upstream
-	// dial to perform a TLS handshake. The upstream-TLS dial wire-up is
-	// owned by USK-916 and is NOT implemented by USK-912; setting
-	// UpstreamTLS=true currently returns a "not yet wired" error.
+	// UpstreamTLS, when true, indicates the caller dialed the upstream
+	// connection over TLS before invoking this builder. USK-916 changed
+	// the field semantics from "request TLS dial" to "TLS has happened
+	// upstream of this builder": the caller (proxybuild.dialForwardUpstream)
+	// owns the dial primitive (DialUpstreamRaw with a populated TLSConfig)
+	// and passes the negotiated *envelope.TLSSnapshot via
+	// UpstreamTLSSnapshot. Mirrors the seam discipline used by USK-915
+	// for client-side TLS terminate (TLS happens in the per-conn handler;
+	// the builder consumes the resulting snapshot).
+	//
+	// Setting UpstreamTLS=true without populating UpstreamTLSSnapshot is
+	// permitted (used by callers that elect to stamp the upstream Layer's
+	// EnvelopeContext.TLS later via a different mechanism) but yields the
+	// same lossy state as the cleartext path — the recorded envelopes
+	// will not reflect upstream TLS reality. The proxybuild forward
+	// handlers always populate the snapshot.
 	UpstreamTLS bool
+
+	// UpstreamTLSSnapshot, when non-nil, is plumbed into the upstream-side
+	// EnvelopeContext.TLS field of the assembled L7 Layers so plugin hooks
+	// and recordings observe the negotiated SNI / ALPN / cipher for the
+	// upstream TLS handshake. USK-916: forward callers that performed the
+	// upstream TLS dial themselves (proxybuild.dialForwardUpstream) own
+	// this field; callers that left UpstreamTLS=false leave it nil. Mirrors
+	// the per-Layer upstream TLS wiring in stack_builder.go::buildStackFromRoute
+	// (live MITM CONNECT path), preserving CLAUDE.md MITM Principle 3
+	// (lossless representations).
+	UpstreamTLSSnapshot *envelope.TLSSnapshot
 
 	// Scheme overrides the envelope Scheme stamped by the assembled L7
 	// Layers. Defaults to "http" when unset, matching the cleartext
@@ -294,9 +317,11 @@ func BuildConnectionStackWithTarget(
 	if params.TLSTerminate {
 		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: TLSTerminate=true not yet wired (deferred to USK-915)")
 	}
-	if params.UpstreamTLS {
-		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: UpstreamTLS=true not yet wired (deferred to USK-916)")
-	}
+	// USK-916: params.UpstreamTLS is now informational only — TLS is
+	// performed caller-side via proxybuild.dialForwardUpstream (which
+	// invokes connector.DialUpstreamRaw with a populated TLSConfig). The
+	// builder consumes UpstreamTLSSnapshot to stamp upstream Layer's
+	// EnvelopeContext.TLS. No reject gate.
 
 	protocol := params.Protocol
 	if protocol == "" {
@@ -312,18 +337,18 @@ func BuildConnectionStackWithTarget(
 		// proxybuild handler layer (it must observe the first request /
 		// first response, which is per-exchange Pipeline territory rather
 		// than per-stack-builder territory).
-		return buildTargetOverrideHTTPStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, cfg)
+		return buildTargetOverrideHTTPStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, params.UpstreamTLSSnapshot, cfg)
 	case ForwardProtocolAuto:
 		// USK-913: peek the first inner byte on clientConn to disambiguate
 		// HTTP/1.x → http arm, h2c → reject with USK-914 citation, TLS →
 		// warn + raw fallback, everything else → raw fallback.
-		return buildTargetOverrideAutoStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, cfg)
+		return buildTargetOverrideAutoStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, params.UpstreamTLSSnapshot, cfg)
 	case ForwardProtocolHTTP2, ForwardProtocolGRPC:
 		// USK-914: h2c forward stack. The GRPC selector reuses the same
 		// h2c stack assembly; the gRPC content-type filter is applied at
 		// the per-stream proxybuild dispatch layer (see
 		// internal/proxybuild/tcp_forward_h2.go).
-		return buildTargetOverrideH2CStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, cfg)
+		return buildTargetOverrideH2CStack(ctx, clientConn, upstreamConn, params.Target, params.effectiveScheme(), params.ClientTLSSnapshot, params.UpstreamTLSSnapshot, cfg)
 	default:
 		// Unreachable: params.validate already rejects unknown values.
 		return nil, fmt.Errorf("connector: BuildConnectionStackWithTarget: unhandled protocol %q", protocol)
@@ -394,6 +419,7 @@ func buildTargetOverrideH2CStack(
 	target string,
 	scheme string,
 	clientTLS *envelope.TLSSnapshot,
+	upstreamTLS *envelope.TLSSnapshot,
 	cfg *BuildConfig,
 ) (*ConnectionStack, error) {
 	if scheme == "" {
@@ -405,13 +431,17 @@ func buildTargetOverrideH2CStack(
 		ConnID:     connID,
 		TargetHost: target,
 		// USK-915: client-side TLS snapshot is stamped here when the forward
-		// path terminated TLS before calling this builder. Upstream stays
-		// cleartext (h2c) — upstream-TLS dial is owned by USK-916.
+		// path terminated TLS before calling this builder.
 		TLS: clientTLS,
 	}
 	upstreamEnvCtx := envelope.EnvelopeContext{
 		ConnID:     connID,
 		TargetHost: target,
+		// USK-916: upstream TLS snapshot is stamped here when the forward
+		// path performed an upstream TLS dial before calling this builder
+		// (proxybuild.dialForwardUpstream). Nil leaves the upstream Layer
+		// envelopes recording a cleartext upstream — the h2c case.
+		TLS: upstreamTLS,
 	}
 
 	stack := NewConnectionStack(connID)
@@ -503,6 +533,7 @@ func buildTargetOverrideHTTPStack(
 	target string,
 	scheme string,
 	clientTLS *envelope.TLSSnapshot,
+	upstreamTLS *envelope.TLSSnapshot,
 	cfg *BuildConfig,
 ) (*ConnectionStack, error) {
 	if scheme == "" {
@@ -514,14 +545,18 @@ func buildTargetOverrideHTTPStack(
 		ConnID:     connID,
 		TargetHost: target,
 		// USK-915: client-side TLS snapshot is stamped here when the forward
-		// path terminated TLS before calling this builder. Upstream stays
-		// cleartext — upstream-TLS dial is owned by USK-916.
+		// path terminated TLS before calling this builder.
 		TLS: clientTLS,
 	}
 	upstreamEnvCtx := envelope.EnvelopeContext{
 		ConnID:     connID,
 		TargetHost: target,
-		// TLS intentionally nil: no handshake happened on the upstream side.
+		// USK-916: upstream TLS snapshot is stamped here when the forward
+		// path performed an upstream TLS dial before calling this builder
+		// (proxybuild.dialForwardUpstream). Nil leaves the upstream Layer
+		// envelopes recording a cleartext upstream — the original USK-913
+		// HTTP→HTTP path.
+		TLS: upstreamTLS,
 	}
 
 	stack := NewConnectionStack(connID)
@@ -591,6 +626,7 @@ func buildTargetOverrideAutoStack(
 	target string,
 	scheme string,
 	clientTLS *envelope.TLSSnapshot,
+	upstreamTLS *envelope.TLSSnapshot,
 	cfg *BuildConfig,
 ) (*ConnectionStack, error) {
 	pc, ok := clientConn.(*PeekConn)
@@ -609,7 +645,7 @@ func buildTargetOverrideAutoStack(
 	case InnerHTTP1:
 		logger.Debug("connector: target-override Auto resolved to HTTP/1.x",
 			"target", target)
-		return buildTargetOverrideHTTPStack(ctx, pc, upstreamConn, target, scheme, clientTLS, cfg)
+		return buildTargetOverrideHTTPStack(ctx, pc, upstreamConn, target, scheme, clientTLS, upstreamTLS, cfg)
 	case InnerH2C:
 		// Don't opportunistically negotiate h2c — operators must declare
 		// Protocol="http2" explicitly. USK-914 wired the h2c arm; we still

--- a/internal/connector/stack_builder_target_override_test.go
+++ b/internal/connector/stack_builder_target_override_test.go
@@ -336,9 +336,13 @@ func TestBuildConnectionStackWithTarget_TLSTerminateDeferred(t *testing.T) {
 	}
 }
 
-// TestBuildConnectionStackWithTarget_UpstreamTLSDeferred confirms
-// UpstreamTLS=true short-circuits with a USK-916 reference.
-func TestBuildConnectionStackWithTarget_UpstreamTLSDeferred(t *testing.T) {
+// TestBuildConnectionStackWithTarget_UpstreamTLSInformational confirms
+// USK-916 changed UpstreamTLS=true from a hard reject into an
+// informational flag — the builder no longer dials upstream TLS itself
+// (caller-side dial via proxybuild.dialForwardUpstream), so the field
+// only signals intent. The builder accepts the value and assembles the
+// stack as if the caller had already dialed TLS upstream of this call.
+func TestBuildConnectionStackWithTarget_UpstreamTLSInformational(t *testing.T) {
 	_, clientPeer := pipePair(t)
 	_, upstreamPeer := pipePair(t)
 	cfg := newTestBuildConfig(t)
@@ -347,13 +351,14 @@ func TestBuildConnectionStackWithTarget_UpstreamTLSDeferred(t *testing.T) {
 		Protocol:    ForwardProtocolRaw,
 		UpstreamTLS: true,
 	}
-	_, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
-	if err == nil {
-		t.Fatal("expected non-nil error for UpstreamTLS=true, got nil")
+	stack, err := BuildConnectionStackWithTarget(context.Background(), clientPeer, upstreamPeer, params, cfg)
+	if err != nil {
+		t.Fatalf("expected UpstreamTLS=true to be accepted (USK-916 informational flag), got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "USK-916") {
-		t.Errorf("expected error to cite USK-916, got %q", err.Error())
+	if stack == nil {
+		t.Fatal("expected non-nil stack, got nil")
 	}
+	_ = stack.Close()
 }
 
 // TestBuildConnectionStackWithTarget_ALPNOffersAccepted verifies that

--- a/internal/proxybuild/tcp_forward.go
+++ b/internal/proxybuild/tcp_forward.go
@@ -47,10 +47,16 @@ const tcpForwardDialTimeout = 30 * time.Second
 //     502s the first exchange when the upstream response is not
 //     text/event-stream (USK-913).
 //
-// Deferred (returns an error at start time):
-//   - "http2" / "grpc" — h2c / gRPC dispatch (USK-914).
-//   - TLS=true (client-side terminate) — (USK-915).
-//   - UpstreamTLS=true (upstream-side dial encrypt) — (USK-916).
+// TLS support:
+//   - TLS=true (client-side terminate) — USK-915. Requires a configured CA
+//     Issuer; listener start rejects fc.TLS=true without one.
+//   - UpstreamTLS=true (upstream-side TLS dial) — USK-916. ALPN propagation:
+//     explicit Protocol derives from declaration; "auto"+client-TLS
+//     propagates the client-negotiated ALPN; "auto"+plaintext-client
+//     advertises only http/1.1 (h2 upstream requires explicit
+//     Protocol="http2"). Upstream cert verification uses the global
+//     BuildConfig.InsecureSkipVerify flag — per-host / mTLS / uTLS is
+//     deferred to a follow-up Issue.
 type TCPForwardParams struct {
 	// Forwards maps local port -> ForwardConfig (target, protocol, tls).
 	Forwards map[string]*config.ForwardConfig
@@ -169,9 +175,11 @@ func (m *Manager) startTCPForwardListener(
 			return nil, fmt.Errorf("tcp forward port %s: tls=true requires a configured CA Issuer", port)
 		}
 	}
-	if fc.UpstreamTLS {
-		return nil, fmt.Errorf("tcp forward port %s: upstream_tls=true not yet supported (upstream TLS dial deferred to USK-916)", port)
-	}
+	// USK-916: fc.UpstreamTLS=true is wired via proxybuild.dialForwardUpstream
+	// (in tcp_forward_tls.go). No listener-start validation needed beyond
+	// the existing Target / Protocol checks — the upstream cert verification
+	// policy uses BuildConfig.InsecureSkipVerify (global) and tolerates a
+	// missing Issuer (upstream TLS does not need the proxy's CA).
 
 	bindAddr := fmt.Sprintf("127.0.0.1:%s", port)
 	ln, err := net.Listen("tcp", bindAddr)
@@ -396,16 +404,23 @@ func (m *Manager) handleTCPForwardConnWithOverride(
 	// next forward dial (USK-734) AND the parent listener's per-listener
 	// upstream-proxy override (USK-826) participates — connCtx carries the
 	// parent listener name via ContextWithListenerName above.
-	dialOpts := connector.DialRawOpts{
-		DialTimeout: tcpForwardDialTimeout,
-	}
-	if parentStack.BuildConfig != nil {
-		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(connCtx)
-	}
-
-	upstreamConn, _, derr := connector.DialUpstreamRaw(connCtx, entry.target, dialOpts)
+	//
+	// USK-916: dialForwardUpstream additionally performs an upstream TLS
+	// handshake when entry.fc.UpstreamTLS=true, returning the TLS snapshot
+	// for envelope stamping below.
+	upstreamConn, upstreamSnap, derr := dialForwardUpstream(connCtx, entry, override, parentStack, connLogger)
 	if derr != nil {
 		connLogger.Debug("tcp forward upstream dial failed", "error", derr)
+		// USK-916: TLS-dial failures (cert verify, handshake timeout, etc)
+		// should produce a state="error" Stream so MCP query("flows",
+		// filter:{state:"error"}) surfaces them. Plain TCP dial failures
+		// stay silent (matches the pre-USK-916 raw forward behaviour where
+		// the connection drops before any Layer is constructed).
+		if entry.fc != nil && entry.fc.UpstreamTLS {
+			if rec := buildTLSStackBuildErrorRecorder(parentStack.FlowStore, nil, parentListenerName, connLogger); rec != nil {
+				rec(connCtx, entry.target, derr)
+			}
+		}
 		return
 	}
 
@@ -432,7 +447,10 @@ func (m *Manager) handleTCPForwardConnWithOverride(
 	// L7 dispatch via connector.BuildConnectionStackWithTarget. The builder
 	// owns the Layer assembly; this handler owns the per-exchange dispatch,
 	// the ctx-cancel watcher, and the websocket/sse expectation filter.
-	m.handleTCPForwardConnL7(connCtx, parentStack, connID, connLogger, entry, override, protocol, clientConn, upstreamConn)
+	// upstreamSnap is non-nil when fc.UpstreamTLS=true (USK-916) and threads
+	// through to the upstream Layer's EnvelopeContext.TLS via
+	// TargetOverrideParams.UpstreamTLSSnapshot.
+	m.handleTCPForwardConnL7(connCtx, parentStack, connID, connLogger, entry, override, protocol, clientConn, upstreamConn, upstreamSnap)
 }
 
 // handleTCPForwardConnRaw runs the USK-711 [bytechunk → bytechunk] path.
@@ -510,6 +528,7 @@ func (m *Manager) handleTCPForwardConnL7(
 	override *forwardConnOverride,
 	protocol string,
 	clientConn, upstreamConn net.Conn,
+	upstreamSnap *envelope.TLSSnapshot,
 ) {
 	// Build the stack via the connector dispatcher. Protocol is a
 	// non-h2 / non-grpc / non-TLS combination per the startTCPForwardListener
@@ -525,6 +544,12 @@ func (m *Manager) handleTCPForwardConnL7(
 	if override != nil && override.tlsTerminated {
 		params.Scheme = "https"
 		params.ClientTLSSnapshot = override.clientTLSSnapshot
+	}
+	// USK-916: when an upstream TLS handshake completed, thread the snapshot
+	// into the upstream Layer's EnvelopeContext.TLS via the builder.
+	if entry.fc != nil && entry.fc.UpstreamTLS && upstreamSnap != nil {
+		params.UpstreamTLS = true
+		params.UpstreamTLSSnapshot = upstreamSnap
 	}
 	stack, err := connector.BuildConnectionStackWithTarget(connCtx, clientConn, upstreamConn, params, parentStack.BuildConfig)
 	if err != nil {

--- a/internal/proxybuild/tcp_forward_h2.go
+++ b/internal/proxybuild/tcp_forward_h2.go
@@ -89,46 +89,34 @@ func (m *Manager) handleTCPForwardH2ConnWithOverride(
 		return
 	}
 
-	// Dial upstream plain TCP. USK-915/USK-916 will introduce TLS dialing;
-	// for now the h2 forward stack is h2c (cleartext on both sides).
-	dialOpts := connector.DialRawOpts{
-		DialTimeout: tcpForwardDialTimeout,
-	}
-	if parentStack.BuildConfig != nil {
-		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(connCtx)
-	}
-	upstreamConn, _, derr := connector.DialUpstreamRaw(connCtx, entry.target, dialOpts)
+	// Dial upstream. USK-916: dialForwardUpstream additionally performs
+	// an upstream TLS handshake when entry.fc.UpstreamTLS=true. When
+	// fc.UpstreamTLS=false the dial is plain TCP (h2c). When true the
+	// upstream Layer reads h2 over TLS — equivalent to the "https+h2c
+	// upstream" combination on the live MITM path (the proxy speaks h2
+	// over TLS on the wire; the http2.Layer is protocol-agnostic and
+	// reads frames identically regardless of the underlying transport).
+	upstreamConn, upstreamSnap, derr := dialForwardUpstream(connCtx, entry, override, parentStack, connLogger)
 	if derr != nil {
 		connLogger.Debug("tcp forward h2 upstream dial failed", "error", derr)
+		// USK-916: TLS-dial failures should produce a state="error" Stream
+		// so MCP query("flows", filter:{state:"error"}) surfaces them.
+		if entry.fc != nil && entry.fc.UpstreamTLS {
+			if rec := buildTLSStackBuildErrorRecorder(parentStack.FlowStore, nil, parentListenerName, connLogger); rec != nil {
+				rec(connCtx, entry.target, derr)
+			}
+		}
 		return
 	}
 
-	// Map ForwardConfig.Protocol → connector.ForwardProtocol.
-	var fwdProto connector.ForwardProtocol
-	switch fc.Protocol {
-	case "http2":
-		fwdProto = connector.ForwardProtocolHTTP2
-	case "grpc":
-		fwdProto = connector.ForwardProtocolGRPC
-	default:
-		// Caller (startTCPForwardListener) routes only http2 / grpc here;
-		// defensive guard.
+	fwdProto, ok := mapH2ForwardProtocol(fc.Protocol)
+	if !ok {
 		_ = upstreamConn.Close()
 		connLogger.Warn("tcp forward h2 dispatched with unexpected protocol", "protocol", fc.Protocol)
 		return
 	}
 
-	// USK-915: when TLS was terminated upstream of this handler, stamp the
-	// envelope Scheme as "https" and forward the client TLS snapshot so
-	// recordings and plugin payloads reflect wire reality.
-	targetParams := connector.TargetOverrideParams{
-		Target:   entry.target,
-		Protocol: fwdProto,
-	}
-	if override != nil && override.tlsTerminated {
-		targetParams.Scheme = "https"
-		targetParams.ClientTLSSnapshot = override.clientTLSSnapshot
-	}
+	targetParams := buildH2TargetParams(entry, override, fwdProto, upstreamSnap)
 	stack, berr := connector.BuildConnectionStackWithTarget(connCtx, clientConn, upstreamConn, targetParams, parentStack.BuildConfig)
 	if berr != nil {
 		connLogger.Debug("tcp forward h2 stack build failed", "error", berr)
@@ -157,6 +145,53 @@ func (m *Manager) handleTCPForwardH2ConnWithOverride(
 
 	isGRPCFilter := fwdProto == connector.ForwardProtocolGRPC
 	runTCPForwardH2Loop(connCtx, parentStack, stack, entry.target, connLogger, isGRPCFilter)
+}
+
+// mapH2ForwardProtocol translates a ForwardConfig.Protocol value into a
+// connector.ForwardProtocol selector for the h2 dispatch arm. Returns
+// (selector, true) for "http2" / "grpc" and (_, false) otherwise; the
+// caller is expected to log and bail on false (defensive guard — the
+// listener-start switch already rejects other values before reaching
+// this dispatcher).
+func mapH2ForwardProtocol(protocol string) (connector.ForwardProtocol, bool) {
+	switch protocol {
+	case "http2":
+		return connector.ForwardProtocolHTTP2, true
+	case "grpc":
+		return connector.ForwardProtocolGRPC, true
+	default:
+		return "", false
+	}
+}
+
+// buildH2TargetParams assembles the TargetOverrideParams for the h2
+// forward stack assembly. Stamps Scheme="https" + ClientTLSSnapshot from
+// the USK-915 client-side TLS terminate override, and UpstreamTLSSnapshot
+// from the USK-916 upstream TLS dial result, when present.
+func buildH2TargetParams(
+	entry *tcpForwardEntry,
+	override *forwardConnOverride,
+	fwdProto connector.ForwardProtocol,
+	upstreamSnap *envelope.TLSSnapshot,
+) connector.TargetOverrideParams {
+	params := connector.TargetOverrideParams{
+		Target:   entry.target,
+		Protocol: fwdProto,
+	}
+	// USK-915: when TLS was terminated upstream of this handler, stamp the
+	// envelope Scheme as "https" and forward the client TLS snapshot so
+	// recordings and plugin payloads reflect wire reality.
+	if override != nil && override.tlsTerminated {
+		params.Scheme = "https"
+		params.ClientTLSSnapshot = override.clientTLSSnapshot
+	}
+	// USK-916: when an upstream TLS handshake completed, thread the snapshot
+	// into the upstream Layer's EnvelopeContext.TLS via the builder.
+	if entry.fc != nil && entry.fc.UpstreamTLS && upstreamSnap != nil {
+		params.UpstreamTLS = true
+		params.UpstreamTLSSnapshot = upstreamSnap
+	}
+	return params
 }
 
 // runTCPForwardH2Loop iterates the client HTTP/2 Layer's Channels()

--- a/internal/proxybuild/tcp_forward_tls.go
+++ b/internal/proxybuild/tcp_forward_tls.go
@@ -392,6 +392,19 @@ func fireForwardTLSHandshakeHook(ctx context.Context, engine *pluginv2.Engine, s
 //     (single-protocol-per-stack invariant). Operators that want h2
 //     upstream MUST declare Protocol="http2" explicitly.
 //
+// Explicit-declaration-wins edge case (Decision #5): when the operator
+// declares Protocol="http2" or Protocol="grpc" but the client-side TLS
+// negotiates "http/1.1" (e.g. the operator mis-configured the listener
+// ALPN by including http/1.1 in alpnOffersForForwardProtocol for an h2
+// declaration, or a client refused h2), the H1 dispatch arm is selected
+// by dispatchForwardTLSByALPN / chooseH1ForwardProtocol while this
+// helper still returns ["h2"] for the upstream offer. The resulting
+// H1↔H2 protocol mismatch will surface as an upstream handshake/dispatch
+// error — that is the intended loud-failure behaviour for a misconfigured
+// listener (explicit operator declaration wins over the runtime-negotiated
+// client ALPN, so the operator sees the misconfiguration rather than the
+// proxy silently bridging mismatched protocols).
+//
 // Returns nil for the raw / explicit-no-ALPN case, matching the
 // "no ALPN extension on the wire" semantic in DialUpstreamRaw / tlslayer.
 func upstreamALPNOffersForForward(protocol string, override *forwardConnOverride) []string {
@@ -456,7 +469,12 @@ func dialForwardUpstream(
 		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(ctx)
 	}
 
-	if entry == nil || entry.fc == nil || !entry.fc.UpstreamTLS {
+	// entry is non-nil by construction — both callers
+	// (handleTCPForwardConnWithOverride, handleTCPForwardH2ConnWithOverride)
+	// hold the per-conn forward entry. entry.fc is guarded explicitly so a
+	// future refactor that detaches fc surfaces here rather than at the
+	// UpstreamTLS read below.
+	if entry.fc == nil || !entry.fc.UpstreamTLS {
 		// Plain dial path — no TLS, no snapshot, no hook.
 		conn, _, err := connector.DialUpstreamRaw(ctx, entry.target, dialOpts)
 		if err != nil {

--- a/internal/proxybuild/tcp_forward_tls.go
+++ b/internal/proxybuild/tcp_forward_tls.go
@@ -366,6 +366,161 @@ func fireForwardTLSHandshakeHook(ctx context.Context, engine *pluginv2.Engine, s
 	}
 }
 
+// upstreamALPNOffersForForward returns the ALPN advertise list the proxy
+// presents on the upstream-side TLS handshake when fc.UpstreamTLS=true
+// (USK-916). The selection follows the ALPN propagation policy resolved
+// at design review:
+//
+//  1. Operator-declared explicit protocol — derive from the declared
+//     protocol via alpnOffersForForwardProtocol. Operators that declared
+//     "http2" / "grpc" want h2 upstream; declared "http" / "websocket" /
+//     "sse" want http/1.1 upstream; declared "raw" wants no ALPN
+//     extension at all.
+//
+//  2. Protocol="auto" + client TLS terminated + client negotiated a
+//     non-empty ALPN — propagate the client-negotiated ALPN as a
+//     single-element list. This preserves the operator's "auto"
+//     declaration intent (let the client pick) and gives the upstream
+//     the same protocol the client chose.
+//
+//  3. Protocol="auto" + plaintext client (or client did not negotiate
+//     an ALPN) — offer only ["http/1.1"]. The Auto peek path on a
+//     plaintext client routes to H1 or Raw only (h2c opportunistic
+//     upgrade is intentionally disabled in
+//     buildTargetOverrideAutoStack). Advertising h2 upstream would risk
+//     an h1↔h2 bridge the data path does not support
+//     (single-protocol-per-stack invariant). Operators that want h2
+//     upstream MUST declare Protocol="http2" explicitly.
+//
+// Returns nil for the raw / explicit-no-ALPN case, matching the
+// "no ALPN extension on the wire" semantic in DialUpstreamRaw / tlslayer.
+func upstreamALPNOffersForForward(protocol string, override *forwardConnOverride) []string {
+	if protocol == "auto" || protocol == "" {
+		if override != nil && override.tlsTerminated && override.clientTLSSnapshot != nil && override.clientTLSSnapshot.ALPN != "" {
+			// Propagate the client-negotiated ALPN as a single-element
+			// list — defensive copy semantics handled by tlslayer/crypto/tls.
+			return []string{override.clientTLSSnapshot.ALPN}
+		}
+		// Plaintext client (or TLS client that did not negotiate ALPN):
+		// safe default is http/1.1 only — see godoc above.
+		return []string{"http/1.1"}
+	}
+	// Explicit Protocol declaration — derive from the operator's choice.
+	return alpnOffersForForwardProtocol(protocol)
+}
+
+// dialForwardUpstream dials the upstream for a TCP forward entry, optionally
+// performing a TLS handshake when entry.fc.UpstreamTLS=true (USK-916).
+// Single dial site shared by handleTCPForwardConnWithOverride (H1 / raw / L7
+// arm) and handleTCPForwardH2ConnWithOverride (H2 arm) so the upstream-TLS
+// policy lives in one place.
+//
+// Behaviour:
+//
+//   - fc.UpstreamTLS=false → plain TCP dial via DialUpstreamRaw with
+//     UpstreamProxy resolved from BuildConfig (USK-734/826 reach the same
+//     hot path as the live MITM dial). Snapshot is nil. No plugin hook.
+//
+//   - fc.UpstreamTLS=true → builds *tls.Config{ServerName, MinVersion=TLS12,
+//     NextProtos} where ServerName=targetHostOnly(entry.target) (USK-916
+//     deferral: no per-host SNI override; MITM-isolated SNI), NextProtos=
+//     upstreamALPNOffersForForward(...). DialUpstreamRaw performs the TCP
+//     dial AND the TLS handshake under one timeout. On success the
+//     returned snapshot is non-nil and (tls, on_handshake, side="client")
+//     plugin hook fires (parity with live MITM dialUpstreamWithALPN).
+//
+// USK-916 deferral surface (documented in helper godoc per Decision #18):
+//
+//   - No per-host TLS material lookup (HostTLSRegistry / HostTLSResolver
+//     deferred — only BuildConfig.InsecureSkipVerify global flag is
+//     honoured).
+//   - No mTLS client cert (ClientCert=nil).
+//   - No uTLS browser fingerprint (UTLSProfile="").
+//
+// Returns (conn, snapshot, error). On any error neither conn nor snapshot
+// is populated; caller treats the failure as "upstream dial failed" and
+// records via buildTLSStackBuildErrorRecorder when applicable (the
+// recorder classifies non-ErrClientTLSMITMHandshake errors as
+// FailureReason="upstream_tls_error" — exactly what we want).
+func dialForwardUpstream(
+	ctx context.Context,
+	entry *tcpForwardEntry,
+	override *forwardConnOverride,
+	parentStack *Stack,
+	connLogger *slog.Logger,
+) (net.Conn, *envelope.TLSSnapshot, error) {
+	dialOpts := connector.DialRawOpts{
+		DialTimeout: tcpForwardDialTimeout,
+	}
+	if parentStack != nil && parentStack.BuildConfig != nil {
+		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(ctx)
+	}
+
+	if entry == nil || entry.fc == nil || !entry.fc.UpstreamTLS {
+		// Plain dial path — no TLS, no snapshot, no hook.
+		conn, _, err := connector.DialUpstreamRaw(ctx, entry.target, dialOpts)
+		if err != nil {
+			return nil, nil, err
+		}
+		return conn, nil, nil
+	}
+
+	// fc.UpstreamTLS=true: build a *tls.Config for upstream TLS.
+	declared := entry.fc.Protocol
+	alpnOffers := upstreamALPNOffersForForward(declared, override)
+	upstreamHost := targetHostOnly(entry.target)
+	tlsCfg := &tls.Config{
+		ServerName: upstreamHost,
+		// MinVersion floors at TLS 1.2 to match the rest of the proxy's
+		// TLS surface (CWE-757).
+		MinVersion: tls.VersionTLS12,
+	}
+	if len(alpnOffers) > 0 {
+		// Defensive copy: crypto/tls retains the slice.
+		tlsCfg.NextProtos = append([]string(nil), alpnOffers...)
+	}
+
+	dialOpts.TLSConfig = tlsCfg
+	dialOpts.OfferALPN = tlsCfg.NextProtos
+	// USK-916 scope: only the global InsecureSkipVerify flag is honoured;
+	// per-host TLS material (mTLS / uTLS / HostTLSRegistry) is deferred.
+	if parentStack != nil && parentStack.BuildConfig != nil {
+		dialOpts.InsecureSkipVerify = parentStack.BuildConfig.InsecureSkipVerify
+	}
+
+	conn, snap, err := connector.DialUpstreamRaw(ctx, entry.target, dialOpts)
+	if err != nil {
+		if connLogger != nil {
+			connLogger.Debug("tcp forward upstream tls dial failed",
+				"target", entry.target,
+				"alpn_offers", alpnOffers,
+				"error", err,
+			)
+		}
+		return nil, nil, err
+	}
+
+	// Parity with live MITM dialUpstreamWithALPN: fire the (tls,
+	// on_handshake, side="client") plugin hook on the proxy-dialing-upstream
+	// handshake. No-op when the engine or snapshot is nil.
+	if parentStack != nil {
+		fireForwardTLSHandshakeHook(ctx, parentStack.PluginV2Engine, "client", snap)
+	}
+
+	if connLogger != nil {
+		negotiatedALPN := ""
+		if snap != nil {
+			negotiatedALPN = snap.ALPN
+		}
+		connLogger.Debug("tcp forward upstream tls dial complete",
+			"target", entry.target,
+			"alpn", negotiatedALPN,
+		)
+	}
+
+	return conn, snap, nil
+}
+
 // configureForwardTLS prepares the per-entry MITM tls.Config cache.
 // Called at listener start when fc.TLS=true and the parent Issuer is known
 // to be non-nil; the cached *tls.Config is reused for every accepted

--- a/internal/proxybuild/tcp_forward_tls_test.go
+++ b/internal/proxybuild/tcp_forward_tls_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 )
 
 // parseLeafCert parses the leaf x509 certificate from a *tls.Certificate.
@@ -331,5 +332,78 @@ func TestConfigureForwardTLS_Happy(t *testing.T) {
 	}
 	if got, want := entry.tlsServerCfg.NextProtos, []string{"h2"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("NextProtos = %v, want %v (http2 → h2 only)", got, want)
+	}
+}
+
+// TestUpstreamALPNOffersForForward pins the USK-916 ALPN propagation
+// policy. Three branches:
+//
+//  1. Explicit Protocol → derive from declaration (delegates to
+//     alpnOffersForForwardProtocol).
+//  2. "auto" + client TLS terminated + client negotiated ALPN →
+//     propagate the client's choice as a single-element list.
+//  3. "auto" + plaintext client (or no client ALPN) → safe default
+//     ["http/1.1"] only (NOT ["h2","http/1.1"] — see helper godoc /
+//     Decision #5).
+func TestUpstreamALPNOffersForForward(t *testing.T) {
+	clientH2 := &forwardConnOverride{
+		tlsTerminated:     true,
+		clientTLSSnapshot: &envelope.TLSSnapshot{ALPN: "h2"},
+	}
+	clientH1 := &forwardConnOverride{
+		tlsTerminated:     true,
+		clientTLSSnapshot: &envelope.TLSSnapshot{ALPN: "http/1.1"},
+	}
+	clientTLSNoALPN := &forwardConnOverride{
+		tlsTerminated:     true,
+		clientTLSSnapshot: &envelope.TLSSnapshot{ALPN: ""},
+	}
+	plainClient := (*forwardConnOverride)(nil)
+
+	cases := []struct {
+		name     string
+		protocol string
+		override *forwardConnOverride
+		want     []string
+	}{
+		// Branch 1: explicit protocol → delegated to
+		// alpnOffersForForwardProtocol, independent of override.
+		{"http_explicit_plain", "http", plainClient, []string{"http/1.1"}},
+		{"http_explicit_clientH2", "http", clientH2, []string{"http/1.1"}},
+		{"http2_explicit_plain", "http2", plainClient, []string{"h2"}},
+		{"http2_explicit_clientH1", "http2", clientH1, []string{"h2"}},
+		{"grpc_explicit", "grpc", plainClient, []string{"h2"}},
+		{"websocket_explicit", "websocket", plainClient, []string{"http/1.1"}},
+		{"sse_explicit", "sse", plainClient, []string{"http/1.1"}},
+		{"raw_explicit", "raw", plainClient, nil},
+		// Branch 2: auto + client TLS terminated + client ALPN known →
+		// propagate single-element list.
+		{"auto_clientH2", "auto", clientH2, []string{"h2"}},
+		{"auto_clientH1", "auto", clientH1, []string{"http/1.1"}},
+		{"empty_clientH2", "", clientH2, []string{"h2"}},
+		// Branch 3: auto + plaintext client (or TLS client with no
+		// negotiated ALPN) → safe default http/1.1.
+		{"auto_plaintext", "auto", plainClient, []string{"http/1.1"}},
+		{"empty_plaintext", "", plainClient, []string{"http/1.1"}},
+		{"auto_clientTLSNoALPN", "auto", clientTLSNoALPN, []string{"http/1.1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := upstreamALPNOffersForForward(tc.protocol, tc.override)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("upstreamALPNOffersForForward(%q, %v) = %v, want %v",
+					tc.protocol, tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpstreamALPNOffersForForward_AutoOverrideNilSnapshot covers the
+// override-non-nil-but-snapshot-nil edge case so the helper does not panic
+// when a malformed override reaches it.
+func TestUpstreamALPNOffersForForward_AutoOverrideNilSnapshot(t *testing.T) {
+	override := &forwardConnOverride{tlsTerminated: true, clientTLSSnapshot: nil}
+	if got, want := upstreamALPNOffersForForward("auto", override), []string{"http/1.1"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("upstreamALPNOffersForForward(auto, nil-snapshot) = %v, want %v", got, want)
 	}
 }

--- a/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
+++ b/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
@@ -1,0 +1,768 @@
+//go:build e2e && !e2e_smoke
+
+// Package proxybuild_test exhaustive tier — USK-916 upstream-side TLS
+// dial for TCP forward listeners. Validates the new fc.UpstreamTLS=true
+// arm dials upstream over TLS, completes the four (TLS × UpstreamTLS)
+// combinations across H1 and H2, advertises ALPN per the propagation
+// policy, fires the (tls, on_handshake, side="client") plugin hook, and
+// records state="error" Streams for upstream cert verification failure.
+package proxybuild_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	gohttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	xhttp2 "golang.org/x/net/http2"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/pluginv2"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/testutil"
+)
+
+// upstreamTLSFixture captures the inputs needed to drive the forward
+// listener under test and assert on recordings.
+type upstreamTLSFixture struct {
+	mgr      *proxybuild.Manager
+	store    *flowStoreCapture
+	buildCfg *connector.BuildConfig
+	fwdAddr  string
+	upstream string
+	rootPool *x509.CertPool // populated when fc.TLS=true (client trusts the MITM CA)
+}
+
+// upstreamTLSFixtureOpts is the variant matrix for newUpstreamTLSFixture.
+type upstreamTLSFixtureOpts struct {
+	protocol     string
+	clientTLS    bool // fc.TLS=true
+	upstreamTLS  bool // fc.UpstreamTLS=true (always true in USK-916 tests)
+	insecureSkip bool // BuildConfig.InsecureSkipVerify
+	pluginEngine *pluginv2.Engine
+}
+
+// newUpstreamTLSFixture spins up a Manager with a forward listener whose
+// (TLS, UpstreamTLS, Protocol) is determined by opts. Skips the per-conn
+// TCP listener — only the manager-driven forward listener is exercised.
+func newUpstreamTLSFixture(t *testing.T, ctx context.Context, upstreamAddr string, opts upstreamTLSFixtureOpts) *upstreamTLSFixture {
+	t.Helper()
+
+	store := &flowStoreCapture{}
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca.Generate: %v", err)
+	}
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(ca.Certificate())
+
+	buildCfg := &connector.BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             cert.NewIssuer(ca),
+		InsecureSkipVerify: opts.insecureSkip,
+	}
+
+	deps := proxybuild.Deps{
+		Logger:         testutil.DiscardLogger(),
+		FlowStore:      store,
+		BuildConfig:    buildCfg,
+		PluginV2Engine: opts.pluginEngine,
+	}
+	mgr, err := proxybuild.NewManager(proxybuild.ManagerConfig{
+		Logger:      testutil.DiscardLogger(),
+		BuildConfig: buildCfg,
+		StackFactory: func(_ context.Context, name, addr string) (*proxybuild.Stack, error) {
+			d := deps
+			d.ListenerName = name
+			d.ListenAddr = addr
+			return proxybuild.BuildLiveStack(context.Background(), d)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.StopAll(context.Background()) })
+
+	if err := mgr.Start(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatalf("manager.Start: %v", err)
+	}
+	if err := mgr.StartTCPForwards(ctx, proxybuild.TCPForwardParams{
+		Forwards: map[string]*config.ForwardConfig{
+			"0": {
+				Target:      upstreamAddr,
+				Protocol:    opts.protocol,
+				TLS:         opts.clientTLS,
+				UpstreamTLS: opts.upstreamTLS,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("StartTCPForwards(%s, tls=%v, upstream_tls=%v): %v",
+			opts.protocol, opts.clientTLS, opts.upstreamTLS, err)
+	}
+	addr := mgr.TCPForwardAddrs()["0"]
+	if addr == "" {
+		t.Fatalf("TCPForwardAddrs missing port 0")
+	}
+
+	return &upstreamTLSFixture{
+		mgr:      mgr,
+		store:    store,
+		buildCfg: buildCfg,
+		fwdAddr:  addr,
+		upstream: upstreamAddr,
+		rootPool: rootPool,
+	}
+}
+
+// startTLSHTTPEchoUpstream binds an httptest.NewTLSServer that echoes the
+// request path back via "Echo-Path" header. The returned cert is the
+// server's self-signed leaf, suitable for client root trust when
+// InsecureSkipVerify=false. Used by the HTTP→HTTPS bridge and HTTPS→HTTPS
+// cells.
+func startTLSHTTPEchoUpstream(t *testing.T) (addr string, certPool *x509.CertPool, stop func()) {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		w.Header().Set("Echo-Path", r.URL.Path)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(gohttp.StatusOK)
+		_, _ = fmt.Fprintf(w, "tls-echo:%s", r.URL.Path)
+	}))
+	srv.TLS = &tls.Config{NextProtos: []string{"http/1.1"}}
+	srv.StartTLS()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	// Trim the "https://" prefix to expose host:port for our fc.Target.
+	u := strings.TrimPrefix(srv.URL, "https://")
+	return u, pool, srv.Close
+}
+
+// startTLSH2EchoUpstream spins up an h2-over-TLS upstream that echoes
+// "h2-echo:<path>" in the body. Returns (addr, certPool, stop).
+func startTLSH2EchoUpstream(t *testing.T) (addr string, certPool *x509.CertPool, stop func()) {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		w.Header().Set("Echo-Path", r.URL.Path)
+		w.Header().Set("X-Echo-Proto", r.Proto)
+		w.WriteHeader(gohttp.StatusOK)
+		_, _ = fmt.Fprintf(w, "h2-echo:%s", r.URL.Path)
+	}))
+	srv.EnableHTTP2 = true
+	srv.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	srv.StartTLS()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	u := strings.TrimPrefix(srv.URL, "https://")
+	return u, pool, srv.Close
+}
+
+// waitForCompleteStream polls store until at least one Stream is in
+// state=complete (or the deadline expires). Useful for asserting recording
+// reached the terminal state before the test exits.
+func waitForCompleteStream(_ *testing.T, store *flowStoreCapture, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		for _, st := range store.Streams() {
+			if st == nil {
+				continue
+			}
+			if upds := store.StreamUpdates(st.ID); len(upds) > 0 {
+				for _, u := range upds {
+					if u.State == "complete" {
+						return true
+					}
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForUpstreamTLSErrorStream polls store until at least one Stream is
+// stamped FailureReason="upstream_tls_error". Returns true when observed
+// within deadline.
+func waitForUpstreamTLSErrorStream(_ *testing.T, store *flowStoreCapture, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		for _, st := range store.Streams() {
+			if st != nil && st.FailureReason == "upstream_tls_error" {
+				return true
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// 1) Happy-path round-trips: 4 (TLS × UpstreamTLS) combinations × {H1, H2}.
+// ---------------------------------------------------------------------------
+
+// TestProxybuild_TCPForward_UpstreamTLS_HTTP_PlainClient drives the
+// "HTTP→HTTPS bridge" cell for H1: plaintext client, fc.TLS=false,
+// fc.UpstreamTLS=true. The proxy dials upstream over TLS while still
+// accepting cleartext from the client. Recorded Stream Scheme stays "http"
+// (client-facing wire) per Decision #11.
+func TestProxybuild_TCPForward_UpstreamTLS_HTTP_PlainClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, _, stopUp := startTLSHTTPEchoUpstream(t)
+	defer stopUp()
+
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: true, // self-signed upstream cert; per-host trust deferred
+	})
+
+	req := "GET /upstream-tls-h1 HTTP/1.1\r\nHost: upstream.example.test\r\nConnection: close\r\n\r\n"
+	conn, err := net.Dial("tcp", fix.fwdAddr)
+	if err != nil {
+		t.Fatalf("net.Dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("conn.Write: %v", err)
+	}
+	buf, _ := io.ReadAll(conn)
+	if !strings.Contains(string(buf), "Echo-Path: /upstream-tls-h1") {
+		t.Errorf("response missing Echo-Path: got=%q", string(buf))
+	}
+	if !strings.Contains(string(buf), "tls-echo:/upstream-tls-h1") {
+		t.Errorf("response missing body: got=%q", string(buf))
+	}
+	// Decision #11: HTTP→HTTPS bridge records Scheme="http" (client wire).
+	if !waitForCompleteStream(t, fix.store, 3*time.Second) {
+		t.Errorf("no Stream reached state=complete; got %v", summarizeStreams(fix.store.Streams()))
+	}
+	if !assertStreamScheme(t, fix.store, "http") {
+		t.Errorf("no Stream recorded with Scheme=\"http\" (HTTP→HTTPS bridge): got %v", summarizeStreams(fix.store.Streams()))
+	}
+}
+
+// TestProxybuild_TCPForward_UpstreamTLS_HTTP_TLSClient drives the
+// "HTTPS→HTTPS" cell for H1: client TLS, fc.TLS=true, fc.UpstreamTLS=true.
+// Recorded Stream Scheme="https".
+func TestProxybuild_TCPForward_UpstreamTLS_HTTP_TLSClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, _, stopUp := startTLSHTTPEchoUpstream(t)
+	defer stopUp()
+
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http",
+		clientTLS:    true,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := &gohttp.Client{
+		Transport: &gohttp.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    fix.rootPool,
+				ServerName: "forward.example.test",
+				NextProtos: []string{"http/1.1"},
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "https://"+fix.fwdAddr+"/upstream-tls-h1-tls", nil)
+	req.Host = "forward.example.test"
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if got, want := resp.StatusCode, gohttp.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if want := "tls-echo:/upstream-tls-h1-tls"; string(body) != want {
+		t.Errorf("body = %q, want %q", string(body), want)
+	}
+	if !waitForHTTPSStream(t, fix.store, 3*time.Second) {
+		t.Errorf("no Stream recorded with Scheme=\"https\" (HTTPS→HTTPS): got %v", summarizeStreams(fix.store.Streams()))
+	}
+}
+
+// TestProxybuild_TCPForward_UpstreamTLS_H2_PlainClient drives the
+// "h2c→h2 over TLS" cell: plaintext client speaks h2c, the proxy dials
+// upstream over TLS+h2. Operator declared Protocol="http2".
+func TestProxybuild_TCPForward_UpstreamTLS_H2_PlainClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, _, stopUp := startTLSH2EchoUpstream(t)
+	defer stopUp()
+
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http2",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := h2cForwardClient(fix.fwdAddr, nil, nil)
+	defer cli.CloseIdleConnections()
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fix.fwdAddr+"/h2c-to-h2-tls", nil)
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if got, want := string(body), "h2-echo:/h2c-to-h2-tls"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+// TestProxybuild_TCPForward_UpstreamTLS_H2_TLSClient drives the
+// "h2 over TLS→h2 over TLS" cell. Both client and upstream TLS+h2.
+func TestProxybuild_TCPForward_UpstreamTLS_H2_TLSClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, _, stopUp := startTLSH2EchoUpstream(t)
+	defer stopUp()
+
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http2",
+		clientTLS:    true,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := &gohttp.Client{
+		Transport: &xhttp2.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    fix.rootPool,
+				ServerName: "forward.example.test",
+				NextProtos: []string{"h2"},
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "https://"+fix.fwdAddr+"/h2tls-to-h2tls", nil)
+	req.Host = "forward.example.test"
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if got, want := string(body), "h2-echo:/h2tls-to-h2tls"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if !waitForHTTPSStream(t, fix.store, 3*time.Second) {
+		t.Errorf("no Stream recorded with Scheme=\"https\" (HTTPS→HTTPS H2): got %v", summarizeStreams(fix.store.Streams()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2) ALPN propagation policy: 4 cells per Decision #4 / #5.
+// ---------------------------------------------------------------------------
+
+// TestProxybuild_UpstreamTLS_ALPN_ExplicitHTTP2 asserts that operator-declared
+// Protocol="http2" + UpstreamTLS=true offers ALPN=[h2] upstream — the
+// upstream server observes "h2" as the negotiated protocol.
+func TestProxybuild_UpstreamTLS_ALPN_ExplicitHTTP2(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	negotiated, addr, stop := startALPNObservingTLSUpstream(t, []string{"h2", "http/1.1"})
+	defer stop()
+
+	fix := newUpstreamTLSFixture(t, ctx, addr, upstreamTLSFixtureOpts{
+		protocol:     "http2",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := h2cForwardClient(fix.fwdAddr, nil, nil)
+	defer cli.CloseIdleConnections()
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "http://"+fix.fwdAddr+"/alpn-h2", nil)
+	resp, err := cli.Do(req)
+	if err != nil {
+		// Even if the test handler 502s, the TLS handshake completed —
+		// negotiated.Load() is what we care about.
+		t.Logf("client.Do error (acceptable; the handshake is what we assert): %v", err)
+	} else {
+		_, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	// Wait briefly for the upstream goroutine to observe the handshake.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := negotiated.Load(); v != nil && v.(string) != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	got := alpnFromAtomic(negotiated)
+	if got != "h2" {
+		t.Errorf("upstream negotiated ALPN = %q, want %q (Protocol=http2 → [h2])", got, "h2")
+	}
+}
+
+// TestProxybuild_UpstreamTLS_ALPN_AutoClientH2 asserts the
+// auto-propagate-client-ALPN policy: Protocol="auto" + TLS=true +
+// UpstreamTLS=true with a client offering h2 → upstream sees ALPN="h2"
+// (single-element propagation).
+func TestProxybuild_UpstreamTLS_ALPN_AutoClientH2(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	negotiated, addr, stop := startALPNObservingTLSUpstream(t, []string{"h2", "http/1.1"})
+	defer stop()
+
+	fix := newUpstreamTLSFixture(t, ctx, addr, upstreamTLSFixtureOpts{
+		protocol:     "auto",
+		clientTLS:    true,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := &gohttp.Client{
+		Transport: &xhttp2.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    fix.rootPool,
+				ServerName: "forward.example.test",
+				NextProtos: []string{"h2"},
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "https://"+fix.fwdAddr+"/auto-client-h2", nil)
+	req.Host = "forward.example.test"
+	if resp, err := cli.Do(req); err == nil {
+		_, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := negotiated.Load(); v != nil && v.(string) != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := alpnFromAtomic(negotiated); got != "h2" {
+		t.Errorf("upstream negotiated ALPN = %q, want %q (auto+client-h2 propagates)", got, "h2")
+	}
+}
+
+// TestProxybuild_UpstreamTLS_ALPN_AutoClientH1 asserts auto-propagate for
+// client offering http/1.1 → upstream sees ALPN="http/1.1".
+func TestProxybuild_UpstreamTLS_ALPN_AutoClientH1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	negotiated, addr, stop := startALPNObservingTLSUpstream(t, []string{"h2", "http/1.1"})
+	defer stop()
+
+	fix := newUpstreamTLSFixture(t, ctx, addr, upstreamTLSFixtureOpts{
+		protocol:     "auto",
+		clientTLS:    true,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	cli := &gohttp.Client{
+		Transport: &gohttp.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    fix.rootPool,
+				ServerName: "forward.example.test",
+				NextProtos: []string{"http/1.1"},
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	req, _ := gohttp.NewRequestWithContext(ctx, "GET", "https://"+fix.fwdAddr+"/auto-client-h1", nil)
+	req.Host = "forward.example.test"
+	if resp, err := cli.Do(req); err == nil {
+		_, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := negotiated.Load(); v != nil && v.(string) != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := alpnFromAtomic(negotiated); got != "http/1.1" {
+		t.Errorf("upstream negotiated ALPN = %q, want %q (auto+client-h1 propagates)", got, "http/1.1")
+	}
+}
+
+// TestProxybuild_UpstreamTLS_ALPN_AutoPlainClient asserts Decision #5:
+// Protocol="auto" + plaintext client + UpstreamTLS=true offers only
+// ["http/1.1"] upstream (NOT h2; single-protocol-per-stack invariant).
+// The upstream server advertises [h2, http/1.1]; the proxy MUST only
+// offer http/1.1 so the negotiation lands on http/1.1.
+func TestProxybuild_UpstreamTLS_ALPN_AutoPlainClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	negotiated, addr, stop := startALPNObservingTLSUpstream(t, []string{"h2", "http/1.1"})
+	defer stop()
+
+	fix := newUpstreamTLSFixture(t, ctx, addr, upstreamTLSFixtureOpts{
+		protocol:     "auto",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: true,
+	})
+
+	// Plaintext client speaks HTTP/1.x; the proxy peeks and routes to H1
+	// arm. Upstream dial offers only http/1.1.
+	req := "GET /auto-plain HTTP/1.1\r\nHost: upstream.example.test\r\nConnection: close\r\n\r\n"
+	conn, err := net.Dial("tcp", fix.fwdAddr)
+	if err != nil {
+		t.Fatalf("net.Dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("conn.Write: %v", err)
+	}
+	_, _ = io.ReadAll(conn)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := negotiated.Load(); v != nil && v.(string) != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := alpnFromAtomic(negotiated); got != "http/1.1" {
+		t.Errorf("upstream negotiated ALPN = %q, want %q (auto+plaintext-client offers only http/1.1)", got, "http/1.1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3) Error path: upstream cert verification failure → state="error".
+// ---------------------------------------------------------------------------
+
+// TestProxybuild_UpstreamTLS_CertVerifyFailure_RecordsError drives a real
+// upstream TLS handshake with a self-signed cert against a proxy that has
+// InsecureSkipVerify=false. The dial fails; the recorder produces a
+// state="error" Stream with FailureReason="upstream_tls_error".
+func TestProxybuild_UpstreamTLS_CertVerifyFailure_RecordsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, _, stopUp := startTLSHTTPEchoUpstream(t)
+	defer stopUp()
+
+	// InsecureSkipVerify=false + self-signed upstream cert (no per-host
+	// trust) → cert verification must fail.
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: false,
+	})
+
+	req := "GET /cert-fail HTTP/1.1\r\nHost: upstream.example.test\r\nConnection: close\r\n\r\n"
+	conn, err := net.Dial("tcp", fix.fwdAddr)
+	if err != nil {
+		t.Fatalf("net.Dial: %v", err)
+	}
+	_, _ = conn.Write([]byte(req))
+	// The proxy drops the connection after the upstream TLS dial fails.
+	_, _ = io.ReadAll(conn)
+	_ = conn.Close()
+
+	if !waitForUpstreamTLSErrorStream(t, fix.store, 3*time.Second) {
+		t.Errorf("no Stream recorded with FailureReason=upstream_tls_error; got %v",
+			summarizeStreams(fix.store.Streams()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4) Plugin hook firing: (tls, on_handshake, side="client") for upstream TLS.
+// ---------------------------------------------------------------------------
+
+// TestProxybuild_UpstreamTLS_PluginHookFires loads a Starlark plugin that
+// emits a print() sentinel each time (tls, on_handshake) fires and asserts
+// the sentinel appears in the plugin-print log stream after a forward
+// round-trip with fc.UpstreamTLS=true. The dispatch path's thread.Print
+// hook forwards plugin print() to the engine logger
+// (internal/pluginv2/lifecycle.go::dispatchLifecycleHook); a CaptureLogger
+// makes the output observable from the test.
+//
+// Hook firing happens for BOTH sides — side="server" if fc.TLS=true (we
+// only do client-side TLS for this test, so server-side does not fire),
+// and side="client" for the upstream TLS dial that USK-916 newly wires.
+// We assert ≥1 sentinel.
+func TestProxybuild_UpstreamTLS_PluginHookFires(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pluginPath := writeUSK913PluginScript(t, `
+def on_hs(env, ctx):
+    print("USK916_TLS_HOOK_FIRED")
+    return None
+register_hook("tls", "on_handshake", on_hs)
+`)
+	cap, logger := testutil.NewCaptureLogger()
+	engine := pluginv2.NewEngine(logger)
+	if err := engine.LoadPlugins(ctx, []pluginv2.PluginConfig{{Path: pluginPath, OnError: string(pluginv2.OnErrorAbort)}}); err != nil {
+		t.Fatalf("LoadPlugins: %v", err)
+	}
+
+	upAddr, _, stopUp := startTLSHTTPEchoUpstream(t)
+	defer stopUp()
+
+	fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+		protocol:     "http",
+		clientTLS:    false,
+		upstreamTLS:  true,
+		insecureSkip: true,
+		pluginEngine: engine,
+	})
+
+	req := "GET /plugin-hook HTTP/1.1\r\nHost: upstream.example.test\r\nConnection: close\r\n\r\n"
+	conn, err := net.Dial("tcp", fix.fwdAddr)
+	if err != nil {
+		t.Fatalf("net.Dial: %v", err)
+	}
+	_, _ = conn.Write([]byte(req))
+	_, _ = io.ReadAll(conn)
+	_ = conn.Close()
+
+	// Wait for the recording side to finalize so the hook has had time to
+	// run.
+	_ = waitForCompleteStream(t, fix.store, 3*time.Second)
+
+	// Poll up to 3 s for the sentinel to surface (the hook fires from the
+	// dial goroutine; the capture logger writes synchronously but the
+	// dispatch may happen after the response has been written).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cap.Contains("USK916_TLS_HOOK_FIRED") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("plugin (tls, on_handshake) sentinel not observed in capture log; output=%q",
+		cap.Output())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (local to this file).
+// ---------------------------------------------------------------------------
+
+// startALPNObservingTLSUpstream binds a TCP listener that performs a TLS
+// handshake offering the supplied ALPN advertise list, records the
+// negotiated ALPN in the returned atomic.Value, and then drops the
+// connection. This is the minimal harness needed to assert the proxy's
+// upstream-ALPN offer list — we do not need to handle any L7 protocol
+// (the negotiated ALPN string is observable directly from the TLS state).
+func startALPNObservingTLSUpstream(t *testing.T, alpnAdvertise []string) (*atomic.Value, string, func()) {
+	t.Helper()
+
+	// Build a self-signed cert (the proxy uses
+	// BuildConfig.InsecureSkipVerify=true in these tests so trust is not
+	// asserted by the dial side).
+	srvCert := buildSelfSignedTLSCert(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{srvCert},
+		NextProtos:   alpnAdvertise,
+		MinVersion:   tls.VersionTLS12,
+	}
+	negotiated := &atomic.Value{}
+	stopCh := make(chan struct{})
+
+	go func() {
+		for {
+			c, accErr := ln.Accept()
+			if accErr != nil {
+				return
+			}
+			go func(raw net.Conn) {
+				defer raw.Close()
+				_ = raw.SetReadDeadline(time.Now().Add(5 * time.Second))
+				tlsConn := tls.Server(raw, tlsCfg)
+				if err := tlsConn.Handshake(); err != nil {
+					return
+				}
+				st := tlsConn.ConnectionState()
+				negotiated.Store(st.NegotiatedProtocol)
+				// Drain any inner bytes briefly so the proxy's HTTP/1.x or
+				// h2 frame writer does not block on a full receive window.
+				_ = tlsConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+				_, _ = io.Copy(io.Discard, tlsConn)
+				_ = tlsConn.Close()
+			}(c)
+		}
+	}()
+	stop := func() {
+		close(stopCh)
+		_ = ln.Close()
+	}
+	return negotiated, ln.Addr().String(), stop
+}
+
+// buildSelfSignedTLSCert returns a fresh self-signed TLS leaf cert,
+// produced via httptest.NewUnstartedServer + StartTLS. The cert is
+// captured before the throwaway server is torn down by t.Cleanup; it has
+// no NextProtos so each caller can set its own. Used by
+// startALPNObservingTLSUpstream so the test does not need to hand-roll
+// x509.CreateCertificate.
+func buildSelfSignedTLSCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(gohttp.HandlerFunc(func(_ gohttp.ResponseWriter, _ *gohttp.Request) {}))
+	srv.TLS = &tls.Config{}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv.TLS.Certificates[0]
+}
+
+// alpnFromAtomic safely reads the negotiated ALPN value from an
+// atomic.Value, returning the empty string on uninitialised value.
+func alpnFromAtomic(a *atomic.Value) string {
+	v := a.Load()
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// assertStreamScheme returns true when at least one recorded Stream has
+// the given Scheme.
+func assertStreamScheme(_ *testing.T, store *flowStoreCapture, scheme string) bool {
+	for _, st := range store.Streams() {
+		if st != nil && st.Scheme == scheme {
+			return true
+		}
+	}
+	return false
+}
+
+// _ assert unused-package-import compile guard for flow.Stream usage
+// elsewhere in the file.
+var _ = (*flow.Stream)(nil)

--- a/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
+++ b/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
-	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/pluginv2"
 	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
 	"github.com/usk6666/yorishiro-proxy/internal/testutil"
@@ -762,7 +761,3 @@ func assertStreamScheme(_ *testing.T, store *flowStoreCapture, scheme string) bo
 	}
 	return false
 }
-
-// _ assert unused-package-import compile guard for flow.Stream usage
-// elsewhere in the file.
-var _ = (*flow.Stream)(nil)


### PR DESCRIPTION
## Summary
- proxybuild: new `dialForwardUpstream` + `upstreamALPNOffersForForward` helpers in `tcp_forward_tls.go` centralise the upstream dial (plain or TLS) for both the H1/raw/L7 arm and the H2 arm.
- proxybuild: H1 and H2 forward handlers perform upstream TLS handshake via `DialUpstreamRaw` when `fc.UpstreamTLS=true`; the `(tls, on_handshake, side="client")` plugin hook fires on success for parity with the live MITM dial path.
- proxybuild: remove the listener-start `UpstreamTLS=true not yet supported` reject; the field is wired end-to-end through the per-conn handler.
- proxybuild: upstream TLS dial failures (cert verify, handshake timeout, etc.) are recorded via `buildTLSStackBuildErrorRecorder` so `state="error"` Streams with `FailureReason="upstream_tls_error"` surface via MCP queries.
- connector: `TargetOverrideParams.UpstreamTLSSnapshot` stamps the upstream Layer's `EnvelopeContext.TLS` in HTTPStack + H2CStack + AutoStack. `UpstreamTLS=true` is now informational rather than a hard reject (existing unit test updated to match).

## ALPN propagation policy (Decision #4 / #5)
- Operator-declared Protocol → derive via `alpnOffersForForwardProtocol`.
- `"auto"` + client TLS terminated + client-negotiated ALPN → propagate the client's choice as a single-element list.
- `"auto"` + plaintext client (or no client ALPN) → offer only `["http/1.1"]` to preserve the single-protocol-per-stack invariant. Operators wanting h2 upstream MUST declare `Protocol="http2"` explicitly. **This refines the Issue body's stated `[h2, http/1.1]` per the design review record** — the proxy's Auto plaintext-peek path routes only to H1 or Raw (no h2c opportunistic upgrade), so advertising h2 upstream would create an unsupported h1↔h2 bridge.

## e2e test coverage (new file `tcp_forward_upstream_tls_integration_test.go`, exhaustive tier)
- 4 (TLS × UpstreamTLS) combinations across H1 and H2: HTTP→HTTPS, HTTPS→HTTPS, h2c→h2-TLS, h2-TLS→h2-TLS.
- 4 ALPN-policy cells: explicit `http2`, auto+client-h2, auto+client-h1, auto+plaintext-client.
- Upstream cert verification failure (`InsecureSkipVerify=false` + self-signed cert) → `state="error"` Stream with `FailureReason="upstream_tls_error"`.
- Plugin `(tls, on_handshake, side="client")` hook firing verified via Starlark `print()` sentinel captured through `testutil.CaptureLogger`.

## Test plan
- [x] `make lint` passes (gofmt + go vet + staticcheck + ineffassign + gocyclo)
- [x] `make build` passes
- [x] `make test` (fast tier) passes
- [x] `make test-e2e-smoke` (merge gate) passes
- [x] Full e2e tier (`go test -tags 'e2e' ./internal/proxybuild/... ./internal/connector/...`) passes including new test file
- [x] CLAUDE.md e2e Subsystem Verification Checklist items addressed for the new file (communication success, stream/flow recording, state transitions, plugin hook firing, error path, MCP-queryable failure reason)

## Reviewer focus points
1. **Decision #5 refinement** — the helper godoc on `upstreamALPNOffersForForward` documents the divergence from the Issue body; please confirm the rationale (single-protocol-per-stack invariant) lands cleanly.
2. **Seam discipline** — the builder now treats `UpstreamTLS` as informational and stamps the snapshot from `UpstreamTLSSnapshot`. TLS is performed in `proxybuild.dialForwardUpstream` (caller-side) mirroring the USK-915 client-side terminate seam.
3. **Error classification** — upstream TLS dial errors use the existing `buildTLSStackBuildErrorRecorder` (no new sentinel); non-`ErrClientTLSMITMHandshake` errors map to `FailureReason="upstream_tls_error"`. Verified via the cert-verify-failure e2e cell.
4. **No mTLS / uTLS / HostTLSRegistry changes** — per Issue scope, deferred. `DialRawOpts{InsecureSkipVerify, OfferALPN, TLSConfig, DialTimeout}` only; per-host TLS material is not consulted on the forward path.

Resolves USK-916
Linear: https://linear.app/usk6666/issue/USK-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)