### PR TITLE
feat(mcp,grpc): proto LPM schemaless decode surface in query/resend (USK-922)

### DIFF
--- a/internal/mcp/query_decode_body_grpc_test.go
+++ b/internal/mcp/query_decode_body_grpc_test.go
@@ -1,0 +1,489 @@
+// Package mcp query_decode_body_grpc_test.go covers the gRPC proto LPM
+// schemaless decode wiring added in USK-922. The unit tier asserts:
+//
+//   - query messages on a gRPC Data envelope surfaces body_decoded as
+//     proto-schemaless JSON when decode_bodies=true (the default).
+//   - decode_bodies=false suppresses the new fields.
+//   - Malformed proto payloads surface body_decode_anomaly{proto_malformed}
+//     and leave the wire-form body intact.
+//   - Empty bodies stay quiet.
+//   - body_max_bytes caps body_decoded independently of the wire-form body.
+//   - Output Filter masks PII inside the decoded JSON before it reaches the
+//     MCP transport boundary (RFC-001 §3.7).
+//   - gRPC Start / End envelopes (grpc_event != "data") are NOT decoded.
+//   - The same dispatch fires through query flow's projectFlowSide
+//     (unary RPC code path).
+//
+// gRPC-Web is covered query-side automatically: the record_step writes
+// metadata grpc_event=data for both gRPC and gRPC-Web Data envelopes. A
+// dedicated gRPC-Web flow fixture exercises that path.
+package mcp
+
+import (
+	"context"
+	"encoding/hex"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/safety"
+)
+
+// protoBytesHi is the proto wire encoding of {field=1 (String) "hi"}.
+// Tag byte 0x0A = (field 1 << 3) | wireLengthDelimited(2), length 0x02,
+// then the ASCII bytes for "hi".
+var protoBytesHi = []byte{0x0a, 0x02, 0x68, 0x69}
+
+// protoBytesSecret encodes {field=1 (String) "secret-card 4111111111111111"}.
+// Used by the Output Filter masking test — the credit-card pattern would
+// survive a JSON-without-mask projection unless the filter ran on the
+// decoded plaintext.
+func protoBytesSecret(t *testing.T) []byte {
+	t.Helper()
+	// 0x0A length-delimited tag + len + value.
+	payload := "card 4111111111111111"
+	buf := []byte{0x0a, byte(len(payload))}
+	buf = append(buf, []byte(payload)...)
+	return buf
+}
+
+// seedGRPCDataFlow stores a single recv-direction gRPC Data envelope flow
+// so query messages / query flow exercises the dispatcher. The Flow.Body is
+// the L7 payload (proto wire bytes) — record_step.go strips the LPM prefix
+// at record time.
+func seedGRPCDataFlow(t *testing.T, store flow.Store, id string, payload []byte, extraMetadata map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+
+	stream := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  "grpc",
+		State:     "complete",
+		Timestamp: time.Now().UTC(),
+		Duration:  100 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, stream); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+
+	u, _ := url.Parse("https://example.com/pkg.Service/Method")
+	send := &flow.Flow{
+		ID:        id + "-send",
+		StreamID:  id,
+		Sequence:  0,
+		Direction: "send",
+		Timestamp: time.Now().UTC(),
+		Method:    "POST",
+		URL:       u,
+		Headers:   map[string][]string{":path": {"/pkg.Service/Method"}},
+		Metadata:  map[string]string{"grpc_event": "start", "grpc_service": "pkg.Service", "grpc_method": "Method"},
+	}
+	if err := store.SaveFlow(ctx, send); err != nil {
+		t.Fatalf("SaveFlow(send): %v", err)
+	}
+
+	dataMeta := map[string]string{
+		"grpc_event":   "data",
+		"grpc_service": "pkg.Service",
+		"grpc_method":  "Method",
+	}
+	for k, v := range extraMetadata {
+		dataMeta[k] = v
+	}
+	data := &flow.Flow{
+		ID:        id + "-data",
+		StreamID:  id,
+		Sequence:  1,
+		Direction: "receive",
+		Timestamp: time.Now().UTC(),
+		Body:      payload,
+		Metadata:  dataMeta,
+	}
+	if err := store.SaveFlow(ctx, data); err != nil {
+		t.Fatalf("SaveFlow(data): %v", err)
+	}
+}
+
+// TestQueryMessages_GRPCData_BodyDecoded_ProtoSchemalessJSON is the
+// happy-path: a Data envelope with simple proto payload yields
+// body_decoded as JSON with the schemaless key shape.
+func TestQueryMessages_GRPCData_BodyDecoded_ProtoSchemalessJSON(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	seedGRPCDataFlow(t, store, "g1", protoBytesHi, nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g1"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	var dataEntry *queryMessageEntry
+	for i := range msgs.Messages {
+		if msgs.Messages[i].Metadata["grpc_event"] == "data" {
+			dataEntry = &msgs.Messages[i]
+			break
+		}
+	}
+	if dataEntry == nil {
+		t.Fatal("no data envelope in messages list")
+	}
+
+	if dataEntry.BodyDecoded == "" {
+		t.Fatalf("BodyDecoded empty; want proto JSON projection. Entry=%+v", dataEntry)
+	}
+	if dataEntry.BodyDecodedEncoding != "proto-schemaless-json" {
+		t.Errorf("BodyDecodedEncoding = %q, want proto-schemaless-json", dataEntry.BodyDecodedEncoding)
+	}
+	if dataEntry.BodyEncodingApplied != "proto-schemaless" {
+		t.Errorf("BodyEncodingApplied = %q, want proto-schemaless", dataEntry.BodyEncodingApplied)
+	}
+	if dataEntry.BodyDecodeAnomaly != nil {
+		t.Errorf("unexpected anomaly: %+v", dataEntry.BodyDecodeAnomaly)
+	}
+	// Key format check: "0001:0000:String" + value "hi".
+	if !strings.Contains(dataEntry.BodyDecoded, "0001:0000:String") {
+		t.Errorf("BodyDecoded missing field key 0001:0000:String: %q", dataEntry.BodyDecoded)
+	}
+	if !strings.Contains(dataEntry.BodyDecoded, `"hi"`) {
+		t.Errorf("BodyDecoded missing value 'hi': %q", dataEntry.BodyDecoded)
+	}
+}
+
+// TestQueryMessages_GRPCData_DecodeBodiesFalse_Suppresses asserts the gRPC
+// path honours the decode_bodies flag.
+func TestQueryMessages_GRPCData_DecodeBodiesFalse_Suppresses(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	seedGRPCDataFlow(t, store, "g2", protoBytesHi, nil)
+
+	off := false
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g2", DecodeBodies: &off})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	for _, m := range msgs.Messages {
+		if m.Metadata["grpc_event"] != "data" {
+			continue
+		}
+		if m.BodyDecoded != "" {
+			t.Errorf("BodyDecoded should be empty when decode_bodies=false, got %q", m.BodyDecoded)
+		}
+		if m.BodyEncodingApplied != "" {
+			t.Errorf("BodyEncodingApplied should be empty when decode_bodies=false, got %q", m.BodyEncodingApplied)
+		}
+	}
+}
+
+// TestQueryMessages_GRPCData_MalformedProto_Anomaly asserts that bogus
+// proto wire bytes surface as proto_malformed and the wire-form body
+// stays intact.
+func TestQueryMessages_GRPCData_MalformedProto_Anomaly(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	// Bogus payload: tag byte advertising length-delimited but no length
+	// data following. protobuf.Decode returns an error.
+	corrupted, _ := hex.DecodeString("0a")
+	seedGRPCDataFlow(t, store, "g3", corrupted, nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g3"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	var dataEntry *queryMessageEntry
+	for i := range msgs.Messages {
+		if msgs.Messages[i].Metadata["grpc_event"] == "data" {
+			dataEntry = &msgs.Messages[i]
+			break
+		}
+	}
+	if dataEntry == nil {
+		t.Fatal("no data envelope in messages list")
+	}
+	if dataEntry.BodyDecodeAnomaly == nil {
+		t.Fatal("expected proto_malformed anomaly, got nil")
+	}
+	if dataEntry.BodyDecodeAnomaly.Type != "proto_malformed" {
+		t.Errorf("anomaly type = %q, want proto_malformed", dataEntry.BodyDecodeAnomaly.Type)
+	}
+	if dataEntry.BodyDecoded != "" {
+		t.Errorf("BodyDecoded should be empty on anomaly, got %q", dataEntry.BodyDecoded)
+	}
+	if dataEntry.BodyEncodingApplied != "" {
+		t.Errorf("BodyEncodingApplied should be empty on anomaly, got %q", dataEntry.BodyEncodingApplied)
+	}
+	// Wire-form body preserved (base64 of the corrupted byte).
+	if dataEntry.Body == "" {
+		t.Errorf("wire-form body should still surface for diagnostic, got empty")
+	}
+}
+
+// TestQueryMessages_GRPCData_EmptyBody_NoDecoded asserts the
+// len(rawBody)==0 short-circuit.
+func TestQueryMessages_GRPCData_EmptyBody_NoDecoded(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	seedGRPCDataFlow(t, store, "g4", nil, nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g4"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	for _, m := range msgs.Messages {
+		if m.Metadata["grpc_event"] != "data" {
+			continue
+		}
+		if m.BodyDecoded != "" {
+			t.Errorf("BodyDecoded should be empty for zero-length body, got %q", m.BodyDecoded)
+		}
+		if m.BodyEncodingApplied != "" {
+			t.Errorf("BodyEncodingApplied should be empty for zero-length body, got %q", m.BodyEncodingApplied)
+		}
+		if m.BodyDecodeAnomaly != nil {
+			t.Errorf("no anomaly expected for empty body, got %+v", m.BodyDecodeAnomaly)
+		}
+	}
+}
+
+// TestQueryMessages_GRPCData_BodyMaxBytes_CapsDecoded asserts the
+// body_max_bytes cap fires on body_decoded independently of the wire-form
+// body and records body_decoded_original_size.
+func TestQueryMessages_GRPCData_BodyMaxBytes_CapsDecoded(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	seedGRPCDataFlow(t, store, "g5", protoBytesHi, nil)
+
+	// 10 bytes — well below the JSON output length, which includes the
+	// key, whitespace, and value.
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g5", BodyMaxBytes: 10})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	var dataEntry *queryMessageEntry
+	for i := range msgs.Messages {
+		if msgs.Messages[i].Metadata["grpc_event"] == "data" {
+			dataEntry = &msgs.Messages[i]
+			break
+		}
+	}
+	if dataEntry == nil {
+		t.Fatal("no data envelope in messages list")
+	}
+	if !dataEntry.BodyTruncatedByQuery {
+		t.Errorf("BodyTruncatedByQuery should be true when decoded body exceeds cap")
+	}
+	if dataEntry.BodyDecodedOriginalSize == 0 {
+		t.Errorf("BodyDecodedOriginalSize should record pre-cap length, got 0")
+	}
+}
+
+// TestQueryMessages_GRPCStart_NoDecoded asserts only Data envelopes get
+// the schemaless projection; Start envelopes (grpc_event="start") leave
+// the additive fields empty.
+func TestQueryMessages_GRPCStart_NoDecoded(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	seedGRPCDataFlow(t, store, "g6", protoBytesHi, nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g6"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	for _, m := range msgs.Messages {
+		if m.Metadata["grpc_event"] == "start" {
+			if m.BodyDecoded != "" {
+				t.Errorf("Start envelope must not get body_decoded, got %q", m.BodyDecoded)
+			}
+			if m.BodyEncodingApplied != "" {
+				t.Errorf("Start envelope must not get body_encoding_applied, got %q", m.BodyEncodingApplied)
+			}
+		}
+	}
+}
+
+// TestQueryFlow_GRPCData_BodyDecoded_UnaryProjection covers the
+// projectFlowSide path: a single unary gRPC flow's response body should
+// surface as response_body_decoded.
+func TestQueryFlow_GRPCData_BodyDecoded_UnaryProjection(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	// Reuse the seed helper but treat the data envelope as the receive
+	// flow for a unary RPC. The send flow (above) projects as the request
+	// side; the data flow projects as the response side.
+	seedGRPCDataFlow(t, store, "g7", protoBytesHi, nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "flow", ID: "g7"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var fq queryFlowResult
+	unmarshalQueryResult(t, result, &fq)
+
+	if fq.ResponseBodyDecoded == "" {
+		t.Fatalf("ResponseBodyDecoded empty; want proto JSON projection")
+	}
+	if fq.ResponseBodyDecodedEncoding != "proto-schemaless-json" {
+		t.Errorf("ResponseBodyDecodedEncoding = %q, want proto-schemaless-json", fq.ResponseBodyDecodedEncoding)
+	}
+	if fq.ResponseBodyEncodingApplied != "proto-schemaless" {
+		t.Errorf("ResponseBodyEncodingApplied = %q, want proto-schemaless", fq.ResponseBodyEncodingApplied)
+	}
+	if !strings.Contains(fq.ResponseBodyDecoded, "0001:0000:String") {
+		t.Errorf("ResponseBodyDecoded missing schemaless field key: %q", fq.ResponseBodyDecoded)
+	}
+}
+
+// TestQueryMessages_GRPCWeb_BodyDecoded_AutomaticDispatch asserts gRPC-Web
+// Data envelopes route through the same dispatcher — record_step writes
+// grpc_event=data for gRPC-Web too (RFC-001 §3.2.3 — gRPC-Web emits
+// GRPCDataMessage). The query-side dispatch keys on metadata, not on
+// Stream.Protocol, so the gRPC-Web stream gets the same proto-schemaless
+// projection automatically.
+func TestQueryMessages_GRPCWeb_BodyDecoded_AutomaticDispatch(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	ctx := context.Background()
+	stream := &flow.Stream{
+		ID:        "gw1",
+		ConnID:    "conn-gw1",
+		Protocol:  "grpc-web",
+		State:     "complete",
+		Timestamp: time.Now().UTC(),
+	}
+	if err := store.SaveStream(ctx, stream); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+	data := &flow.Flow{
+		ID:        "gw1-data",
+		StreamID:  "gw1",
+		Sequence:  0,
+		Direction: "receive",
+		Timestamp: time.Now().UTC(),
+		Body:      protoBytesHi,
+		Metadata:  map[string]string{"grpc_event": "data"},
+	}
+	if err := store.SaveFlow(ctx, data); err != nil {
+		t.Fatalf("SaveFlow: %v", err)
+	}
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "gw1"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	if len(msgs.Messages) == 0 {
+		t.Fatal("no messages returned")
+	}
+	entry := msgs.Messages[0]
+	if entry.BodyDecoded == "" {
+		t.Fatalf("BodyDecoded empty on gRPC-Web Data envelope: %+v", entry)
+	}
+	if entry.BodyDecodedEncoding != "proto-schemaless-json" {
+		t.Errorf("BodyDecodedEncoding = %q, want proto-schemaless-json", entry.BodyDecodedEncoding)
+	}
+	if entry.BodyEncodingApplied != "proto-schemaless" {
+		t.Errorf("BodyEncodingApplied = %q, want proto-schemaless", entry.BodyEncodingApplied)
+	}
+}
+
+// TestQueryMessages_GRPCData_OutputFilter_MasksDecoded is the security
+// regression: PII inside the decoded JSON must be masked before the
+// response leaves the MCP transport boundary. Mirrors the gzip-equivalent
+// test for the HTTP path.
+func TestQueryMessages_GRPCData_OutputFilter_MasksDecoded(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+
+	engine, err := safety.NewEngine(safety.Config{
+		OutputRules: []safety.RuleConfig{
+			{
+				Preset:      safety.PresetCreditCard,
+				Action:      "mask",
+				Targets:     []string{"body"},
+				Replacement: "[CC_REDACTED]",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("safety.NewEngine: %v", err)
+	}
+
+	ctx := context.Background()
+	s := newServer(ctx, nil, store, nil, WithSafetyEngine(engine))
+	ct, st := gomcp.NewInMemoryTransports()
+	ss, err := s.server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { ss.Close() })
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "grpc-pii", Version: "v0"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	seedGRPCDataFlow(t, store, "g8", protoBytesSecret(t), nil)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: "g8"})
+	if result.IsError {
+		t.Fatalf("query error: %v", result.Content)
+	}
+	var msgs queryMessagesResult
+	unmarshalQueryResult(t, result, &msgs)
+
+	var dataEntry *queryMessageEntry
+	for i := range msgs.Messages {
+		if msgs.Messages[i].Metadata["grpc_event"] == "data" {
+			dataEntry = &msgs.Messages[i]
+			break
+		}
+	}
+	if dataEntry == nil {
+		t.Fatal("no data envelope in messages list")
+	}
+	if strings.Contains(dataEntry.BodyDecoded, "4111111111111111") {
+		t.Errorf("Output Filter did not mask credit card in decoded body: %q", dataEntry.BodyDecoded)
+	}
+	if !strings.Contains(dataEntry.BodyDecoded, "[CC_REDACTED]") {
+		t.Errorf("expected mask token in decoded body; got %q", dataEntry.BodyDecoded)
+	}
+}

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -17,6 +17,7 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/bodydecode"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
@@ -1020,6 +1021,75 @@ func (s *Server) computeDecodedBodyWithLimit(rawBody []byte, headers map[string]
 	return out, 0
 }
 
+// isGRPCDataMessage reports whether the flow's metadata identifies it as a
+// gRPC DATA envelope. Detection mirrors projectGRPCData in
+// internal/pipeline/record_step.go which stamps grpc_event=data on every
+// GRPCDataMessage flow. GRPCStart (headers) and GRPCEnd (trailers) carry
+// different grpc_event values and are intentionally excluded — only Data
+// envelopes hold proto wire bytes worth decoding into a schemaless JSON
+// projection (USK-922).
+func isGRPCDataMessage(metadata map[string]string) bool {
+	if metadata == nil {
+		return false
+	}
+	return metadata["grpc_event"] == "data"
+}
+
+// computeDecodedGRPCBodyWithLimit decodes a gRPC Data envelope's stored
+// payload as schemaless proto JSON (PacketProxy-style; see
+// internal/encoding/protobuf for the codec). rawBody is the L7 payload —
+// already decompressed and LPM-stripped at record time by
+// projectGRPCData (record_step.go writes fl.Body = m.Payload). Do NOT pass
+// Envelope.Raw / Flow.RawBytes here; those hold the wire-form LPM frame.
+//
+// On success, the decoded JSON is masked via Output Filter (RFC-001 §3.7),
+// independently capped against body_max_bytes (Q15 — gzip-style amplification
+// is impossible here but the cap still applies for token budgeting), and
+// returned with BodyEncoding="proto-schemaless-json" (the decoded JSON axis
+// surfaced as body_decoded_encoding) and Applied="proto-schemaless" (the
+// codec-name axis surfaced as body_encoding_applied; mirrors HTTP
+// "gzip"/"br").
+//
+// On decode failure, the wire-form body is preserved (callers populate Body
+// from rawBody separately) and the view surfaces
+// queryDecodeAnomaly{Type:"proto_malformed"}.
+func (s *Server) computeDecodedGRPCBodyWithLimit(rawBody []byte, decodeEnabled bool, max int) (view decodedBodyView, originalSize int) {
+	if !decodeEnabled || len(rawBody) == 0 {
+		return decodedBodyView{}, 0
+	}
+	jsonStr, err := protobuf.Decode(rawBody)
+	if err != nil {
+		return decodedBodyView{
+			Anomaly: &queryDecodeAnomaly{Type: "proto_malformed", Detail: err.Error()},
+		}, 0
+	}
+	masked := s.filterOutputBody([]byte(jsonStr))
+	preSize := len(masked)
+	capped, fired := limitBodyBytes(masked, max)
+	out := decodedBodyView{
+		Body:         string(capped),
+		BodyEncoding: "proto-schemaless-json",
+		Applied:      "proto-schemaless",
+	}
+	if fired {
+		return out, preSize
+	}
+	return out, 0
+}
+
+// computeDecodedBodyForMessage dispatches between the HTTP Content-Encoding
+// path (computeDecodedBodyWithLimit) and the gRPC schemaless-proto path
+// (computeDecodedGRPCBodyWithLimit) based on per-flow metadata. The gRPC
+// branch fires for flows tagged grpc_event=data — i.e. native gRPC Data
+// envelopes AND gRPC-Web Data envelopes (RFC-001 §3.2.3: gRPC-Web emits
+// GRPCDataMessage via the same record_step path).
+func (s *Server) computeDecodedBodyForMessage(rawBody []byte, headers map[string][]string, metadata map[string]string, decodeEnabled, truncated bool, max int) (view decodedBodyView, originalSize int) {
+	if isGRPCDataMessage(metadata) {
+		return s.computeDecodedGRPCBodyWithLimit(rawBody, decodeEnabled, max)
+	}
+	return s.computeDecodedBodyWithLimit(rawBody, headers, decodeEnabled, truncated, max)
+}
+
 // resolveDecodeBodies returns the effective value of the decode_bodies query
 // input flag, applying its default of true when omitted.
 func resolveDecodeBodies(input queryInput) bool {
@@ -1101,7 +1171,7 @@ func (s *Server) buildOriginalRequest(originalMsg *flow.Flow, decodeEnabled bool
 	origBodyStr, origBodyEnc := encodeBody(capped)
 	v.Body = origBodyStr
 	v.BodyEncoding = origBodyEnc
-	dec, _ := s.computeDecodedBodyWithLimit(originalMsg.Body, originalMsg.Headers, decodeEnabled, originalMsg.BodyTruncated, limit.bodyMaxBytes)
+	dec, _ := s.computeDecodedBodyForMessage(originalMsg.Body, originalMsg.Headers, originalMsg.Metadata, decodeEnabled, originalMsg.BodyTruncated, limit.bodyMaxBytes)
 	v.BodyDecoded = dec.Body
 	v.BodyDecodedEncoding = dec.BodyEncoding
 	v.BodyEncodingApplied = dec.Applied
@@ -1129,7 +1199,7 @@ func (s *Server) buildOriginalResponse(originalMsg *flow.Flow, decodeEnabled boo
 	origBodyStr, origBodyEnc := encodeBody(capped)
 	v.Body = origBodyStr
 	v.BodyEncoding = origBodyEnc
-	dec, _ := s.computeDecodedBodyWithLimit(originalMsg.Body, originalMsg.Headers, decodeEnabled, originalMsg.BodyTruncated, limit.bodyMaxBytes)
+	dec, _ := s.computeDecodedBodyForMessage(originalMsg.Body, originalMsg.Headers, originalMsg.Metadata, decodeEnabled, originalMsg.BodyTruncated, limit.bodyMaxBytes)
 	v.BodyDecoded = dec.Body
 	v.BodyDecodedEncoding = dec.BodyEncoding
 	v.BodyEncodingApplied = dec.Applied
@@ -1307,8 +1377,11 @@ func (s *Server) projectFlowSide(msg *flow.Flow, decodeEnabled bool, limit bodyL
 	}
 	// Decode against the original (pre-mask) body so the codec sees the real
 	// wire bytes — the SafetyFilter on compressed bytes is a no-op today, but
-	// if a future filter mutates them the decoder would fail.
-	dec, decOrig := s.computeDecodedBodyWithLimit(msg.Body, msg.Headers, decodeEnabled, msg.BodyTruncated, limit.bodyMaxBytes)
+	// if a future filter mutates them the decoder would fail. The dispatcher
+	// routes gRPC Data envelopes (msg.Metadata["grpc_event"]=="data") through
+	// the schemaless-proto path (USK-922) and everything else through the
+	// Content-Encoding path.
+	dec, decOrig := s.computeDecodedBodyForMessage(msg.Body, msg.Headers, msg.Metadata, decodeEnabled, msg.BodyTruncated, limit.bodyMaxBytes)
 	out.decoded = dec
 	if decOrig > 0 {
 		out.queryTruncated = true
@@ -1458,9 +1531,11 @@ func (s *Server) convertMessagesToEntries(msgs []*flow.Flow, decodeEnabled bool,
 			entry.BodyEncoding = bodyEnc
 			// Only decode the L7-parsed Body. RawBytes are wire bytes and must
 			// not be reinterpreted (Content-Encoding decoding presumes the
-			// parser has already extracted the L7 payload).
+			// parser has already extracted the L7 payload). gRPC Data envelopes
+			// route through computeDecodedBodyForMessage to surface the proto
+			// wire bytes as schemaless JSON (USK-922).
 			if !usedRawBytes {
-				dec, decOriginal := s.computeDecodedBodyWithLimit(msg.Body, msg.Headers, decodeEnabled, msg.BodyTruncated, limit.bodyMaxBytes)
+				dec, decOriginal := s.computeDecodedBodyForMessage(msg.Body, msg.Headers, msg.Metadata, decodeEnabled, msg.BodyTruncated, limit.bodyMaxBytes)
 				entry.BodyDecoded = dec.Body
 				entry.BodyDecodedEncoding = dec.BodyEncoding
 				entry.BodyEncodingApplied = dec.Applied

--- a/internal/mcp/resend_grpc_helpers.go
+++ b/internal/mcp/resend_grpc_helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	httputilpkg "github.com/usk6666/yorishiro-proxy/internal/connector/transport"
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/layer"
@@ -113,14 +114,20 @@ func validateResendGRPCMetadataAndEncoding(input *resendGRPCInput) error {
 }
 
 // validateResendGRPCMessagesShape rejects an empty messages list and any
-// message with an unsupported body_encoding.
+// message with an unsupported body_encoding. The "proto-schemaless-json"
+// value (USK-922) is accepted in addition to "text" and "base64"; the
+// payload is then re-encoded to proto wire bytes via
+// internal/encoding/protobuf in populateResendGRPCMessages.
 func validateResendGRPCMessagesShape(input *resendGRPCInput) error {
 	if len(input.Messages) == 0 {
 		return errors.New("messages must contain at least one element (a gRPC RPC requires at least one DATA frame)")
 	}
 	for i, m := range input.Messages {
-		if m.BodyEncoding != "" && m.BodyEncoding != "text" && m.BodyEncoding != "base64" {
-			return fmt.Errorf("messages[%d]: unsupported body_encoding %q: must be text or base64", i, m.BodyEncoding)
+		switch m.BodyEncoding {
+		case "", "text", "base64", "proto-schemaless-json":
+			// supported
+		default:
+			return fmt.Errorf("messages[%d]: unsupported body_encoding %q: must be text, base64, or proto-schemaless-json", i, m.BodyEncoding)
 		}
 	}
 	return nil
@@ -457,10 +464,16 @@ func resendGRPCCanonicalURL(scheme, authority, service, method string) *url.URL 
 // compressed=true on any message when the resolved Encoding is empty
 // (the Layer's Send path treats Compressed=true with no encoding as
 // passthrough — useful for fuzzing but a footgun for diagnostic resend).
+//
+// USK-922: body_encoding="proto-schemaless-json" routes the payload
+// through internal/encoding/protobuf.Encode to produce the proto wire bytes
+// the gRPC Layer will LPM-frame. The size cap is enforced AFTER encoding so
+// a small JSON input that expands to a huge proto payload still trips the
+// cap (JSON-amplification guard).
 func populateResendGRPCMessages(input *resendGRPCInput, plan *resendGRPCPlan) error {
 	plan.messages = make([]resendGRPCDataPlan, 0, len(input.Messages))
 	for i, m := range input.Messages {
-		decoded, err := decodeBodyEncoded(m.Payload, m.BodyEncoding, fmt.Sprintf("messages[%d].payload", i))
+		decoded, err := decodeResendGRPCPayload(m.Payload, m.BodyEncoding, i)
 		if err != nil {
 			return err
 		}
@@ -476,6 +489,22 @@ func populateResendGRPCMessages(input *resendGRPCInput, plan *resendGRPCPlan) er
 		})
 	}
 	return nil
+}
+
+// decodeResendGRPCPayload converts the per-message payload string to the
+// raw proto bytes the gRPC Layer will LPM-frame. body_encoding "text" and
+// "base64" pass through decodeBodyEncoded; "proto-schemaless-json" re-encodes
+// via internal/encoding/protobuf.Encode so AI agents can mutate proto bodies
+// without hand-computing wire bytes (USK-922).
+func decodeResendGRPCPayload(payload, bodyEncoding string, index int) ([]byte, error) {
+	if bodyEncoding == "proto-schemaless-json" {
+		encoded, err := protobuf.Encode(payload)
+		if err != nil {
+			return nil, fmt.Errorf("messages[%d]: invalid proto-schemaless-json: %w", index, err)
+		}
+		return encoded, nil
+	}
+	return decodeBodyEncoded(payload, bodyEncoding, fmt.Sprintf("messages[%d].payload", index))
 }
 
 // concatResendGRPCPayloads returns the concatenation of every plan

--- a/internal/mcp/resend_grpc_integration_test.go
+++ b/internal/mcp/resend_grpc_integration_test.go
@@ -21,6 +21,7 @@ package mcp
 //         internal/pluginv2/surface.go: ("grpc","on_end") = PhaseSupportNone)
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -667,6 +668,78 @@ func TestResendGRPC_RejectsEmptyMessages(t *testing.T) {
 
 // (Skipped: requires synthesising a non-gRPC Stream row; covered by the
 // equivalent test in resend_http / resend_ws integration suites.)
+
+// ---------------------------------------------------------------------------
+// USK-922 — proto-schemaless-json body_encoding round-trip.
+//
+// The AI agent path:
+//   1. recorded gRPC flow → query messages returns body_decoded as JSON
+//   2. AI mutates the JSON → feeds it back as resend_grpc.messages[]
+//      with body_encoding="proto-schemaless-json"
+//   3. proxy re-encodes via internal/encoding/protobuf.Encode and sends
+//      the resulting proto wire bytes upstream
+// ---------------------------------------------------------------------------
+
+func TestResendGRPC_ProtoSchemalessJSON_RoundTrip(t *testing.T) {
+	cs, _, _, _ := setupResendGRPCSession(t)
+	upstream := &resendGRPCEchoServer{}
+	addr, shutdown := startResendGRPCUpstream(t, upstream)
+	defer shutdown()
+
+	// "hi from resend" is sent via the JSON projection of a single
+	// String field. The Echo server captures the raw payload bytes, so
+	// we verify the upstream received the same proto wire bytes the
+	// standalone Encode would produce.
+	jsonPayload := `{"0001:0000:String":"hi from resend"}`
+
+	callResendGRPC(t, cs, map[string]any{
+		"target_addr": addr,
+		"scheme":      "https",
+		"service":     resendGRPCServiceName,
+		"method":      resendGRPCMethodUnary,
+		"messages": []map[string]any{
+			{"payload": jsonPayload, "body_encoding": "proto-schemaless-json"},
+		},
+		"timeout_ms": 10000,
+	})
+
+	req, _, _, _ := upstream.snapshot()
+	// Verify the upstream observed the exact proto wire bytes — a
+	// single String field with the embedded text.
+	wantBytes := []byte{0x0a, 0x0e, 'h', 'i', ' ', 'f', 'r', 'o', 'm', ' ', 'r', 'e', 's', 'e', 'n', 'd'}
+	if !bytes.Equal(req, wantBytes) {
+		t.Errorf("upstream received wire bytes\n got: %x\nwant: %x", req, wantBytes)
+	}
+}
+
+func TestResendGRPC_ProtoSchemalessJSON_InvalidJSON_SurfacesError(t *testing.T) {
+	cs, _, _, _ := setupResendGRPCSession(t)
+
+	res, _ := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "resend_grpc",
+		Arguments: map[string]any{
+			"target_addr": "127.0.0.1:9999",
+			"scheme":      "https",
+			"service":     "Svc",
+			"method":      "M",
+			"messages": []map[string]any{
+				{"payload": "not-json", "body_encoding": "proto-schemaless-json"},
+			},
+		},
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error for invalid proto-schemaless-json, got %+v", res)
+	}
+	var msg strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*gomcp.TextContent); ok {
+			msg.WriteString(tc.Text)
+		}
+	}
+	if !strings.Contains(msg.String(), "proto-schemaless-json") {
+		t.Errorf("error message must mention proto-schemaless-json, got %q", msg.String())
+	}
+}
 
 // status import keeps the linter happy; used implicitly via codes only in
 // this file. The blank assignment defends against the linter dropping it

--- a/internal/mcp/resend_grpc_proto_schemaless_test.go
+++ b/internal/mcp/resend_grpc_proto_schemaless_test.go
@@ -1,0 +1,186 @@
+// Package mcp resend_grpc_proto_schemaless_test.go covers the
+// proto-schemaless-json body_encoding wiring on the resend_grpc tool
+// (USK-922). The unit tier asserts:
+//
+//   - validateResendGRPCMessagesShape accepts "proto-schemaless-json"
+//     alongside "text" and "base64".
+//   - validateResendGRPCMessagesShape continues to reject unknown values
+//     with an explicit allowlist error.
+//   - populateResendGRPCMessages routes the JSON payload through
+//     internal/encoding/protobuf.Encode and recovers the original proto
+//     wire bytes (round-trip).
+//   - Invalid JSON surfaces "messages[i]: invalid proto-schemaless-json: ..."
+//     so the AI agent can correlate the offending message index.
+//   - The size cap is enforced AFTER encoding (a small JSON producing
+//     oversize proto bytes is rejected).
+package mcp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
+)
+
+// TestValidateResendGRPCMessagesShape_AcceptsProtoSchemalessJSON asserts
+// the validator allowlist includes the new encoding.
+func TestValidateResendGRPCMessagesShape_AcceptsProtoSchemalessJSON(t *testing.T) {
+	t.Parallel()
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: `{"0001:0000:String":"hi"}`, BodyEncoding: "proto-schemaless-json"},
+		},
+	}
+	if err := validateResendGRPCMessagesShape(input); err != nil {
+		t.Fatalf("validateResendGRPCMessagesShape: %v", err)
+	}
+}
+
+// TestValidateResendGRPCMessagesShape_RejectsUnknownEncoding pins the
+// allowlist error wording — the error must enumerate the three accepted
+// values so AI agents can self-correct.
+func TestValidateResendGRPCMessagesShape_RejectsUnknownEncoding(t *testing.T) {
+	t.Parallel()
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: "x", BodyEncoding: "json"},
+		},
+	}
+	err := validateResendGRPCMessagesShape(input)
+	if err == nil {
+		t.Fatal("expected error for unknown body_encoding, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "proto-schemaless-json") {
+		t.Errorf("error must enumerate proto-schemaless-json in allowlist: %q", msg)
+	}
+	if !strings.Contains(msg, "text") || !strings.Contains(msg, "base64") {
+		t.Errorf("error must enumerate text and base64 in allowlist: %q", msg)
+	}
+}
+
+// TestPopulateResendGRPCMessages_ProtoSchemalessJSON_Roundtrip asserts the
+// happy-path: a valid JSON payload round-trips to the same proto wire
+// bytes the standalone protobuf.Encode would emit.
+func TestPopulateResendGRPCMessages_ProtoSchemalessJSON_Roundtrip(t *testing.T) {
+	t.Parallel()
+	payload := `{"0001:0000:String":"hi from resend"}`
+	wantBytes, err := protobuf.Encode(payload)
+	if err != nil {
+		t.Fatalf("standalone protobuf.Encode: %v", err)
+	}
+
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: payload, BodyEncoding: "proto-schemaless-json"},
+		},
+	}
+	plan := &resendGRPCPlan{}
+	if err := populateResendGRPCMessages(input, plan); err != nil {
+		t.Fatalf("populateResendGRPCMessages: %v", err)
+	}
+	if len(plan.messages) != 1 {
+		t.Fatalf("plan.messages len = %d, want 1", len(plan.messages))
+	}
+	if !bytes.Equal(plan.messages[0].payload, wantBytes) {
+		t.Errorf("encoded payload diverges from protobuf.Encode\n got: %x\nwant: %x",
+			plan.messages[0].payload, wantBytes)
+	}
+}
+
+// TestPopulateResendGRPCMessages_ProtoSchemalessJSON_InvalidJSON asserts
+// invalid JSON surfaces the standard error shape so AI agents can correlate
+// the failure to a specific message index.
+func TestPopulateResendGRPCMessages_ProtoSchemalessJSON_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: "not-a-json", BodyEncoding: "proto-schemaless-json"},
+		},
+	}
+	plan := &resendGRPCPlan{}
+	err := populateResendGRPCMessages(input, plan)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "messages[0]:") {
+		t.Errorf("error must reference messages[0] index, got: %q", msg)
+	}
+	if !strings.Contains(msg, "invalid proto-schemaless-json") {
+		t.Errorf("error must mention invalid proto-schemaless-json, got: %q", msg)
+	}
+}
+
+// TestPopulateResendGRPCMessages_ProtoSchemalessJSON_SizeCapEnforced
+// asserts the maxResendGRPCPayload cap fires on the POST-encode byte
+// length (JSON-amplification guard). A JSON payload that encodes to
+// exactly maxResendGRPCPayload+1 must be rejected.
+func TestPopulateResendGRPCMessages_ProtoSchemalessJSON_SizeCapEnforced(t *testing.T) {
+	t.Parallel()
+	// Build a String field whose value byte length pushes the encoded
+	// proto size past the cap by 1. Tag byte 0x0a + varint length + value
+	// bytes, where the varint length itself takes 4 bytes for a value
+	// near 16 MiB. We make the inner string len = maxResendGRPCPayload
+	// so the total wire size is len + varint(len) + 1 > cap.
+	const valueLen = maxResendGRPCPayload
+	bigValue := strings.Repeat("A", valueLen)
+	payload := `{"0001:0000:String":"` + bigValue + `"}`
+
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: payload, BodyEncoding: "proto-schemaless-json"},
+		},
+	}
+	plan := &resendGRPCPlan{}
+	err := populateResendGRPCMessages(input, plan)
+	if err == nil {
+		t.Fatal("expected payload-too-large error, got nil")
+	}
+	if !strings.Contains(err.Error(), "payload too large") {
+		t.Errorf("error must mention payload too large, got: %q", err.Error())
+	}
+}
+
+// TestPopulateResendGRPCMessages_ProtoSchemalessJSON_RequiresEncodingForCompressed
+// asserts the compressed=true precondition still applies to the new
+// encoding path.
+func TestPopulateResendGRPCMessages_ProtoSchemalessJSON_RequiresEncodingForCompressed(t *testing.T) {
+	t.Parallel()
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{
+				Payload:      `{"0001:0000:String":"hi"}`,
+				BodyEncoding: "proto-schemaless-json",
+				Compressed:   true,
+			},
+		},
+	}
+	plan := &resendGRPCPlan{}
+	err := populateResendGRPCMessages(input, plan)
+	if err == nil {
+		t.Fatal("expected error for compressed=true without encoding, got nil")
+	}
+	if !strings.Contains(err.Error(), "compressed=true requires encoding") {
+		t.Errorf("error must mention encoding requirement, got: %q", err.Error())
+	}
+}
+
+// TestPopulateResendGRPCMessages_TextEncoding_StillWorks regression guard:
+// the new dispatch must not break the text/base64 paths.
+func TestPopulateResendGRPCMessages_TextEncoding_StillWorks(t *testing.T) {
+	t.Parallel()
+	input := &resendGRPCInput{
+		Messages: []resendGRPCData{
+			{Payload: "hello", BodyEncoding: "text"},
+		},
+	}
+	plan := &resendGRPCPlan{}
+	if err := populateResendGRPCMessages(input, plan); err != nil {
+		t.Fatalf("populateResendGRPCMessages: %v", err)
+	}
+	if string(plan.messages[0].payload) != "hello" {
+		t.Errorf("text passthrough broken: got %q", plan.messages[0].payload)
+	}
+}

--- a/internal/mcp/resources/help_query.md
+++ b/internal/mcp/resources/help_query.md
@@ -48,9 +48,16 @@ Maximum number of items to return. Default: 50, max: 1000. Applies to `flows`, `
 Number of items to skip for pagination. Must be >= 0. Applies to `flows`, `messages`, `fuzz_jobs`, and `fuzz_results`.
 
 ### decode_bodies (boolean, optional, default `true`)
-Decode HTTP `Content-Encoding` (`gzip`, `deflate`, `br`, `zstd`) bodies in `flow` and `messages` responses. When `true`, additive `*_body_decoded` / `*_body_encoding_applied` fields are populated alongside the original wire-form `*_body` fields. Set to `false` to skip decompression.
+Decode protocol-specific bodies in `flow` and `messages` responses. When `true`, additive `*_body_decoded` / `*_body_encoding_applied` fields are populated alongside the original wire-form `*_body` fields. Set to `false` to skip all decoding.
 
-The original (compressed) body is always returned in `*_body` regardless of this flag, preserving wire fidelity for downstream tools and `resend_*`. Decode failures (unknown codec, malformed input, decoded size > 16 MiB cap, multi-codec chain) surface a `*_body_decode_anomaly` field; the wire-form body is left intact.
+Two decode paths are supported:
+
+- **HTTP `Content-Encoding`** (`gzip`, `deflate`, `br`, `zstd`): the wire-form body is decompressed into `*_body_decoded` with `*_body_decoded_encoding` set to `text` or `base64`, and `*_body_encoding_applied` set to the codec name (e.g. `gzip`).
+- **gRPC schemaless proto** (USK-922): gRPC Data envelopes (`metadata.grpc_event="data"`) — including gRPC and gRPC-Web — get a schemaless JSON projection of the proto wire payload via `internal/encoding/protobuf.Decode`. `*_body_decoded` contains JSON with sorted keys formatted as `"<fieldNumber hex>:<ordinal hex>:<wireType>"` (e.g. `"0001:0000:String"`, `"0002:0001:Varint"`, `"0003:0002:embedded message"`). `*_body_decoded_encoding="proto-schemaless-json"`. `*_body_encoding_applied="proto-schemaless"`. The same JSON shape is accepted back by `resend_grpc` (`body_encoding="proto-schemaless-json"`) for round-trip mutation without hand-computing wire bytes.
+
+The original wire-form body is always returned in `*_body` regardless of this flag, preserving wire fidelity for downstream tools and `resend_*`. Decode failures surface a `*_body_decode_anomaly` field; the wire-form body is left intact. Anomaly types include `unknown_encoding`, `malformed`, `size_exceeded`, `chain_rejected`, `truncated_decode` (HTTP path) and `proto_malformed` (gRPC path).
+
+> **Schemaless gRPC heuristic ambiguity**: the proto wire format encodes embedded messages, packed-repeated varints, and raw bytes with the same wire type (length-delimited). The decoder picks one interpretation heuristically (printable UTF-8 → `String`; otherwise embedded → repeated → bytes); ambiguous payloads may surface as the wrong type. Schema-aware decoding via a `.proto` registry is tracked in USK-923. Use the raw wire bytes (`body` with `body_encoding="base64"`) when the schemaless projection is ambiguous.
 
 ### include_bodies (boolean, optional, default `true`)
 Include message body fields in the `flow` and `messages` responses. Set to `false` to suppress every body field (`*_body`, `*_body_encoding`, `*_body_decoded*`, `raw_request`, `raw_response`) and return metadata only. Headers, status, method, URL, timestamps, and the record-time `*_body_truncated` flag are preserved.
@@ -100,7 +107,7 @@ Requires: `id` (flow ID).
 
 Returns: id, conn_id, protocol, state, method, url, request/response headers and bodies, raw bytes (base64), connection info, protocol_summary, message_preview (for streaming), original_request (for variant flows), timestamps.
 
-When `decode_bodies` is `true` (the default) and the body has a recognised `Content-Encoding`, the response also includes `request_body_decoded` / `response_body_decoded` (plaintext after Output Filter masking), `request_body_decoded_encoding` / `response_body_decoded_encoding` (`text` or `base64`), `request_body_encoding_applied` / `response_body_encoding_applied` (codec name, e.g. `gzip`). On decode failure, `request_body_decode_anomaly` / `response_body_decode_anomaly` carry `{type, detail}` (`unknown_encoding`, `malformed`, `size_exceeded`, `chain_rejected`, `truncated_decode`).
+When `decode_bodies` is `true` (the default) and the body is decodable, the response also includes `request_body_decoded` / `response_body_decoded` (plaintext / proto-schemaless JSON after Output Filter masking), `request_body_decoded_encoding` / `response_body_decoded_encoding` (`text`, `base64`, or `proto-schemaless-json`), and `request_body_encoding_applied` / `response_body_encoding_applied` (codec name — `gzip` / `br` / `deflate` / `zstd` for HTTP `Content-Encoding`, or `proto-schemaless` for gRPC Data envelopes). On decode failure, `request_body_decode_anomaly` / `response_body_decode_anomaly` carry `{type, detail}`: HTTP path uses `unknown_encoding`, `malformed`, `size_exceeded`, `chain_rejected`, `truncated_decode`; gRPC path uses `proto_malformed`.
 
 ### messages
 Get paginated messages within a flow. Supports direction filtering for streaming protocols.

--- a/internal/mcp/resources/help_resend_grpc.md
+++ b/internal/mcp/resources/help_resend_grpc.md
@@ -56,10 +56,18 @@ Ordered metadata list. Preserves wire case, order, and duplicates per RFC-001 §
 ### messages (array, optional)
 Request-side LPM (length-prefixed message) list. At least one element required. Each element has:
 - **payload** (string, REQUIRED): LPM payload interpreted per `body_encoding`.
-- **body_encoding** (string, optional): `"text"` (default) or `"base64"`.
+- **body_encoding** (string, optional): `"text"` (default), `"base64"`, or `"proto-schemaless-json"`.
 - **compressed** (boolean, optional): Set the LPM compression flag. Requires `encoding` to be set (recovered from flow or user-supplied).
 
 An RPC with zero DATA frames is not well-formed and is rejected.
+
+#### body_encoding values
+
+- `"text"` (default): the payload is the raw proto bytes as UTF-8 (may contain control characters and is rarely human-readable).
+- `"base64"`: the payload is base64-encoded raw proto bytes. Useful when copying `body` from `query messages` for a gRPC flow that came back as `body_encoding="base64"`.
+- `"proto-schemaless-json"` (USK-922): the payload is a JSON object produced by `query.decode_bodies=true` (or hand-written following the same key format). The proxy re-encodes it to proto wire bytes via `internal/encoding/protobuf.Encode` before LPM-framing. JSON keys follow the format `"<fieldNumber hex>:<ordinal hex>:<wireType>"` — for example `"0001:0000:String"`, `"0002:0001:Varint"`, `"0003:0002:embedded message"`, `"0004:0003:repeated"`, `"0005:0004:bytes"`, `"0006:0005:64-bit"`, `"0007:0006:32-bit"`. Embedded messages are nested JSON objects; repeated is a JSON array of integers; bytes is a colon-separated hex string. The size cap (16 MiB) is enforced AFTER encoding, not on the JSON input.
+
+> **Heuristic ambiguity caveat**: the schemaless decoder picks `String` / `embedded message` / `repeated` / `bytes` by inspection of the wire bytes — there is no `.proto` schema. The same wire payload may decode as `embedded message` in one envelope and `bytes` in another (visually similar wire encodings). For predictable round-tripping, keep the `body_encoding="base64"` form of the bytes that came out of `query` and only switch to `proto-schemaless-json` when you intend to mutate the JSON. Schema-aware decoding via a `.proto` registry is tracked in USK-923.
 
 ### trailer_metadata (array of `{name, value}`, optional)
 Optional Send-direction trailer HEADERS. When supplied, the request terminates via a trailer frame instead of `END_STREAM` on the last DATA.
@@ -134,6 +142,20 @@ Tag stored on the new flow's `Tags` map.
   "accept_encoding": ["gzip", "identity"],
   "messages": [
     {"payload": "H4sI...", "body_encoding": "base64", "compressed": true}
+  ]
+}
+```
+
+### Replay with a schemaless-proto JSON payload (USK-922)
+Feeding the same JSON shape that `query.decode_bodies=true` returns under `*_body_decoded`. The proxy re-encodes via `internal/encoding/protobuf.Encode` before LPM-framing.
+```json
+{
+  "flow_id": "grpc-abc-123",
+  "messages": [
+    {
+      "payload": "{\"0001:0000:String\":\"hi from resend\"}",
+      "body_encoding": "proto-schemaless-json"
+    }
   ]
 }
 ```

--- a/internal/mcp/resources/schema_resend_grpc.json
+++ b/internal/mcp/resources/schema_resend_grpc.json
@@ -56,7 +56,11 @@
         "required": ["payload"],
         "properties": {
           "payload": { "type": "string", "description": "LPM payload interpreted per body_encoding." },
-          "body_encoding": { "type": "string", "enum": ["text", "base64"] },
+          "body_encoding": {
+            "type": "string",
+            "description": "text (default) | base64 | proto-schemaless-json. proto-schemaless-json re-encodes via internal/encoding/protobuf (USK-922).",
+            "enum": ["text", "base64", "proto-schemaless-json"]
+          },
           "compressed": { "type": "boolean", "description": "Set the LPM compression flag; requires encoding to be set." }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary
- Wire `internal/encoding/protobuf` (existing, unused) into MCP `query` and `resend_grpc` for gRPC bodies — the package's first production use.
- `query messages` / `query flow` now surface `body_decoded` as schemaless proto JSON for gRPC Data envelopes when `decode_bodies=true` (default). Encoding axes: `body_decoded_encoding=proto-schemaless-json`, `body_encoding_applied=proto-schemaless`. Failures: `body_decode_anomaly{Type=proto_malformed}`.
- `resend_grpc` accepts `body_encoding=proto-schemaless-json` per-message; the proxy re-encodes via `protobuf.Encode` to proto bytes before LPM framing. AI agents can mutate proto bodies without hand-computing wire bytes.
- Output Filter (PII masking) applies to `body_decoded`; `body_max_bytes` independently caps decoded JSON. Resend-side size cap is enforced AFTER encoding (JSON-amplification guard).
- gRPC-Web is covered query-side automatically via `metadata.grpc_event="data"` (RFC-001 §3.2.3). Resend stays native-gRPC-only — no `resend_grpc_web` tool exists.
- Help docs (`help_query.md`, `help_resend_grpc.md`) describe the encoding axes, key format `"<fieldNumber hex>:<ordinal hex>:<wireType>"`, and the schemaless heuristic-ambiguity caveat. `schema_resend_grpc.json` enum extended.
- USK-923 forward-pointer left for schema-aware (.proto-registry) decode.

## Test plan
- [x] `make lint` clean
- [x] `make build` succeeds
- [x] `make test` passes (8 new unit tests in `query_decode_body_grpc_test.go` covering happy path, `decode_bodies=false` suppression, `proto_malformed` anomaly, empty body, `body_max_bytes` cap, Start-envelope exclusion, unary `projectFlowSide`, gRPC-Web dispatch, Output Filter masking; 6 unit tests in `resend_grpc_proto_schemaless_test.go` covering validator allowlist, error wording, round-trip via `protobuf.Encode`, invalid-JSON error shape, post-encode size cap, compressed precondition, text-encoding regression)
- [x] `make test-e2e-smoke` passes (no smoke-tier additions)
- [x] e2e exhaustive: 2 new integration tests in `resend_grpc_integration_test.go` — `TestResendGRPC_ProtoSchemalessJSON_RoundTrip` (JSON payload → upstream observes exact proto wire bytes) and `TestResendGRPC_ProtoSchemalessJSON_InvalidJSON_SurfacesError`. Both pass under `-tags e2e`.

Resolves USK-922
Linear: https://linear.app/usk6666/issue/USK-922

🤖 Generated with [Claude Code](https://claude.com/claude-code)