### PR TITLE
feat(mcp,docs): TCP forward L7 — proxy_start schema + smoke + docs (USK-917)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,15 +36,17 @@ Each connection is an explicit stack of `Layer`s (RFC-001 §3.3); each Layer yie
 
 | Protocol | L7 Structured View | L4 raw bytes | Notes |
 |----------|-------------------|--------------|-------|
-| HTTP/1.x | YES | YES | Custom parser; `net/http` not used in data path |
-| HTTP/2 | YES | YES | Custom frame engine; event-granular Channel + per-stream BodyBuffer |
-| gRPC | YES | YES (via HTTP/2) | Native LPM reassembly; GRPCStart/Data/End envelope events |
+| HTTP/1.x | YES | YES | Custom parser; `net/http` not used in data path. Forward: supported (USK-911~917). |
+| HTTP/2 | YES | YES | Custom frame engine; event-granular Channel + per-stream BodyBuffer. Forward: supported (USK-911~917). |
+| gRPC | YES | YES (via HTTP/2) | Native LPM reassembly; GRPCStart/Data/End envelope events. Forward: supported (USK-911~917). |
 | gRPC-Web | YES | YES (via HTTP/1.x or HTTP/2) | Binary + base64 wire formats |
-| WebSocket | YES | YES (per frame) | Per-message-deflate (RFC 7692) supported |
-| SSE | YES | YES | Per-event envelopes; streaming-aware Pipeline; per-event Transform / Intercept (rules/sse) — USK-892. Engines mutate SSEMessage fields directly; session-side sseMessageMutated field-diff is the authoritative re-encode signal (env.Raw is NOT cleared). |
-| Raw TCP | N/A | YES (byte stream) | Smuggling-safe pass-through (`bytechunk` Layer) |
+| WebSocket | YES | YES (per frame) | Per-message-deflate (RFC 7692) supported. Forward: supported (USK-911~917). |
+| SSE | YES | YES | Per-event envelopes; streaming-aware Pipeline; per-event Transform / Intercept (rules/sse) — USK-892. Engines mutate SSEMessage fields directly; session-side sseMessageMutated field-diff is the authoritative re-encode signal (env.Raw is NOT cleared). Forward: supported (USK-911~917). |
+| Raw TCP | N/A | YES (byte stream) | Smuggling-safe pass-through (`bytechunk` Layer). Forward: supported (USK-911~917). |
 | SOCKS5 | N/A | N/A (excluded as transport layer itself) | Apply raw bytes/L7 to the protocol delegated after handshake/tunnel |
 | TLS handshake | YES (observation) | N/A | `TLSHandshakeMessage` envelope; SNI / ALPN / JA3 / JA4 visible to plugins |
+
+> **TCP forward L7 dispatch (USK-911~917)**: All L7-supported protocols above are also usable through TCP forward mode (`tcp_forwards`) with independent client-side (`tls`) and upstream-side (`upstream_tls`) TLS axes. See `internal/proxybuild/tcp_forward.go` for the dispatch matrix and [RFC-001 §3.4.2](docs/rfc/envelope.md#342-tcp-forward-l7-dispatch).
 
 ### Design Principles
 

--- a/docs/rfc/envelope.md
+++ b/docs/rfc/envelope.md
@@ -657,6 +657,27 @@ func (s *ConnectionStack) UpstreamTopmostForStream(streamID string) layer.Layer
 - HTTP/3 / QUIC extended CONNECT is a separate milestone; the overlay is described against the HTTP/2 framing surface only.
 - gRPC / SSE behavior under extended CONNECT is unchanged: those layers do not participate in extended-CONNECT-driven swaps.
 
+#### 3.4.2 TCP Forward L7 Dispatch
+
+In addition to the CONNECT / SOCKS5 / transparent paths, `yorishiro-proxy` accepts pre-configured **TCP forward** listeners (`tcp_forwards` in `proxy_start`). Each entry maps a local port to an upstream `host:port` and selects the connection-stack assembly explicitly rather than via peek-based detection.
+
+Implementation: `internal/proxybuild/tcp_forward.go`. Configuration: `internal/config.ForwardConfig` with three independent axes —
+
+- **`Protocol`** — one of `auto` (peek), `raw`, `http`, `http2`, `grpc`, `websocket`, `sse`. Selects which Layer stack the forward dispatches into; `auto` peeks the first bytes and falls back to `raw` when no L7 signature is detected. Inner L7 dispatch (WebSocket Upgrade, SSE response sniff, gRPC content-type) is derived from the chosen protocol Layer and reuses the same Pipeline.
+- **`TLS`** — when `true`, the proxy terminates client TLS on the forward listener (the per-entry `tls.Config` honors SNI and dispatches by negotiated ALPN), then applies L7 parsing on the cleartext stream. Recorded Stream `Scheme="https"`.
+- **`UpstreamTLS`** — when `true`, the proxy dials the upstream over TLS (global TLS fingerprint, SNI derived from `Target`, configured verification / mTLS material). Wire-level ALPN propagation follows the rule in `dialForwardUpstream`: explicit `Protocol="http2"` → offer `[h2]`; `Protocol="http"` → `[http/1.1]`; `Protocol="auto"` → propagate the client-negotiated ALPN if any, else `[http/1.1]`.
+
+`TLS` and `UpstreamTLS` are independent (4 combinations) and are never inferred from `Target`'s scheme or port. The TLS × UpstreamTLS matrix:
+
+| TLS   | UpstreamTLS | Client wire | Upstream wire | Use case                                      |
+|-------|-------------|-------------|---------------|-----------------------------------------------|
+| false | false       | plaintext   | plaintext     | Raw L4/L7 forwarding (default)                |
+| true  | false       | TLS         | plaintext     | TLS termination only                          |
+| false | true        | plaintext   | TLS           | Plaintext client → TLS-only upstream          |
+| true  | true        | TLS         | TLS           | Full MITM: terminate then re-encrypt upstream |
+
+All forwarded streams reuse the same `Pipeline` and `RecordStep`, so Flow / Stream recording (`flow.Stream.Scheme` reflects the client-side wire; per-Flow `Envelope.Raw` preserves wire bytes), plugin hooks, intercept / transform rules, and Safety Input Filter apply identically to forward traffic.
+
 ### 3.5 Pipeline Step Categorization
 
 Pipeline interface is unchanged:

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -86,7 +86,7 @@ type proxyStartInput struct {
 	// both formats in the MCP JSON schema; parsed into *config.ForwardConfig
 	// by parseTCPForwardsAny. See yorishiro://help/proxy_start for the full
 	// TLS × upstream_tls matrix.
-	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string or {target, protocol, tls, upstream_tls} object; tls=client-side termination, upstream_tls=upstream-dial encryption (independent)"`
+	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string (legacy) or {target, protocol, tls, upstream_tls} object. protocol: auto|raw|http|http2|grpc|websocket|sse (empty=auto). tls=client-side TLS MITM termination on the forwarded port; upstream_tls=upstream-dial TLS encryption to target. Both default false and are independent (4 combinations: plaintext/plaintext, TLS-terminate/plaintext, plaintext/TLS, TLS-terminate/TLS). See yorishiro://help/proxy_start for the full matrix."`
 
 	// SOCKS5Auth specifies the SOCKS5 authentication method.
 	// Valid values: "none" (default), "password".

--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -49,7 +49,7 @@ Each entry maps a local port number (string key) to either:
 - A **ForwardConfig object** with the following fields:
   - **target** (string, required): Upstream address in `"host:port"` format (e.g. `"api.example.com:50051"`)
   - **protocol** (string, optional): Expected protocol for L7 parsing. Default: `"auto"` (peek-based detection).
-    Valid values: `"auto"`, `"raw"`, `"http"`, `"http2"`, `"grpc"`, `"websocket"`
+    Valid values: `"auto"`, `"raw"`, `"http"`, `"http2"`, `"grpc"`, `"websocket"`, `"sse"`
   - **tls** (boolean, optional): Enable client-side TLS MITM termination on the forwarded listen port. Default: `false`.
     When true, the proxy presents a dynamically-issued certificate to the local client and terminates TLS before applying L7 parsing.
   - **upstream_tls** (boolean, optional): Enable upstream-dial TLS encryption to `target`. Default: `false`.
@@ -206,6 +206,35 @@ Example:
       "tls": true
     },
     "3306": "db.example.com:3306"
+  }
+}
+```
+
+### Start with TCP forward to TLS-only upstream (HTTP → HTTPS bridge)
+```json
+{
+  "listen_addr": "127.0.0.1:8080",
+  "tcp_forwards": {
+    "8081": {
+      "target": "api.example.com:443",
+      "protocol": "http",
+      "upstream_tls": true
+    }
+  }
+}
+```
+
+### Start with TCP forward — full MITM (TLS terminate + re-encrypt upstream)
+```json
+{
+  "listen_addr": "127.0.0.1:8080",
+  "tcp_forwards": {
+    "8443": {
+      "target": "api.example.com:443",
+      "protocol": "http",
+      "tls": true,
+      "upstream_tls": true
+    }
   }
 }
 ```

--- a/internal/mcptest/tcp_forward_l7_smoke_integration_test.go
+++ b/internal/mcptest/tcp_forward_l7_smoke_integration_test.go
@@ -1,0 +1,296 @@
+//go:build e2e
+
+// Package mcptest_test holds USK-917's smoke coverage for the L7 TCP
+// forward feature: proxy_start tcp_forwards with Protocol="http" across
+// all four (TLS × UpstreamTLS) cells.
+//
+// internal/proxybuild/tcp_forward_tls_integration_test.go and
+// tcp_forward_upstream_tls_integration_test.go cover the proxybuild
+// manager directly at the nightly (exhaustive) tier. This file is the
+// merge-gate smoke that proves the full proxy_start → MCP handoff still
+// honors the four (TLS, UpstreamTLS) combinations on the user-facing
+// path (USK-911 schema + USK-915/916 wiring + USK-917 docs/UI wrap-up).
+package mcptest_test
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/mcptest"
+)
+
+// TestE2E_TCPForward_L7_TLSMatrix exercises the four TLS×UpstreamTLS
+// cells with Protocol="http". Each cell drives a real HTTP/1.1
+// request → response round-trip and confirms a flow lands in the
+// recorder visible via query(flows).
+//
+// Cells (TLS = client-side terminate, UpstreamTLS = upstream-dial encrypt):
+//   - (false, false): plaintext client → plaintext upstream.
+//   - (true,  false): TLS client (proxy MITM cert)   → plaintext upstream.
+//   - (false, true):  plaintext client → TLS upstream (HTTP→HTTPS bridge).
+//   - (true,  true):  TLS client → TLS upstream (full MITM).
+//
+// We construct two upstream flavors. The TLS upstreams reuse the
+// canonical httptest.NewTLSServer self-signed pattern with NextProtos=[http/1.1];
+// the proxy's -insecure flag (set by HarnessOptions default) is what makes
+// the upstream-side TLS verification accept the leaf.
+func TestE2E_TCPForward_L7_TLSMatrix(t *testing.T) {
+	// Spin one harness up front and reuse across cells — each cell
+	// uses its own listener Name and a unique forward port, so they
+	// do not interfere. This keeps the smoke fast while still
+	// exercising the full JSON-RPC / MCP wiring per cell.
+	h := mcptest.StartHarness(t, mcptest.HarnessOptions{})
+
+	// Capture the proxy's CA cert so the test client can verify the
+	// dynamically-issued forward-listener cert under fc.TLS=true.
+	rootPool := fetchProxyCAPool(t, h)
+
+	plainUpstream := startPlainHTTPEcho(t)
+	tlsUpstream := startTLSHTTPEcho(t)
+
+	type cell struct {
+		name        string
+		tls         bool
+		upstreamTLS bool
+		upstream    string // host:port (plaintext or TLS)
+	}
+	cases := []cell{
+		{name: "plaintext_to_plaintext", tls: false, upstreamTLS: false, upstream: plainUpstream},
+		{name: "tls_terminate_to_plaintext", tls: true, upstreamTLS: false, upstream: plainUpstream},
+		{name: "plaintext_to_upstream_tls", tls: false, upstreamTLS: true, upstream: tlsUpstream},
+		{name: "tls_terminate_to_upstream_tls", tls: true, upstreamTLS: true, upstream: tlsUpstream},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forwardPort := pickFreePort(t)
+			listenerName := fmt.Sprintf("forward-l7-%d", i)
+			path := "/usk917-" + tc.name
+
+			startArgs := map[string]any{
+				"name":        listenerName,
+				"listen_addr": "127.0.0.1:0",
+				"tcp_forwards": map[string]any{
+					strconv.Itoa(forwardPort): map[string]any{
+						"target":       tc.upstream,
+						"protocol":     "http",
+						"tls":          tc.tls,
+						"upstream_tls": tc.upstreamTLS,
+					},
+				},
+			}
+
+			res := h.MustOK(t, "proxy_start", startArgs)
+			if _, ok := res.Decoded["tcp_forwards"]; !ok {
+				t.Fatalf("proxy_start did not echo tcp_forwards (decoded=%v text=%s)", res.Decoded, res.Text)
+			}
+
+			body := driveHTTPThroughForward(t, forwardPort, path, tc.tls, rootPool, 5*time.Second)
+			if !strings.Contains(body, "Echo-Path: "+path) {
+				t.Errorf("response missing Echo-Path header for %q; got body=%q", path, body)
+			}
+
+			if !waitForFlowWithPath(t, h, path, 3*time.Second) {
+				t.Errorf("no recorded flow with url containing %q after forward round-trip (cell %q)", path, tc.name)
+			}
+
+			// Stop the listener to free the listener name for the
+			// next cell. Errors are non-fatal — t.Cleanup on the
+			// harness tears down regardless.
+			_ = h.CallTool(t, "proxy_stop", map[string]any{"name": listenerName})
+		})
+	}
+}
+
+// driveHTTPThroughForward sends a single HTTP/1.1 GET request to
+// 127.0.0.1:port (plaintext or TLS depending on useTLS) and returns the
+// full raw response (status line + headers + body) so callers can
+// assert on the Echo-Path header. Per-step deadlines keep a hung
+// proxy from stalling the test indefinitely.
+func driveHTTPThroughForward(t *testing.T, port int, path string, useTLS bool, rootPool *x509.CertPool, timeout time.Duration) string {
+	t.Helper()
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+
+	var conn net.Conn
+	var err error
+	if useTLS {
+		tlsCfg := &tls.Config{
+			RootCAs:    rootPool,
+			ServerName: "forward.usk917.test",
+			NextProtos: []string{"http/1.1"},
+			MinVersion: tls.VersionTLS12,
+		}
+		dialer := &net.Dialer{Timeout: timeout}
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsCfg)
+	} else {
+		conn, err = net.DialTimeout("tcp", addr, timeout)
+	}
+	if err != nil {
+		t.Fatalf("dial forward port %s (tls=%v): %v", addr, useTLS, err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	// Use a host header that matches the SNI for fc.TLS=true so the
+	// proxy's per-host cert issuance is exercised end-to-end. For
+	// plaintext cells the Host is informational only.
+	req := "GET " + path + " HTTP/1.1\r\n" +
+		"Host: forward.usk917.test\r\n" +
+		"Connection: close\r\n" +
+		"\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	raw, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return string(raw)
+}
+
+// startPlainHTTPEcho binds a hand-rolled HTTP/1.1 echo on
+// 127.0.0.1:ephemeral and returns its host:port. The handler accepts
+// one request per connection and writes a 200 response carrying an
+// Echo-Path header so downstream assertions can pin the route.
+//
+// We hand-roll the listener rather than reusing
+// HarnessOptions.UpstreamProto="http/1.1" because the harness's
+// upstream is always wrapped by httptest.StartTLS — the (false,false)
+// and (true,false) cells need a *plaintext* upstream.
+func startPlainHTTPEcho(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("plain echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+				br := bufio.NewReader(c)
+				path := readHTTP1RequestPath(br)
+				if path == "" {
+					return
+				}
+				// Drain the rest of the headers so the request
+				// is fully consumed before we respond.
+				for {
+					line, rerr := br.ReadString('\n')
+					if rerr != nil {
+						return
+					}
+					if line == "\r\n" || line == "\n" {
+						break
+					}
+				}
+				resp := "HTTP/1.1 200 OK\r\n" +
+					"Content-Type: text/plain\r\n" +
+					"Echo-Path: " + path + "\r\n" +
+					"Content-Length: 0\r\n" +
+					"Connection: close\r\n" +
+					"\r\n"
+				_, _ = c.Write([]byte(resp))
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// startTLSHTTPEcho stands up a TLS HTTP/1.1 server via httptest.StartTLS
+// with NextProtos=[http/1.1]. The harness's -insecure flag (default)
+// allows the proxy's upstream-side dial to accept the self-signed leaf.
+func startTLSHTTPEcho(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Echo-Path", r.URL.Path)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "tls-echo:%s", r.URL.Path)
+	}))
+	srv.TLS = &tls.Config{NextProtos: []string{"http/1.1"}, MinVersion: tls.VersionTLS12}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "https://")
+}
+
+// readHTTP1RequestPath reads the first request line of an HTTP/1.x
+// request and returns the URL path. Returns "" if the line is
+// malformed or read fails.
+func readHTTP1RequestPath(br *bufio.Reader) string {
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return ""
+	}
+	parts := strings.SplitN(strings.TrimRight(line, "\r\n"), " ", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+// fetchProxyCAPool queries the proxy's CA cert via the MCP query tool
+// and returns a CertPool the test client can use as RootCAs. The proxy
+// MITMs the forward listener with a dynamically-issued leaf chained
+// off this CA when fc.TLS=true.
+func fetchProxyCAPool(t *testing.T, h *mcptest.Harness) *x509.CertPool {
+	t.Helper()
+	res := h.MustOK(t, "query", map[string]any{"resource": "ca_cert"})
+	pemStr, _ := res.Decoded["pem"].(string)
+	if pemStr == "" {
+		t.Fatalf("query(ca_cert) returned empty PEM: decoded=%v text=%s", res.Decoded, res.Text)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(pemStr)) {
+		t.Fatalf("append proxy CA PEM into pool failed; PEM=%q", pemStr)
+	}
+	return pool
+}
+
+// waitForFlowWithPath polls query(resource=flows) until at least one
+// flow's URL contains the given path substring. Returns true when
+// observed within deadline. The recording side runs after the wire
+// round-trip completes, so a brief poll is appropriate.
+func waitForFlowWithPath(t *testing.T, h *mcptest.Harness, path string, deadline time.Duration) bool {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		res := h.MustOK(t, "query", map[string]any{
+			"resource": "flows",
+		})
+		// Re-decode from Text since the harness's Decoded view of
+		// flow URL fields can vary by transport — we only need a
+		// substring match.
+		var payload struct {
+			Flows []struct {
+				URL string `json:"url"`
+			} `json:"flows"`
+		}
+		if err := json.Unmarshal([]byte(res.Text), &payload); err == nil {
+			for _, f := range payload.Flows {
+				if strings.Contains(f.URL, path) {
+					return true
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}

--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -59,13 +59,16 @@ export interface TransformRule {
 }
 
 /** Allowed protocols for TCP forwarding. */
-export type ForwardProtocol = "auto" | "raw" | "http" | "http2" | "grpc" | "websocket";
+export type ForwardProtocol = "auto" | "raw" | "http" | "http2" | "grpc" | "websocket" | "sse";
 
 /** TCP forward configuration for a single port. */
 export interface ForwardConfig {
   target: string;
   protocol?: ForwardProtocol;
+  /** Client-side TLS MITM termination on the forwarded listen port. */
   tls?: boolean;
+  /** Upstream-dial TLS encryption to target (independent of `tls`). */
+  upstream_tls?: boolean;
 }
 
 /** Connection info for a flow. */

--- a/web/src/pages/Settings/TcpForwards.tsx
+++ b/web/src/pages/Settings/TcpForwards.tsx
@@ -9,7 +9,7 @@ interface TcpForwardsProps {
 }
 
 /** Valid protocol values for ForwardConfig. */
-const PROTOCOL_OPTIONS = ["auto", "raw", "http", "http2", "grpc", "websocket"] as const;
+const PROTOCOL_OPTIONS = ["auto", "raw", "http", "http2", "grpc", "websocket", "sse"] as const;
 
 /**
  * TcpForwards — manage TCP forward mappings (local port -> ForwardConfig).
@@ -29,6 +29,7 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
   const [upstreamPort, setUpstreamPort] = useState("");
   const [protocol, setProtocol] = useState<ForwardProtocol>("auto");
   const [tlsEnabled, setTlsEnabled] = useState(false);
+  const [upstreamTlsEnabled, setUpstreamTlsEnabled] = useState(false);
   const [showForm, setShowForm] = useState(false);
 
   const forwards = config.tcp_forwards ?? {};
@@ -75,6 +76,9 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
     if (tlsEnabled) {
       newEntry.tls = true;
     }
+    if (upstreamTlsEnabled) {
+      newEntry.upstream_tls = true;
+    }
 
     // Build new forwards map: existing + new entry
     const newForwards: Record<string, ForwardConfig> = { ...forwards, [port]: newEntry };
@@ -85,13 +89,14 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
       });
       addToast({
         type: "success",
-        message: `TCP forward added: port ${port} -> ${upstream}${protocol !== "auto" ? ` (${protocol})` : ""}${tlsEnabled ? " [TLS]" : ""}`,
+        message: `TCP forward added: port ${port} -> ${upstream}${protocol !== "auto" ? ` (${protocol})` : ""}${tlsEnabled ? " [TLS]" : ""}${upstreamTlsEnabled ? " [Upstream TLS]" : ""}`,
       });
       setLocalPort("");
       setUpstreamHost("");
       setUpstreamPort("");
       setProtocol("auto");
       setTlsEnabled(false);
+      setUpstreamTlsEnabled(false);
       setShowForm(false);
       onRefresh();
     } catch (err) {
@@ -100,7 +105,7 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
         message: `Failed to add TCP forward: ${err instanceof Error ? err.message : String(err)}`,
       });
     }
-  }, [localPort, upstreamHost, upstreamPort, protocol, tlsEnabled, forwards, start, addToast, onRefresh]);
+  }, [localPort, upstreamHost, upstreamPort, protocol, tlsEnabled, upstreamTlsEnabled, forwards, start, addToast, onRefresh]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -208,6 +213,17 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
                     <span>Enable TLS MITM</span>
                   </label>
                 </div>
+                <div className="input-wrapper">
+                  <label className="input-label">Upstream TLS</label>
+                  <label style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", cursor: "pointer", padding: "var(--space-xs) 0" }}>
+                    <input
+                      type="checkbox"
+                      checked={upstreamTlsEnabled}
+                      onChange={(e) => setUpstreamTlsEnabled(e.target.checked)}
+                    />
+                    <span>Dial upstream over TLS</span>
+                  </label>
+                </div>
               </div>
               <div className="settings-add-form-actions">
                 <Button
@@ -254,6 +270,13 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
                         <span style={{ marginLeft: "var(--space-xs)" }}>
                           <Badge variant="warning">
                             TLS
+                          </Badge>
+                        </span>
+                      )}
+                      {fc.upstream_tls && (
+                        <span style={{ marginLeft: "var(--space-xs)" }}>
+                          <Badge variant="warning">
+                            Upstream TLS
                           </Badge>
                         </span>
                       )}


### PR DESCRIPTION
## Summary
- Extend MCP `proxy_start.tcp_forwards` schema description to enumerate all 7 Protocol values (auto/raw/http/http2/grpc/websocket/sse) and document the `upstream_tls` field. The inner ForwardConfig stays `map[string]any` (schema-opaque by design — Go-side `validateTCPForwardsConfig` is authoritative).
- Add smoke-tier e2e test `internal/mcptest/tcp_forward_l7_smoke_integration_test.go` covering all 4 (TLS × UpstreamTLS) cells via Protocol="http" through the JSON-RPC harness (`mcptest.StartHarness`). Each cell asserts a real HTTP/1.1 round-trip and verifies the flow lands in the recorder via `query(flows)`.
- Update `internal/mcp/resources/help_proxy_start.md` to include `"sse"` in the protocol enum and add upstream_tls examples (HTTP→HTTPS bridge, full MITM).
- Add new RFC-001 subsection §3.4.2 "TCP Forward L7 Dispatch" summarizing the dispatch matrix.
- Update CLAUDE.md L7/L4 Support table with `Forward: supported (USK-911~917)` annotations and a footnote linking to the RFC.
- WebUI Settings: add `"sse"` option to the protocol selector, `upstream_tls` checkbox + state, and an "Upstream TLS" badge in the mapping list.

## Test plan
- [x] `make build` green
- [x] `make lint` green
- [x] `make test` green (fast tier)
- [x] `make test-e2e-smoke` green — `TestE2E_TCPForward_L7_TLSMatrix` (4 subtests) PASS
- [ ] MCP schema reflection shows the full 7-value Protocol enum + `upstream_tls` (the schema is `map[string]any`, so verification is via the description string surfaced through `proxy_start`'s `Description`/help resource)
- [ ] WebUI Settings → TCP Forwards renders `"sse"` option and `upstream_tls` checkbox

Resolves USK-917
Linear: https://linear.app/usk6666/issue/USK-917

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)