### PR TITLE
fix(mcp,grpc): recover authority/service/method for listener-captured gRPC flows (USK-920)

### DIFF
--- a/docs/rfc/envelope.md
+++ b/docs/rfc/envelope.md
@@ -233,6 +233,16 @@ type GRPCStartMessage struct {
     Service string
     Method  string
 
+    // USK-920: the request-side pseudo-headers (:authority, :scheme,
+    // :path) are projected as derived L7 fields so RecordStep can build
+    // Flow.URL the same way it does for HTTPMessage. Empty on the
+    // response side (response HEADERS only carry :status). The pseudo-
+    // header wire bytes remain in Envelope.Raw — these fields are an
+    // overlay, not a replacement.
+    Authority string
+    Scheme    string
+    Path      string
+
     // gRPC metadata — custom and reserved. HTTP/2 pseudo-headers (:method,
     // :path, :status, etc.) are NOT included here; they belong to the
     // transport layer and are observable via Envelope.Context if needed.

--- a/internal/envelope/grpc.go
+++ b/internal/envelope/grpc.go
@@ -8,6 +8,14 @@ import "time"
 // One GRPCStartMessage envelope is emitted for the request side
 // (Direction=Send, Sequence=0) and one for the response side
 // (Direction=Receive, Sequence=0). Both share the RPC's Envelope.StreamID.
+//
+// USK-920: Authority / Scheme / Path are projected out of the HTTP/2
+// pseudo-headers on the request side so downstream consumers (notably
+// RecordStep → Flow.URL) can reconstruct the RPC's URL without re-parsing
+// the wire HPACK block. The pseudo-header wire bytes remain in
+// Envelope.Raw (untouched); these fields are a derived L7 overlay,
+// matching the existing HTTPMessage.Authority / Scheme / Path pattern.
+// Empty on the response side (response HEADERS only carry :status).
 type GRPCStartMessage struct {
 	// Service is the gRPC service name (derived from :path on the request
 	// side and mirrored on the response side).
@@ -15,6 +23,22 @@ type GRPCStartMessage struct {
 
 	// Method is the gRPC method name.
 	Method string
+
+	// Authority is the :authority pseudo-header from the request-side
+	// HEADERS frame. Empty on the response side. USK-920.
+	Authority string
+
+	// Scheme is the :scheme pseudo-header from the request-side HEADERS
+	// frame ("http" for h2c, "https" for TLS+ALPN h2). Empty on the
+	// response side. USK-920.
+	Scheme string
+
+	// Path is the :path pseudo-header from the request-side HEADERS
+	// frame ("/Service/Method"). Empty on the response side. USK-920.
+	// Service / Method are also parsed out individually; Path is retained
+	// verbatim so a malformed :path (which yields Service="" Method="")
+	// still leaves an inspectable trace.
+	Path string
 
 	// Metadata is the full gRPC metadata list. HTTP/2 pseudo-headers are
 	// NOT included here — they belong to the transport layer and are
@@ -53,6 +77,9 @@ func (m *GRPCStartMessage) CloneMessage() Message {
 	return &GRPCStartMessage{
 		Service:        m.Service,
 		Method:         m.Method,
+		Authority:      m.Authority,
+		Scheme:         m.Scheme,
+		Path:           m.Path,
 		Metadata:       cloneKeyValues(m.Metadata),
 		Timeout:        m.Timeout,
 		ContentType:    m.ContentType,

--- a/internal/layer/grpc/channel.go
+++ b/internal/layer/grpc/channel.go
@@ -1064,7 +1064,16 @@ func buildStartMessage(evt *http2.H2HeadersEvent, dir envelope.Direction) (*enve
 	// Service / Method on the request side derive from :path; on the
 	// response side they are mirrored from the request side by the
 	// channel.absorbHeaders caller (the response carries no :path).
+	//
+	// USK-920: also surface the request-side pseudo-headers (:authority /
+	// :scheme / :path) as derived L7 fields so RecordStep can project
+	// Flow.URL the same way it does for HTTPMessage. Response-side
+	// HEADERS frames only carry :status (no authority/scheme/path), so we
+	// leave the fields zero in that case.
 	if dir == envelope.Send {
+		msg.Authority = evt.Authority
+		msg.Scheme = evt.Scheme
+		msg.Path = evt.Path
 		msg.Service, msg.Method = parseGRPCPath(evt.Path)
 	}
 	return msg, msg.Encoding

--- a/internal/mcp/resend_grpc_helpers.go
+++ b/internal/mcp/resend_grpc_helpers.go
@@ -315,7 +315,13 @@ func applyResendGRPCUserStartFields(input *resendGRPCInput, plan *resendGRPCPlan
 // recoverResendGRPCStartFromFlow loads the original RPC's Send / Receive
 // GRPCStart Flows and returns the recovered (authority, scheme,
 // metadata, encoding, accept-encoding) values. Side-effect: fills empty
-// plan.service / plan.method from the recovered URL.Path.
+// plan.service / plan.method from the recovered URL.Path (or Metadata
+// fallback for legacy flows that pre-date USK-920).
+//
+// USK-920: Stream.Scheme is consulted as a secondary scheme source so
+// listener-captured gRPC flows (where the gRPC Layer's GRPCStartMessage
+// did not carry pseudo-headers until USK-920) still resolve to a valid
+// scheme without forcing the operator to pass one in by hand.
 func (s *Server) recoverResendGRPCStartFromFlow(ctx context.Context, flowID string, plan *resendGRPCPlan) (authority, scheme string, meta []envelope.KeyValue, encoding string, accept []string, err error) {
 	stream, sendStart, recvStart, lerr := s.loadResendGRPCFlows(ctx, flowID)
 	if lerr != nil {
@@ -333,6 +339,15 @@ func (s *Server) recoverResendGRPCStartFromFlow(ctx context.Context, flowID stri
 	}
 	authority = recAuthority
 	scheme = recScheme
+	// USK-920: when the recorded Flow's URL did not carry a scheme (legacy
+	// rows pre-dating the pseudo-header projection), fall back to the
+	// stream-level handshake transport. Stream.Scheme is "https" / "http"
+	// / "tcp" per types.go; only the first two are meaningful to gRPC.
+	if scheme == "" && stream.Scheme != "" {
+		if s := strings.ToLower(stream.Scheme); s == "http" || s == "https" {
+			scheme = s
+		}
+	}
 	meta = flowMapToKeyValues(sendStart.Headers)
 	encoding = firstFlowHeaderValue(sendStart.Headers, "Grpc-Encoding")
 	if recvStart != nil {
@@ -367,23 +382,54 @@ func finalizeResendGRPCAuthorityScheme(input *resendGRPCInput, plan *resendGRPCP
 // authority is URL.Host; scheme is URL.Scheme (mapped from h2 vs h2c).
 // Empty-tolerant — any missing field surfaces as "" and the caller's
 // validation requires the user to supply a non-empty override.
+//
+// USK-920: Flow.URL is the primary source (populated by record_step.go
+// projectGRPCStart now that GRPCStartMessage carries the pseudo-headers).
+// For flows recorded before USK-920 (where Flow.URL is nil but the
+// projection wrote grpc_service / grpc_method into Flow.Metadata), the
+// helper falls back to Metadata so already-recorded flows also recover
+// service / method without a manual override. Authority and scheme remain
+// recoverable only via URL — for true legacy rows the caller still needs
+// target_addr / scheme, which is acceptable because the breaking change
+// (listener-captured flows after USK-911~917) lands together with this
+// fix.
 func extractResendGRPCStartFields(f *flow.Flow) (authority, service, method, scheme string) {
-	if f == nil || f.URL == nil {
+	if f == nil {
 		return "", "", "", ""
 	}
-	authority = f.URL.Host
-	scheme = f.URL.Scheme
-	parts := strings.SplitN(strings.TrimPrefix(f.URL.Path, "/"), "/", 2)
-	if len(parts) == 2 {
-		service = parts[0]
-		method = parts[1]
+	if f.URL != nil {
+		authority = f.URL.Host
+		scheme = f.URL.Scheme
+		parts := strings.SplitN(strings.TrimPrefix(f.URL.Path, "/"), "/", 2)
+		if len(parts) == 2 {
+			service = parts[0]
+			method = parts[1]
+		}
+	}
+	// Metadata fallback for legacy flows: projectGRPCStart writes
+	// grpc_service / grpc_method unconditionally (see record_step.go), so
+	// flows recorded before USK-920 still carry the RPC identity even
+	// when the URL projection was missing.
+	if service == "" {
+		service = f.Metadata["grpc_service"]
+	}
+	if method == "" {
+		method = f.Metadata["grpc_method"]
 	}
 	return authority, service, method, scheme
 }
 
-// loadResendGRPCFlows fetches the Stream and the first send / first
-// receive Flows. The receive Flow is allowed to be missing (a request
+// loadResendGRPCFlows fetches the Stream and the Send-side / Receive-side
+// GRPCStart Flows. The Receive Flow is allowed to be missing (a request
 // that never got a response is still resendable).
+//
+// USK-920: the live data path records additional non-Start Flows on the
+// Send direction (h2-frame wire chunks, LPM wire chunks via
+// session.GRPCH2DataFrameRecordOption / GRPCLPMRecordOption), so the first
+// Send Flow returned by the store is NOT guaranteed to be the GRPCStart
+// envelope. We scan for the first Flow whose Metadata["grpc_event"]=="start"
+// and fall back to sendFlows[0] only when no semantic Start flow exists
+// (e.g. an in-process resend that recorded only synthesized envelopes).
 func (s *Server) loadResendGRPCFlows(ctx context.Context, flowID string) (*flow.Stream, *flow.Flow, *flow.Flow, error) {
 	if s.flowStore.store == nil {
 		return nil, nil, nil, errors.New("resend_grpc: flow store is not initialized")
@@ -403,11 +449,31 @@ func (s *Server) loadResendGRPCFlows(ctx context.Context, flowID string) (*flow.
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_grpc: get receive flows %s: %w", flowID, err)
 	}
-	var recvFlow *flow.Flow
-	if len(recvFlows) > 0 {
-		recvFlow = recvFlows[0]
+	return stream, pickGRPCStartFlow(sendFlows), pickGRPCStartFlow(recvFlows), nil
+}
+
+// pickGRPCStartFlow returns the first Flow in flows that the RecordStep
+// projection tagged as the GRPCStart envelope (Metadata["grpc_event"]
+// == "start"). When no such Flow exists, the first Flow is returned so
+// legacy / synthetic streams (which never carried per-event Metadata)
+// keep working. A nil / empty input yields nil.
+//
+// USK-920: the live data path emits additional Send-direction Flows for
+// per-frame wire-byte snapshots (LPM and H2 DATA recording callbacks),
+// so "the first Send Flow" is not equivalent to "the GRPCStart Flow".
+func pickGRPCStartFlow(flows []*flow.Flow) *flow.Flow {
+	if len(flows) == 0 {
+		return nil
 	}
-	return stream, sendFlows[0], recvFlow, nil
+	for _, fl := range flows {
+		if fl == nil || fl.Metadata == nil {
+			continue
+		}
+		if fl.Metadata["grpc_event"] == "start" {
+			return fl
+		}
+	}
+	return flows[0]
 }
 
 // splitAndTrimComma splits on commas and trims whitespace from each

--- a/internal/mcp/resend_grpc_helpers_test.go
+++ b/internal/mcp/resend_grpc_helpers_test.go
@@ -1,0 +1,131 @@
+// Package mcp resend_grpc_helpers_test.go — unit coverage for
+// extractResendGRPCStartFields (USK-920).
+//
+// projectGRPCStart (internal/pipeline/record_step.go) writes grpc_service /
+// grpc_method into Flow.Metadata unconditionally, and after USK-920 also
+// populates Flow.URL from the request-side pseudo-headers. The recovery
+// helper must prefer the URL projection when present and fall back to
+// Metadata for already-recorded flows that pre-date the URL projection.
+package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+)
+
+func TestExtractResendGRPCStartFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		flow          *flow.Flow
+		wantAuthority string
+		wantService   string
+		wantMethod    string
+		wantScheme    string
+	}{
+		{
+			name: "url_only",
+			flow: &flow.Flow{
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "api.example.com:443",
+					Path:   "/hello.HelloService/SayHello",
+				},
+			},
+			wantAuthority: "api.example.com:443",
+			wantService:   "hello.HelloService",
+			wantMethod:    "SayHello",
+			wantScheme:    "https",
+		},
+		{
+			name: "metadata_only_legacy_flow",
+			flow: &flow.Flow{
+				Metadata: map[string]string{
+					"grpc_service": "hello.HelloService",
+					"grpc_method":  "SayHello",
+				},
+			},
+			// Authority/scheme unrecoverable for legacy rows that pre-date
+			// the URL projection — caller must supply target_addr+scheme.
+			wantAuthority: "",
+			wantService:   "hello.HelloService",
+			wantMethod:    "SayHello",
+			wantScheme:    "",
+		},
+		{
+			name: "url_and_metadata_present_url_wins",
+			flow: &flow.Flow{
+				URL: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1:9000",
+					Path:   "/url.Service/UrlMethod",
+				},
+				Metadata: map[string]string{
+					"grpc_service": "metadata.Service",
+					"grpc_method":  "MetadataMethod",
+				},
+			},
+			// URL is authoritative — Metadata only fills in when URL is
+			// missing the field.
+			wantAuthority: "127.0.0.1:9000",
+			wantService:   "url.Service",
+			wantMethod:    "UrlMethod",
+			wantScheme:    "http",
+		},
+		{
+			name: "url_missing_path_metadata_fills_service_method",
+			flow: &flow.Flow{
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "api.example.com",
+				},
+				Metadata: map[string]string{
+					"grpc_service": "hello.HelloService",
+					"grpc_method":  "SayHello",
+				},
+			},
+			wantAuthority: "api.example.com",
+			wantService:   "hello.HelloService",
+			wantMethod:    "SayHello",
+			wantScheme:    "https",
+		},
+		{
+			name:          "neither_url_nor_metadata",
+			flow:          &flow.Flow{},
+			wantAuthority: "",
+			wantService:   "",
+			wantMethod:    "",
+			wantScheme:    "",
+		},
+		{
+			name:          "nil_flow",
+			flow:          nil,
+			wantAuthority: "",
+			wantService:   "",
+			wantMethod:    "",
+			wantScheme:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotAuth, gotSvc, gotMethod, gotScheme := extractResendGRPCStartFields(tc.flow)
+			if gotAuth != tc.wantAuthority {
+				t.Errorf("authority = %q, want %q", gotAuth, tc.wantAuthority)
+			}
+			if gotSvc != tc.wantService {
+				t.Errorf("service = %q, want %q", gotSvc, tc.wantService)
+			}
+			if gotMethod != tc.wantMethod {
+				t.Errorf("method = %q, want %q", gotMethod, tc.wantMethod)
+			}
+			if gotScheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", gotScheme, tc.wantScheme)
+			}
+		})
+	}
+}

--- a/internal/mcp/resend_grpc_listener_capture_integration_test.go
+++ b/internal/mcp/resend_grpc_listener_capture_integration_test.go
@@ -1,0 +1,546 @@
+//go:build e2e && !e2e_smoke
+
+// Package mcp resend_grpc_listener_capture_integration_test.go is the
+// USK-920 acceptance gate: a listener-captured gRPC flow (via
+// proxybuild.Manager + ForwardConfig.Protocol="grpc") must be replayable
+// by resend_grpc using only {flow_id, messages}, with no manual overrides
+// for target_addr / scheme / service / method.
+//
+// USK-922/923 follow-up: the test must also cover the
+// body_encoding ∈ {"base64", "proto-schemaless-json", "proto-json (with
+// schema)", "proto-json (without schema)"} matrix on the recovered
+// listener-captured flow. The no-schema arm asserts the error string
+// includes the recovered service / method so the operator sees the
+// recovered identity rather than empty strings.
+//
+// Tagged `e2e && !e2e_smoke` per CLAUDE.md guidance: it spins up a full
+// proxybuild Manager + grpc-go upstream, so it belongs in the nightly
+// full tier rather than the per-PR merge gate.
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/connector/transport"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/testutil"
+)
+
+// ---------------------------------------------------------------------------
+// Raw codec — round-trips []byte payloads without protobuf marshalling.
+// Re-declared here under a unique name so the codec registration does not
+// collide with the codec(s) registered by sibling integration tests in
+// other packages.
+// ---------------------------------------------------------------------------
+
+const listenerCaptureRawCodecName = "raw_listener_capture"
+
+type listenerCaptureRawCodec struct{}
+
+func (listenerCaptureRawCodec) Name() string { return listenerCaptureRawCodecName }
+
+func (listenerCaptureRawCodec) Marshal(v any) ([]byte, error) {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("listenerCaptureRawCodec: Marshal: want *[]byte, got %T", v)
+	}
+	if b == nil {
+		return nil, nil
+	}
+	out := make([]byte, len(*b))
+	copy(out, *b)
+	return out, nil
+}
+
+func (listenerCaptureRawCodec) Unmarshal(data []byte, v any) error {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("listenerCaptureRawCodec: Unmarshal: want *[]byte, got %T", v)
+	}
+	*b = make([]byte, len(data))
+	copy(*b, data)
+	return nil
+}
+
+func init() {
+	encoding.RegisterCodec(listenerCaptureRawCodec{})
+}
+
+// ---------------------------------------------------------------------------
+// Upstream service — usk.test.Greeter / SayHello, raw-codec.
+//
+// We deliberately use the same service+method names as the protoschema
+// test fixture so the registered FileDescriptorSet (used by the
+// proto-json case) matches the wire :path.
+// ---------------------------------------------------------------------------
+
+const (
+	listenerCaptureServiceName = "usk.test.Greeter"
+	listenerCaptureMethodName  = "SayHello"
+)
+
+type listenerCaptureGreeterServer struct {
+	mu      sync.Mutex
+	lastReq []byte
+	callCnt int
+}
+
+func (g *listenerCaptureGreeterServer) record(req []byte) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lastReq = append([]byte(nil), req...)
+	g.callCnt++
+}
+
+var listenerCaptureGreeterDesc = grpc.ServiceDesc{
+	ServiceName: listenerCaptureServiceName,
+	HandlerType: (*any)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: listenerCaptureMethodName,
+			Handler: func(srv any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				var req []byte
+				if err := dec(&req); err != nil {
+					return nil, err
+				}
+				h := srv.(*listenerCaptureGreeterServer)
+				h.record(req)
+				// Echo bytes back so the client's RecvMsg sees something.
+				resp := append([]byte(nil), req...)
+				return &resp, nil
+			},
+		},
+	},
+	Metadata: listenerCaptureServiceName,
+}
+
+// startH2CGreeterUpstream starts an h2c gRPC server on a random local
+// port. Returns (addr, server-pointer, shutdown).
+func startH2CGreeterUpstream(t *testing.T) (addr string, srv *listenerCaptureGreeterServer, shutdown func()) {
+	t.Helper()
+	srv = &listenerCaptureGreeterServer{}
+	gs := grpc.NewServer(grpc.ForceServerCodec(listenerCaptureRawCodec{}))
+	gs.RegisterService(&listenerCaptureGreeterDesc, srv)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	go func() { _ = gs.Serve(ln) }()
+	return ln.Addr().String(), srv, func() {
+		gs.GracefulStop()
+		_ = ln.Close()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// proxybuild manager wiring — bound to the SQLite store backing the MCP
+// session.
+// ---------------------------------------------------------------------------
+
+// startGRPCForwardListener constructs a proxybuild.Manager wired to
+// `store` and brings up a TCP forward listener with
+// ForwardConfig.Protocol="grpc" targeting `upstreamAddr` (h2c upstream).
+// Returns the manager and the bound forward address.
+func startGRPCForwardListener(t *testing.T, ctx context.Context, store flow.Store, upstreamAddr string) (
+	mgr *proxybuild.Manager, fwdAddr string,
+) {
+	t.Helper()
+	logger := testutil.DiscardLogger()
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca.Generate: %v", err)
+	}
+	buildCfg := &connector.BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             cert.NewIssuer(ca),
+		InsecureSkipVerify: true,
+	}
+	factory := func(ctx context.Context, name, addr string) (*proxybuild.Stack, error) {
+		return proxybuild.BuildLiveStack(ctx, proxybuild.Deps{
+			Logger:       logger,
+			ListenerName: name,
+			ListenAddr:   addr,
+			FlowStore:    store,
+			BuildConfig:  buildCfg,
+		})
+	}
+	m, err := proxybuild.NewManager(proxybuild.ManagerConfig{
+		Logger:       logger,
+		StackFactory: factory,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.Start(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatalf("manager.Start: %v", err)
+	}
+	if err := m.StartTCPForwards(ctx, proxybuild.TCPForwardParams{
+		Forwards: map[string]*config.ForwardConfig{
+			"0": {Target: upstreamAddr, Protocol: "grpc"},
+		},
+	}); err != nil {
+		t.Fatalf("StartTCPForwards: %v", err)
+	}
+	addrs := m.TCPForwardAddrs()
+	fwdAddr = addrs["0"]
+	if fwdAddr == "" {
+		t.Fatalf("TCPForwardAddrs missing port 0: %v", addrs)
+	}
+	return m, fwdAddr
+}
+
+// ---------------------------------------------------------------------------
+// MCP session wiring (shares the SQLite store with proxybuild).
+// ---------------------------------------------------------------------------
+
+// setupListenerCaptureMCPSession creates an MCP client session backed by
+// `store`. InsecureSkipVerify is enabled on the TLSTransport for parity
+// with the rest of the resend_grpc suite (the resend in our test paths
+// dials over plaintext h2c, but the option is harmless).
+func setupListenerCaptureMCPSession(t *testing.T, store flow.Store) *gomcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+	s := newServer(ctx, nil, store, nil,
+		WithTLSTransport(&transport.StandardTransport{InsecureSkipVerify: true}),
+	)
+	ct, st := gomcp.NewInMemoryTransports()
+	ss, err := s.server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { ss.Close() })
+
+	client := gomcp.NewClient(&gomcp.Implementation{
+		Name:    "listener-capture-resend-grpc-test",
+		Version: "v0.0.1",
+	}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	return cs
+}
+
+// registerListenerCaptureSchema registers the embedded test fixture
+// FileDescriptorSet into the running MCP server's grpc_schema registry
+// for the proto-json arms.
+func registerListenerCaptureSchema(t *testing.T, cs *gomcp.ClientSession) {
+	t.Helper()
+	b64 := base64.StdEncoding.EncodeToString(embeddedTestDescBytes)
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "grpc_schema",
+		Arguments: map[string]any{
+			"action": "register",
+			"params": map[string]any{
+				"source":             "descriptor_set",
+				"descriptor_set_b64": b64,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("grpc_schema register: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("grpc_schema register error: %v", res.Content)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — driving the captured RPC + locating the recorded flow.
+// ---------------------------------------------------------------------------
+
+// driveOneRPCThroughForward dials the forward port over h2c and invokes
+// SayHello with `payload` as the raw-codec body. The upstream echoes it
+// back; we wait for the request to land in `srv.lastReq` before
+// returning.
+func driveOneRPCThroughForward(t *testing.T, ctx context.Context, fwdAddr string, srv *listenerCaptureGreeterServer, payload []byte) {
+	t.Helper()
+	cc, err := grpc.NewClient(fwdAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(listenerCaptureRawCodec{})),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer cc.Close()
+
+	full := "/" + listenerCaptureServiceName + "/" + listenerCaptureMethodName
+	req := payload
+	var resp []byte
+	if err := cc.Invoke(ctx, full, &req, &resp); err != nil {
+		t.Fatalf("Invoke %s: %v", full, err)
+	}
+	if string(resp) != string(payload) {
+		t.Errorf("upstream echo = %q, want %q", resp, payload)
+	}
+	// Sanity check upstream captured something.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.mu.Lock()
+		c := srv.callCnt
+		srv.mu.Unlock()
+		if c > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("upstream never observed the RPC call")
+}
+
+// waitForListenerCapturedGRPCFlow polls the store until a Send-direction
+// flow tagged grpc_event=start with grpc_service / grpc_method matching
+// our fixture is present, then returns its flow_id (which is also the
+// stream_id — gRPC starts open a new stream).
+func waitForListenerCapturedGRPCFlow(t *testing.T, store flow.Store) string {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		streams, err := store.ListStreams(ctx, flow.StreamListOptions{Protocol: "grpc"})
+		if err == nil {
+			for _, st := range streams {
+				flows, ferr := store.GetFlows(ctx, st.ID, flow.FlowListOptions{Direction: "send"})
+				if ferr != nil || len(flows) == 0 {
+					continue
+				}
+				for _, fl := range flows {
+					if fl.Metadata == nil {
+						continue
+					}
+					if fl.Metadata["grpc_event"] != "start" {
+						continue
+					}
+					if fl.Metadata["grpc_service"] != listenerCaptureServiceName {
+						continue
+					}
+					if fl.Metadata["grpc_method"] != listenerCaptureMethodName {
+						continue
+					}
+					return st.ID
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("never saw a listener-captured grpc Start flow with the expected service/method")
+	return ""
+}
+
+// callResendGRPCWithStruct issues resend_grpc with the supplied map. The
+// caller gets the raw result so it can branch on IsError vs a successful
+// structured payload.
+func callResendGRPCWithStruct(t *testing.T, cs *gomcp.ClientSession, args map[string]any) *gomcp.CallToolResult {
+	t.Helper()
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "resend_grpc",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("CallTool resend_grpc: %v", err)
+	}
+	return res
+}
+
+// extractToolErrorText returns the concatenated TextContent of an
+// IsError=true tool result.
+func extractToolErrorText(res *gomcp.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*gomcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// decodeStructured unmarshals a non-error result's StructuredContent.
+func decodeStructured(t *testing.T, res *gomcp.CallToolResult, v any) {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success, got error: %s", extractToolErrorText(res))
+	}
+	if res.StructuredContent == nil {
+		t.Fatalf("expected structured content, got nil")
+	}
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured: %v", err)
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		t.Fatalf("unmarshal structured: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+// TestResendGRPCListenerCapture_FlowIDAlone_Base64 is the canonical
+// USK-920 acceptance gate: a listener-captured gRPC flow must resend with
+// {flow_id, messages: [{payload, body_encoding:"base64"}]} and no manual
+// overrides.
+func TestResendGRPCListenerCapture_FlowIDAlone_Base64(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := newTestStore(t)
+	upAddr, upSrv, upStop := startH2CGreeterUpstream(t)
+	defer upStop()
+	mgr, fwdAddr := startGRPCForwardListener(t, ctx, store, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	driveOneRPCThroughForward(t, ctx, fwdAddr, upSrv, []byte("hello-listener"))
+	flowID := waitForListenerCapturedGRPCFlow(t, store)
+
+	cs := setupListenerCaptureMCPSession(t, store)
+
+	// Recovery sanity: flow_id only, base64-encoded payload. The resend
+	// must dial the same h2c upstream (scheme=http recovered) and the
+	// service / method must come from the listener-captured Flow.URL.
+	res := callResendGRPCWithStruct(t, cs, map[string]any{
+		"flow_id": flowID,
+		"messages": []map[string]any{
+			{
+				"payload":       base64.StdEncoding.EncodeToString([]byte("resend-listener")),
+				"body_encoding": "base64",
+			},
+		},
+		"timeout_ms": 10000,
+	})
+	var out resendGRPCResult
+	decodeStructured(t, res, &out)
+	if upSrv.callCnt < 2 {
+		t.Errorf("upstream callCnt=%d, want >= 2 after resend", upSrv.callCnt)
+	}
+}
+
+// TestResendGRPCListenerCapture_FlowIDAlone_ProtoSchemalessJSON exercises
+// USK-922 addendum #1: body_encoding="proto-schemaless-json" must work
+// flow_id-only on a listener-captured flow.
+func TestResendGRPCListenerCapture_FlowIDAlone_ProtoSchemalessJSON(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := newTestStore(t)
+	upAddr, upSrv, upStop := startH2CGreeterUpstream(t)
+	defer upStop()
+	mgr, fwdAddr := startGRPCForwardListener(t, ctx, store, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	driveOneRPCThroughForward(t, ctx, fwdAddr, upSrv, []byte("\x0a\x05hello"))
+	flowID := waitForListenerCapturedGRPCFlow(t, store)
+
+	cs := setupListenerCaptureMCPSession(t, store)
+
+	// proto-schemaless-json uses PacketProxy-style "FFFF:OOOO:Type" keys
+	// (see internal/encoding/protobuf). Field 1 / ordinal 0 / String for
+	// the f_string field on usk.test.HelloRequest. The upstream codec is
+	// raw bytes so any well-formed proto payload round-trips.
+	res := callResendGRPCWithStruct(t, cs, map[string]any{
+		"flow_id": flowID,
+		"messages": []map[string]any{
+			{
+				"payload":       `{"0001:0000:String":"resend-schemaless"}`,
+				"body_encoding": "proto-schemaless-json",
+			},
+		},
+		"timeout_ms": 10000,
+	})
+	var out resendGRPCResult
+	decodeStructured(t, res, &out)
+}
+
+// TestResendGRPCListenerCapture_FlowIDAlone_ProtoJSON_WithSchema exercises
+// USK-923 addendum #2: body_encoding="proto-json" with a registered
+// schema must work flow_id-only.
+func TestResendGRPCListenerCapture_FlowIDAlone_ProtoJSON_WithSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := newTestStore(t)
+	upAddr, upSrv, upStop := startH2CGreeterUpstream(t)
+	defer upStop()
+	mgr, fwdAddr := startGRPCForwardListener(t, ctx, store, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	driveOneRPCThroughForward(t, ctx, fwdAddr, upSrv, []byte("\x0a\x05hello"))
+	flowID := waitForListenerCapturedGRPCFlow(t, store)
+
+	cs := setupListenerCaptureMCPSession(t, store)
+	registerListenerCaptureSchema(t, cs)
+
+	res := callResendGRPCWithStruct(t, cs, map[string]any{
+		"flow_id": flowID,
+		"messages": []map[string]any{
+			{
+				"payload":       `{"f_string":"hello-proto-json","f_int32":42}`,
+				"body_encoding": "proto-json",
+			},
+		},
+		"timeout_ms": 10000,
+	})
+	var out resendGRPCResult
+	decodeStructured(t, res, &out)
+}
+
+// TestResendGRPCListenerCapture_FlowIDAlone_ProtoJSON_NoSchema exercises
+// USK-920 addendum #3: when body_encoding="proto-json" is used without a
+// registered schema, the hard error must include the recovered service /
+// method (not empty strings) so the operator can immediately call
+// grpc_schema register with the right name.
+func TestResendGRPCListenerCapture_FlowIDAlone_ProtoJSON_NoSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := newTestStore(t)
+	upAddr, upSrv, upStop := startH2CGreeterUpstream(t)
+	defer upStop()
+	mgr, fwdAddr := startGRPCForwardListener(t, ctx, store, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	driveOneRPCThroughForward(t, ctx, fwdAddr, upSrv, []byte("\x0a\x05hello"))
+	flowID := waitForListenerCapturedGRPCFlow(t, store)
+
+	cs := setupListenerCaptureMCPSession(t, store)
+	// NOTE: deliberately NOT calling registerListenerCaptureSchema.
+
+	res := callResendGRPCWithStruct(t, cs, map[string]any{
+		"flow_id": flowID,
+		"messages": []map[string]any{
+			{
+				"payload":       `{"f_string":"no-schema"}`,
+				"body_encoding": "proto-json",
+			},
+		},
+		"timeout_ms": 10000,
+	})
+	if !res.IsError {
+		t.Fatalf("expected error, got success: %+v", res.StructuredContent)
+	}
+	errText := extractToolErrorText(res)
+	if !strings.Contains(errText, listenerCaptureServiceName) {
+		t.Errorf("error text missing recovered service %q: %q", listenerCaptureServiceName, errText)
+	}
+	if !strings.Contains(errText, listenerCaptureMethodName) {
+		t.Errorf("error text missing recovered method %q: %q", listenerCaptureMethodName, errText)
+	}
+}

--- a/internal/pipeline/record_step.go
+++ b/internal/pipeline/record_step.go
@@ -830,8 +830,19 @@ func (s *RecordStep) createStream(ctx context.Context, env *envelope.Envelope) {
 	}
 
 	// Derive scheme from Message type when available.
-	if msg, ok := env.Message.(*envelope.HTTPMessage); ok && msg.Scheme != "" {
-		st.Scheme = msg.Scheme
+	switch msg := env.Message.(type) {
+	case *envelope.HTTPMessage:
+		if msg.Scheme != "" {
+			st.Scheme = msg.Scheme
+		}
+	case *envelope.GRPCStartMessage:
+		// USK-920: project the request-side :scheme onto Stream.Scheme so
+		// listener-captured gRPC streams record the handshake transport
+		// the same way HTTPMessage does. Response-side Start envelopes
+		// carry Scheme="" and are no-ops here.
+		if msg.Scheme != "" {
+			st.Scheme = msg.Scheme
+		}
 	}
 
 	// USK-841 milestone (g): SaveStream call decision. Reveals which Stream
@@ -1241,6 +1252,26 @@ func projectGRPCStart(m *envelope.GRPCStartMessage, fl *flow.Flow) {
 	}
 	if m.Encoding != "" {
 		fl.Metadata["grpc_encoding"] = m.Encoding
+	}
+	// USK-920: project the request-side pseudo-headers (:authority,
+	// :scheme, :path) into Flow.URL so resend_grpc { flow_id } can
+	// recover the RPC target without manual overrides — mirroring the
+	// HTTPMessage projection in envelopeToFlow. Response-side Start
+	// envelopes (Authority=="" && Scheme=="") leave Flow.URL nil because
+	// fl.URL on the receive direction is not used by recovery.
+	if m.Authority != "" || m.Scheme != "" {
+		path := m.Path
+		if path == "" && (m.Service != "" || m.Method != "") {
+			// Defensive: a missing :path with non-empty Service/Method
+			// would mean buildStartMessage was bypassed; reconstruct so
+			// the URL is still well-formed for downstream consumers.
+			path = "/" + m.Service + "/" + m.Method
+		}
+		fl.URL = &url.URL{
+			Scheme: m.Scheme,
+			Host:   m.Authority,
+			Path:   path,
+		}
 	}
 	if hdrs := keyValuesToMap(m.Metadata); hdrs != nil {
 		fl.Headers = hdrs

--- a/internal/pipeline/record_step_test.go
+++ b/internal/pipeline/record_step_test.go
@@ -3156,3 +3156,143 @@ func metadataKeysSorted(m map[string]string) []string {
 	}
 	return keys
 }
+
+// TestRecordStep_GRPCStartProjectsURLAndScheme pins the USK-920 projection
+// contract: a Send-direction GRPCStartMessage carrying request-side
+// pseudo-headers (:authority / :scheme / :path) must produce a Flow with a
+// well-formed URL and a Stream whose Scheme matches :scheme. This is the
+// recovery path that lets resend_grpc replay listener-captured flows from
+// {flow_id} alone (extractResendGRPCStartFields reads Flow.URL first).
+//
+// The table covers every observable shape produced by gRPC channel.go's
+// buildStartMessage:
+//   - Full triple — happy path (https, h2c, response-side empty).
+//   - Path missing but Service+Method present — defensive reconstruction.
+//   - Response-side (Authority+Scheme empty) — no URL projection.
+//
+// Each branch directly mirrors a `if dir == envelope.Send` outcome in
+// internal/layer/grpc/channel.go, so a refactor that drops one field cannot
+// silently regress to the pre-USK-920 behavior.
+func TestRecordStep_GRPCStartProjectsURLAndScheme(t *testing.T) {
+	cases := []struct {
+		name       string
+		msg        *envelope.GRPCStartMessage
+		wantURL    bool
+		wantHost   string
+		wantScheme string
+		wantPath   string
+		wantStream string
+	}{
+		{
+			name: "full_https",
+			msg: &envelope.GRPCStartMessage{
+				Service:   "hello.HelloService",
+				Method:    "SayHello",
+				Authority: "api.example.com:443",
+				Scheme:    "https",
+				Path:      "/hello.HelloService/SayHello",
+			},
+			wantURL:    true,
+			wantHost:   "api.example.com:443",
+			wantScheme: "https",
+			wantPath:   "/hello.HelloService/SayHello",
+			wantStream: "https",
+		},
+		{
+			name: "full_h2c_http",
+			msg: &envelope.GRPCStartMessage{
+				Service:   "hello.HelloService",
+				Method:    "SayHello",
+				Authority: "127.0.0.1:9000",
+				Scheme:    "http",
+				Path:      "/hello.HelloService/SayHello",
+			},
+			wantURL:    true,
+			wantHost:   "127.0.0.1:9000",
+			wantScheme: "http",
+			wantPath:   "/hello.HelloService/SayHello",
+			wantStream: "http",
+		},
+		{
+			name: "path_missing_reconstructed_from_service_method",
+			msg: &envelope.GRPCStartMessage{
+				Service:   "hello.HelloService",
+				Method:    "SayHello",
+				Authority: "api.example.com",
+				Scheme:    "https",
+				// Path intentionally empty — projectGRPCStart must reconstruct.
+			},
+			wantURL:    true,
+			wantHost:   "api.example.com",
+			wantScheme: "https",
+			wantPath:   "/hello.HelloService/SayHello",
+			wantStream: "https",
+		},
+		{
+			name: "response_side_no_url_projection",
+			msg: &envelope.GRPCStartMessage{
+				// Authority / Scheme / Path empty on the response side per
+				// channel.go's `if dir == envelope.Send` gate.
+				Service: "hello.HelloService",
+				Method:  "SayHello",
+			},
+			wantURL:    false,
+			wantStream: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			w := &mockWriter{}
+			step := NewRecordStep(w, nil)
+			env := &envelope.Envelope{
+				StreamID:  "stream-" + tc.name,
+				FlowID:    "flow-" + tc.name,
+				Direction: envelope.Send,
+				Sequence:  0,
+				Protocol:  envelope.ProtocolGRPC,
+				Raw:       []byte("hpack-bytes"),
+				Message:   tc.msg,
+			}
+			step.Process(context.Background(), env)
+
+			if len(w.streams) != 1 {
+				t.Fatalf("expected 1 stream, got %d", len(w.streams))
+			}
+			if got := w.streams[0].Scheme; got != tc.wantStream {
+				t.Errorf("stream Scheme = %q, want %q", got, tc.wantStream)
+			}
+
+			if len(w.flows) != 1 {
+				t.Fatalf("expected 1 flow, got %d", len(w.flows))
+			}
+			fl := w.flows[0]
+			if tc.wantURL {
+				if fl.URL == nil {
+					t.Fatal("flow URL is nil; want populated")
+				}
+				if fl.URL.Host != tc.wantHost {
+					t.Errorf("flow URL.Host = %q, want %q", fl.URL.Host, tc.wantHost)
+				}
+				if fl.URL.Scheme != tc.wantScheme {
+					t.Errorf("flow URL.Scheme = %q, want %q", fl.URL.Scheme, tc.wantScheme)
+				}
+				if fl.URL.Path != tc.wantPath {
+					t.Errorf("flow URL.Path = %q, want %q", fl.URL.Path, tc.wantPath)
+				}
+			} else if fl.URL != nil {
+				t.Errorf("flow URL = %+v, want nil for response-side Start", fl.URL)
+			}
+			// grpc_service / grpc_method must always project regardless of
+			// pseudo-header presence — the Metadata fallback in
+			// extractResendGRPCStartFields depends on it for legacy flows.
+			if got := fl.Metadata["grpc_service"]; got != tc.msg.Service {
+				t.Errorf("flow Metadata[grpc_service] = %q, want %q", got, tc.msg.Service)
+			}
+			if got := fl.Metadata["grpc_method"]; got != tc.msg.Method {
+				t.Errorf("flow Metadata[grpc_method] = %q, want %q", got, tc.msg.Method)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Authority` / `Scheme` / `Path` fields to `GRPCStartMessage`; populate from `H2HeadersEvent` in the gRPC Layer so the wire pseudo-headers reach the Pipeline.
- Project `Flow.URL` (and `Stream.Scheme`) in `record_step` for `GRPCStartMessage`, mirroring the existing HTTPMessage projection. Listener-captured gRPC flows now record a URL the same way HTTP flows do.
- Add a `Flow.Metadata` fallback in `extractResendGRPCStartFields` so already-recorded flows without `Flow.URL` still recover service/method.
- Scan for `grpc_event=="start"` in `loadResendGRPCFlows` instead of returning `sendFlows[0]` — the live data path records per-frame wire snapshots ahead of the semantic Start Flow.

## Test plan
- [x] Unit: `extractResendGRPCStartFields` covers URL-only / Metadata-only / both-present / URL-without-path / neither / nil-flow.
- [x] E2E (`e2e && !e2e_smoke`): listener-captured gRPC + `resend_grpc { flow_id }` with `body_encoding` ∈ {`base64`, `proto-schemaless-json`, `proto-json` with schema, `proto-json` without schema}.
- [x] `make lint`, `make build`, `make test`, `make test-e2e-smoke` all pass locally.
- [x] No regression on `resend_http` / `resend_ws` (unchanged code paths).

Resolves USK-920
Linear: https://linear.app/usk6666/issue/USK-920

🤖 Generated with [Claude Code](https://claude.com/claude-code)