### PR TITLE
fix(mcp,query): default wire_level=semantic in query messages/flows (USK-921)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ but also subsystem integration. Confirm that the following checklist is satisfie
 - [ ] **Error paths**: Flow is recorded with `State="error"` on connection failure or timeout
 - [ ] **Raw bytes recording**: Wire-observed raw bytes (`Envelope.Raw`) are correctly recorded — L4-capable principle
 - [ ] **Variant recording**: On intercept/transform modification, both original and modified variants are recorded
-- [ ] **MCP tool integration**: Flows are correctly retrievable via the `query` tool (with `resource: "flows"` / `resource: "flow"` parameters; Protocol family filter accepts `http`/`ws`/`grpc`/`grpc-web`/`sse`/`raw`/`tls-handshake`)
+- [ ] **MCP tool integration**: Flows are correctly retrievable via the `query` tool (with `resource: "flows"` / `resource: "flow"` parameters; Protocol family filter accepts `http`/`ws`/`grpc`/`grpc-web`/`sse`/`raw`/`tls-handshake`; `filter.wire_level` accepts `semantic`/`h2-frame`/`h1-chunk`/`grpc-lpm-frame`/`grpcweb-base64`/`all` with default `semantic` — overlay rows are excluded from `message_count` / `message_preview` unless explicitly opted in)
 
 > **Applicability**: Not all items are required for every test. Verify relevant items based on protocol characteristics and test purpose.
 > Example: Raw TCP has no L7 structured view, so header validation under "message content" is not required.

--- a/docs/rfc/envelope.md
+++ b/docs/rfc/envelope.md
@@ -316,6 +316,8 @@ HTTP/2 frame-level bytes (frame headers, SETTINGS, WINDOW_UPDATE, etc.) are owne
 
 The two overlays produce independent per-direction sequence counters; the schemaV14 UNIQUE constraint on `(stream_id, sequence, direction, variant, wire_level)` keeps the three views (semantic + LPM + h2-frame) from colliding under the same StreamID.
 
+**MCP default exposure (USK-921).** The MCP `query` tool (`messages` / `flow` / `flows` resources) hard-defaults `filter.wire_level` to `semantic` at the control-plane boundary so the L7 view never returns overlay rows by default — they would otherwise inflate `message_count` and `message_preview` by 2-4x on gRPC / WS / SSE / gRPC-Web flows. AI agents opt in to overlay rows via `filter.wire_level={h2-frame | h1-chunk | grpc-lpm-frame | grpcweb-base64 | all}`. The wire-level data persists losslessly in the flow store regardless of the MCP cosmetic default (L4-capable promise: §3.2 wire-level recording always holds; the default filter is a cosmetic projection at the MCP transport boundary, never a wire-data modification).
+
 #### 3.2.4 RawMessage
 
 For TCP, raw-mode TLS passthrough, and any byte-chunk channel.

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -135,6 +135,17 @@ type queryFilter struct {
 	State string `json:"state,omitempty" jsonschema:"flow lifecycle state filter (active, complete, error)"`
 	// Direction filters messages by direction ("send" or "receive").
 	Direction string `json:"direction,omitempty" jsonschema:"message direction filter (send or receive)"`
+	// WireLevel filters messages by wire_level discriminator (USK-921).
+	// The flow store records both canonical L7 "semantic" envelopes and
+	// per-protocol wire-level overlay envelopes (h2-frame, h1-chunk,
+	// grpc-lpm-frame, grpcweb-base64) for diagnostic L4 visibility. To
+	// keep the default L7 view free of overlay clutter the MCP query path
+	// hard-defaults this filter to "semantic" — set "all" to receive
+	// every wire_level, or one of the overlay values to isolate a single
+	// diagnostic view. Empty / unset → "semantic". Applies to the flows,
+	// flow, and messages resources (overlay rows are excluded from
+	// message_count and message_preview by default).
+	WireLevel string `json:"wire_level,omitempty" jsonschema:"wire_level filter (USK-921). semantic (default) returns only canonical L7 envelopes; h2-frame / h1-chunk / grpc-lpm-frame / grpcweb-base64 isolate a single diagnostic overlay; all returns every wire_level. Applies to flows / flow / messages resources."`
 	// ConnID filters flows by connection ID (exact match).
 	ConnID string `json:"conn_id,omitempty" jsonschema:"connection ID filter for flows (exact match)"`
 	// Host filters flows by host (matches server_addr or URL host).
@@ -216,6 +227,62 @@ var validFilterOrigins = []string{"proxy", "resend", "fuzz"}
 // validFilterFuzzJobStatuses lists valid values for filter.status (fuzz_jobs).
 var validFilterFuzzJobStatuses = []string{"running", "paused", "completed", "cancelled", "error"}
 
+// wireLevelFilterAll is the opt-in sentinel disabling the wire_level
+// default; passing "all" surfaces every wire_level (semantic + every
+// overlay) to the caller. Distinct from the empty / unset value which
+// the MCP query path normalises to flow.WireLevelSemantic.
+const wireLevelFilterAll = "all"
+
+// validFilterWireLevels lists accepted values for filter.wire_level (USK-921).
+// The MCP query path (flows / flow / messages) hard-defaults to
+// flow.WireLevelSemantic when the field is empty / unset; "all" disables
+// the predicate. The overlay values are reused verbatim from the
+// flow.WireLevel* canonical set so a new producer surfaces here at the
+// same time it surfaces at the SQL boundary.
+var validFilterWireLevels = []string{
+	flow.WireLevelSemantic,
+	flow.WireLevelH2Frame,
+	flow.WireLevelHTTP1Chunk,
+	flow.WireLevelGRPCLPMFrame,
+	flow.WireLevelGRPCWebBase64,
+	wireLevelFilterAll,
+}
+
+// nonSemanticWireLevel reports the wire_level discriminator suitable for
+// inclusion in the JSON response — i.e. surfacing every value except the
+// default flow.WireLevelSemantic (the latter is implied by the absence of
+// the field on a default-filtered response). The empty string passes
+// through unchanged so pre-schemaV14 rows stay invisible.
+func nonSemanticWireLevel(wl string) string {
+	if wl == flow.WireLevelSemantic {
+		return ""
+	}
+	return wl
+}
+
+// resolveWireLevelFilter validates and translates filter.wire_level into
+// the value passed to flow.FlowListOptions.WireLevel. Empty / unset →
+// flow.WireLevelSemantic so the MCP L7 view never includes overlay rows
+// without explicit opt-in (USK-921). "all" disables the predicate (empty
+// string returned). Any other accepted value passes through verbatim.
+// Unknown values surface a validateEnum error with the canonical list.
+func resolveWireLevelFilter(filter *queryFilter) (string, error) {
+	value := ""
+	if filter != nil {
+		value = filter.WireLevel
+	}
+	if value == "" {
+		return flow.WireLevelSemantic, nil
+	}
+	if err := validateEnum("wire_level", value, validFilterWireLevels); err != nil {
+		return "", err
+	}
+	if value == wireLevelFilterAll {
+		return "", nil
+	}
+	return value, nil
+}
+
 // validFlowSortByValues lists valid values for sort_by (flows).
 var validFlowSortByValues = []string{"timestamp", "duration_ms"}
 
@@ -261,8 +328,30 @@ func validateFlowFilters(input queryInput) error {
 				return err
 			}
 		}
+		// USK-921: validate the wire_level filter at the flows entry
+		// point so callers see the canonical enum error before any
+		// per-flow message lookup. The same resolver runs inside
+		// handleQueryFlows when building the per-flow opts so an
+		// unset value still gets the semantic default.
+		if _, err := resolveWireLevelFilter(input.Filter); err != nil {
+			return err
+		}
 	}
 	if err := validateEnum("sort_by", input.SortBy, validFlowSortByValues); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateMessageFilters validates enum filter parameters for the messages
+// and flow resources (USK-921). Both handlers consume filter.wire_level to
+// control overlay visibility; the dedicated validator surfaces the canonical
+// enum error before the SQL fetch happens.
+func validateMessageFilters(input queryInput) error {
+	if input.Filter == nil {
+		return nil
+	}
+	if _, err := resolveWireLevelFilter(input.Filter); err != nil {
 		return err
 	}
 	return nil
@@ -308,6 +397,12 @@ func validateQueryInput(input queryInput) error {
 	switch input.Resource {
 	case "flows":
 		return validateFlowFilters(input)
+	case "flow", "messages":
+		// USK-921: the flow / messages handlers also honour
+		// filter.wire_level; surface the enum error at the dispatch
+		// boundary so the per-handler GetFlows call sees a validated
+		// value (or the semantic default).
+		return validateMessageFilters(input)
 	case "fuzz_jobs":
 		return validateFuzzJobFilters(input)
 	case "fuzz_results":
@@ -587,10 +682,15 @@ type queryFlowsEntry struct {
 	// "client_tls_error") when state == "error". Empty for state != "error"
 	// or for errored streams that did not surface a classifiable signal
 	// (USK-797 makes this column visible to MCP clients).
-	FailureReason   string            `json:"failure_reason,omitempty"`
-	Method          string            `json:"method"`
-	URL             string            `json:"url"`
-	StatusCode      int               `json:"status_code"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	Method        string `json:"method"`
+	URL           string `json:"url"`
+	StatusCode    int    `json:"status_code"`
+	// MessageCount is the number of canonical L7 semantic envelopes
+	// recorded for the flow. Wire-level overlay rows (h2-frame,
+	// h1-chunk, grpc-lpm-frame, grpcweb-base64) are excluded by default
+	// — pass filter.wire_level="all" to include them, or one of the
+	// overlay values to count only that overlay (USK-921).
 	MessageCount    int               `json:"message_count"`
 	BlockedBy       string            `json:"blocked_by,omitempty"`
 	ProtocolSummary map[string]string `json:"protocol_summary,omitempty"`
@@ -688,10 +788,21 @@ func (s *Server) handleQueryFlows(ctx context.Context, input queryInput) (*gomcp
 		return nil, nil, fmt.Errorf("count flows: %w", err)
 	}
 
+	// USK-921: default to flow.WireLevelSemantic so per-flow MessageCount /
+	// summary derivations only see canonical L7 envelopes — overlay rows
+	// (h2-frame, h1-chunk, grpc-lpm-frame, grpcweb-base64) would otherwise
+	// inflate message_count by 2-4x for gRPC / WS / SSE / gRPC-Web flows.
+	// Callers opt in via filter.wire_level={overlay value | all}.
+	wireLevel, err := resolveWireLevelFilter(input.Filter)
+	if err != nil {
+		return nil, nil, err
+	}
+	msgListOpts := flow.FlowListOptions{WireLevel: wireLevel}
+
 	entries := make([]queryFlowsEntry, 0, len(flowList))
 	for _, fl := range flowList {
 		// Fetch messages for method/url/status_code/message_count via JOIN data.
-		msgs, err := s.flowStore.store.GetFlows(ctx, fl.ID, flow.FlowListOptions{})
+		msgs, err := s.flowStore.store.GetFlows(ctx, fl.ID, msgListOpts)
 		if err != nil {
 			return nil, nil, fmt.Errorf("get messages for flow %s: %w", fl.ID, err)
 		}
@@ -801,9 +912,15 @@ type queryFlowResult struct {
 	RawRequest                  string              `json:"raw_request,omitempty"`
 	RawResponse                 string              `json:"raw_response,omitempty"`
 	ConnInfo                    *connInfoResult     `json:"conn_info,omitempty"`
-	MessageCount                int                 `json:"message_count"`
-	ProtocolSummary             map[string]string   `json:"protocol_summary,omitempty"`
-	MessagePreview              []queryMessageEntry `json:"message_preview,omitempty"`
+	// MessageCount is the number of canonical L7 semantic envelopes
+	// recorded for the flow. Wire-level overlay rows (h2-frame,
+	// h1-chunk, grpc-lpm-frame, grpcweb-base64) are excluded by default
+	// — pass filter.wire_level="all" to include them, or one of the
+	// overlay values to count only that overlay (USK-921). The same
+	// filter governs which envelopes appear in MessagePreview.
+	MessageCount    int                 `json:"message_count"`
+	ProtocolSummary map[string]string   `json:"protocol_summary,omitempty"`
+	MessagePreview  []queryMessageEntry `json:"message_preview,omitempty"`
 	// OriginalRequest holds the original (pre-modification) request data
 	// when a variant exists (intercept/transform modified the request).
 	// Only populated when the flow contains variant messages.
@@ -1320,7 +1437,17 @@ func (s *Server) handleQueryFlow(ctx context.Context, input queryInput) (*gomcp.
 	if err != nil {
 		return nil, nil, fmt.Errorf("get flow: %w", err)
 	}
-	msgs, err := s.flowStore.store.GetFlows(ctx, fl.ID, flow.FlowListOptions{})
+	// USK-921: default to flow.WireLevelSemantic so MessageCount /
+	// message_preview only see canonical L7 envelopes — overlay rows
+	// (h2-frame, h1-chunk, grpc-lpm-frame, grpcweb-base64) would
+	// otherwise inflate the counts and the preview window for gRPC / WS
+	// / SSE / gRPC-Web flows. Callers opt in via filter.wire_level=
+	// {overlay value | all}.
+	wireLevel, err := resolveWireLevelFilter(input.Filter)
+	if err != nil {
+		return nil, nil, err
+	}
+	msgs, err := s.flowStore.store.GetFlows(ctx, fl.ID, flow.FlowListOptions{WireLevel: wireLevel})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get messages: %w", err)
 	}
@@ -1545,7 +1672,13 @@ type queryMessageEntry struct {
 	BodyOriginalSize        int               `json:"body_original_size,omitempty"`
 	BodyDecodedOriginalSize int               `json:"body_decoded_original_size,omitempty"`
 	Metadata                map[string]string `json:"metadata,omitempty"`
-	Timestamp               string            `json:"timestamp"`
+	// WireLevel mirrors flow.Flow.WireLevel — "semantic" for canonical
+	// L7 envelopes, or one of the overlay discriminators (h2-frame,
+	// h1-chunk, grpc-lpm-frame, grpcweb-base64) when the caller opted
+	// in to overlay rows via filter.wire_level (USK-921). Omitted when
+	// empty so the default semantic-only response stays compact.
+	WireLevel string `json:"wire_level,omitempty"`
+	Timestamp string `json:"timestamp"`
 }
 
 // queryMessagesResult is the response for the messages resource.
@@ -1598,7 +1731,13 @@ func (s *Server) convertMessagesToEntries(msgs []*flow.Flow, decodeEnabled bool,
 			// params so callers can tell the two truncation classes apart.
 			BodyTruncated: msg.BodyTruncated,
 			Metadata:      msg.Metadata,
-			Timestamp:     msg.Timestamp.UTC().Format("2006-01-02T15:04:05Z"),
+			// USK-921: surface the wire_level discriminator so callers
+			// who opted in to overlay rows (filter.wire_level=h2-frame /
+			// grpc-lpm-frame / ...) can tell which framing view each
+			// entry represents. Default-semantic responses get an empty
+			// string here and the field omits from JSON via omitempty.
+			WireLevel: nonSemanticWireLevel(msg.WireLevel),
+			Timestamp: msg.Timestamp.UTC().Format("2006-01-02T15:04:05Z"),
 		}
 
 		switch {
@@ -1641,7 +1780,13 @@ func (s *Server) convertMessagesToEntries(msgs []*flow.Flow, decodeEnabled bool,
 }
 
 // buildMessageListOptions validates and builds message list options from query input.
-// Returns an error if the direction filter value is invalid.
+// Returns an error if the direction or wire_level filter value is invalid.
+//
+// USK-921: when filter.wire_level is empty / unset, the resolver injects
+// flow.WireLevelSemantic so the default messages response hides wire-level
+// overlay rows (h2-frame, h1-chunk, grpc-lpm-frame, grpcweb-base64). Pass
+// filter.wire_level="all" to receive every wire_level, or one of the
+// overlay values to isolate a single diagnostic view.
 func buildMessageListOptions(input queryInput) (flow.FlowListOptions, error) {
 	opts := flow.FlowListOptions{}
 	if input.Filter != nil && input.Filter.Direction != "" {
@@ -1650,6 +1795,11 @@ func buildMessageListOptions(input queryInput) (flow.FlowListOptions, error) {
 		}
 		opts.Direction = input.Filter.Direction
 	}
+	wireLevel, err := resolveWireLevelFilter(input.Filter)
+	if err != nil {
+		return opts, err
+	}
+	opts.WireLevel = wireLevel
 	return opts, nil
 }
 
@@ -1707,9 +1857,13 @@ func (s *Server) handleQueryMessages(ctx context.Context, input queryInput) (*go
 		return nil, nil, fmt.Errorf("get messages: %w", err)
 	}
 
-	// Use filtered count as total for pagination when direction filter is active.
+	// Use filtered count as total for pagination when direction or
+	// wire_level filtering reduced the result set (USK-921: the
+	// flow.CountFlows aggregate returns every wire_level row but the
+	// MCP default filter is "semantic"; without this branch the Total
+	// field would over-report by the overlay-row count).
 	filteredTotal := total
-	if msgOpts.Direction != "" {
+	if msgOpts.Direction != "" || msgOpts.WireLevel != "" {
 		filteredTotal = len(allMsgs)
 	}
 

--- a/internal/mcp/query_wire_level_test.go
+++ b/internal/mcp/query_wire_level_test.go
@@ -1,0 +1,454 @@
+package mcp
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+)
+
+// seedFlowWithMixedWireLevels creates a Stream and Flows mixing semantic
+// and wire-level overlay rows (h2-frame, grpc-lpm-frame) under the same
+// (stream_id, sequence, direction, variant) so the schemaV14 UNIQUE
+// constraint accepts them. Mirrors the live recording shape of a
+// tcp_forwards gRPC unary RPC where every semantic GRPCStart/Data/End
+// envelope is shadowed by overlay rows produced by
+// session.GRPCH2DataFrameRecordOption + session.GRPCLPMRecordOption.
+//
+// Returns the stream ID and the expected (semantic count, h2-frame count,
+// grpc-lpm-frame count) tuple so the test can pivot on each axis.
+func seedFlowWithMixedWireLevels(t *testing.T, store flow.Store, id string) (string, int, int, int) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	st := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  "grpc",
+		Scheme:    "http",
+		State:     "complete",
+		Timestamp: now,
+		Duration:  150 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, st); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+
+	parsedURL, _ := url.Parse("http://example.com/svc.Echo/Unary")
+
+	// Five canonical L7 semantic rows: Send Start + Send Data + Recv Start
+	// + Recv Data + Recv End. This is the user-observed "5 messages" count
+	// from the USK-921 repro.
+	semantic := []*flow.Flow{
+		{
+			ID: id + "-send-start", StreamID: id, Sequence: 0, Direction: "send",
+			Timestamp: now, Method: "POST", URL: parsedURL,
+			Headers:   map[string][]string{":path": {"/svc.Echo/Unary"}},
+			Metadata:  map[string]string{"grpc_event": "start"},
+			WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: id + "-send-data", StreamID: id, Sequence: 1, Direction: "send",
+			Timestamp: now,
+			Body:      []byte("send-payload"),
+			Metadata:  map[string]string{"grpc_event": "data"},
+			WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: id + "-recv-start", StreamID: id, Sequence: 0, Direction: "receive",
+			Timestamp: now, StatusCode: 200,
+			Headers:   map[string][]string{":status": {"200"}},
+			Metadata:  map[string]string{"grpc_event": "start"},
+			WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: id + "-recv-data", StreamID: id, Sequence: 1, Direction: "receive",
+			Timestamp: now,
+			Body:      []byte("recv-payload"),
+			Metadata:  map[string]string{"grpc_event": "data"},
+			WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: id + "-recv-end", StreamID: id, Sequence: 2, Direction: "receive",
+			Timestamp: now,
+			Metadata:  map[string]string{"grpc_event": "end"},
+			WireLevel: flow.WireLevelSemantic,
+		},
+	}
+
+	// Two h2-frame overlay rows: one per Data envelope, sharing the same
+	// (sequence, direction) as the semantic Data envelope. The widened
+	// UNIQUE on (stream_id, sequence, direction, variant, wire_level)
+	// accepts the coexistence.
+	h2Frames := []*flow.Flow{
+		{
+			ID: id + "-send-data-h2", StreamID: id, Sequence: 1, Direction: "send",
+			Timestamp: now,
+			RawBytes:  []byte("h2-frame-bytes-send"),
+			WireLevel: flow.WireLevelH2Frame,
+		},
+		{
+			ID: id + "-recv-data-h2", StreamID: id, Sequence: 1, Direction: "receive",
+			Timestamp: now,
+			RawBytes:  []byte("h2-frame-bytes-recv"),
+			WireLevel: flow.WireLevelH2Frame,
+		},
+	}
+
+	// Two grpc-lpm-frame overlay rows: same coexistence rules.
+	lpmFrames := []*flow.Flow{
+		{
+			ID: id + "-send-data-lpm", StreamID: id, Sequence: 1, Direction: "send",
+			Timestamp: now,
+			RawBytes:  []byte("lpm-bytes-send"),
+			WireLevel: flow.WireLevelGRPCLPMFrame,
+		},
+		{
+			ID: id + "-recv-data-lpm", StreamID: id, Sequence: 1, Direction: "receive",
+			Timestamp: now,
+			RawBytes:  []byte("lpm-bytes-recv"),
+			WireLevel: flow.WireLevelGRPCLPMFrame,
+		},
+	}
+
+	for _, f := range semantic {
+		if err := store.SaveFlow(ctx, f); err != nil {
+			t.Fatalf("SaveFlow(semantic %s): %v", f.ID, err)
+		}
+	}
+	for _, f := range h2Frames {
+		if err := store.SaveFlow(ctx, f); err != nil {
+			t.Fatalf("SaveFlow(h2-frame %s): %v", f.ID, err)
+		}
+	}
+	for _, f := range lpmFrames {
+		if err := store.SaveFlow(ctx, f); err != nil {
+			t.Fatalf("SaveFlow(lpm-frame %s): %v", f.ID, err)
+		}
+	}
+
+	return id, len(semantic), len(h2Frames), len(lpmFrames)
+}
+
+// TestQuery_Messages_DefaultWireLevelHidesOverlays asserts that the
+// USK-921 fix excludes wire-level overlay rows (h2-frame, grpc-lpm-frame)
+// from the messages response by default. Without the fix the user-
+// observed "9 messages" inflation reappears.
+func TestQuery_Messages_DefaultWireLevelHidesOverlays(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, h2Count, lpmCount := seedFlowWithMixedWireLevels(t, store, "wl-default")
+	totalRows := semCount + h2Count + lpmCount
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{Resource: "messages", ID: id})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryMessagesResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.Count != semCount {
+		t.Errorf("count = %d, want %d (only semantic envelopes)", out.Count, semCount)
+	}
+	if out.Total != semCount {
+		t.Errorf("total = %d, want %d (only semantic envelopes)", out.Total, semCount)
+	}
+	if got := len(out.Messages); got != semCount {
+		t.Errorf("messages len = %d, want %d", got, semCount)
+	}
+	for _, m := range out.Messages {
+		if m.WireLevel != "" {
+			t.Errorf("entry %s wire_level = %q, want empty (semantic-only response)", m.ID, m.WireLevel)
+		}
+	}
+
+	// Sanity belt — the DB does carry the overlay rows; only the MCP
+	// projection hides them. Confirms the test fixture has the expected
+	// total before the filter is applied.
+	all, err := store.GetFlows(context.Background(), id, flow.FlowListOptions{})
+	if err != nil {
+		t.Fatalf("GetFlows(no filter): %v", err)
+	}
+	if len(all) != totalRows {
+		t.Errorf("DB row count = %d, want %d (semantic+h2+lpm)", len(all), totalRows)
+	}
+}
+
+// TestQuery_Messages_ExplicitWireLevelOverlay asserts that opting in to a
+// single overlay (filter.wire_level=h2-frame) returns only those rows and
+// surfaces the discriminator on each entry.
+func TestQuery_Messages_ExplicitWireLevelOverlay(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, _, h2Count, _ := seedFlowWithMixedWireLevels(t, store, "wl-h2")
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "messages",
+		ID:       id,
+		Filter:   &queryFilter{WireLevel: flow.WireLevelH2Frame},
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryMessagesResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.Count != h2Count {
+		t.Errorf("count = %d, want %d (h2-frame only)", out.Count, h2Count)
+	}
+	for _, m := range out.Messages {
+		if m.WireLevel != flow.WireLevelH2Frame {
+			t.Errorf("entry %s wire_level = %q, want %q", m.ID, m.WireLevel, flow.WireLevelH2Frame)
+		}
+	}
+}
+
+// TestQuery_Messages_WireLevelAllReturnsEverything asserts the "all"
+// opt-out surfaces every wire_level (semantic + overlays).
+func TestQuery_Messages_WireLevelAllReturnsEverything(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, h2Count, lpmCount := seedFlowWithMixedWireLevels(t, store, "wl-all")
+	totalRows := semCount + h2Count + lpmCount
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "messages",
+		ID:       id,
+		Filter:   &queryFilter{WireLevel: "all"},
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryMessagesResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.Count != totalRows {
+		t.Errorf("count = %d, want %d (every wire_level)", out.Count, totalRows)
+	}
+	// Spot-check that at least one of each discriminator shows up.
+	var sawSemantic, sawH2, sawLPM bool
+	for _, m := range out.Messages {
+		switch m.WireLevel {
+		case "":
+			sawSemantic = true // semantic rows hide the discriminator via omitempty
+		case flow.WireLevelH2Frame:
+			sawH2 = true
+		case flow.WireLevelGRPCLPMFrame:
+			sawLPM = true
+		}
+	}
+	if !sawSemantic || !sawH2 || !sawLPM {
+		t.Errorf("wire_level mix = (sem=%v h2=%v lpm=%v), want all three", sawSemantic, sawH2, sawLPM)
+	}
+}
+
+// TestQuery_Messages_WireLevelInvalid asserts that an unknown wire_level
+// value surfaces a structured error listing the canonical enum members,
+// matching the validateEnum contract every other filter axis uses.
+func TestQuery_Messages_WireLevelInvalid(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	seedFlowWithMixedWireLevels(t, store, "wl-invalid")
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "messages",
+		ID:       "wl-invalid",
+		Filter:   &queryFilter{WireLevel: "bogus"},
+	})
+	if !result.IsError {
+		t.Fatal("expected IsError=true for invalid wire_level value")
+	}
+	text := extractTextContent(result)
+	if !strings.Contains(text, `invalid wire_level "bogus"`) {
+		t.Errorf("error message %q should mention invalid wire_level", text)
+	}
+	// Spot-check the canonical enum members surface so the AI agent
+	// sees a usable remediation hint.
+	for _, want := range []string{"semantic", "h2-frame", "grpc-lpm-frame", "all"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("error message %q should list canonical value %q", text, want)
+		}
+	}
+}
+
+// TestQuery_Flow_DefaultWireLevelHidesOverlays asserts the flow resource
+// (single-flow detail) reports MessageCount over the semantic-only
+// projection by default — the same defect path the user hit when running
+// `query flow` on the tcp_forwards gRPC stream.
+func TestQuery_Flow_DefaultWireLevelHidesOverlays(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, _, _ := seedFlowWithMixedWireLevels(t, store, "wl-flow")
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{Resource: "flow", ID: id})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryFlowResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.MessageCount != semCount {
+		t.Errorf("message_count = %d, want %d (semantic only)", out.MessageCount, semCount)
+	}
+	// MessagePreview only fires for streaming flows (more than 2
+	// messages). With semCount=5 it should populate; assert each entry
+	// has no overlay discriminator.
+	if len(out.MessagePreview) == 0 {
+		t.Fatalf("message_preview empty; expected populated for %d-message streaming flow", semCount)
+	}
+	for _, m := range out.MessagePreview {
+		if m.WireLevel != "" {
+			t.Errorf("preview entry %s wire_level = %q, want empty (semantic-only)", m.ID, m.WireLevel)
+		}
+	}
+}
+
+// TestQuery_Flow_WireLevelAllInflatesCount asserts that opting in to
+// "all" re-includes the overlay rows in MessageCount + MessagePreview,
+// proving the filter is wired into both projections.
+func TestQuery_Flow_WireLevelAllInflatesCount(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, h2Count, lpmCount := seedFlowWithMixedWireLevels(t, store, "wl-flow-all")
+	totalRows := semCount + h2Count + lpmCount
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "flow",
+		ID:       id,
+		Filter:   &queryFilter{WireLevel: "all"},
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryFlowResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.MessageCount != totalRows {
+		t.Errorf("message_count = %d, want %d (every wire_level)", out.MessageCount, totalRows)
+	}
+}
+
+// TestQuery_Flows_DefaultWireLevelHidesOverlays asserts the flows
+// (paginated list) resource computes per-flow MessageCount from semantic
+// rows only by default, mirroring the messages / flow handlers.
+func TestQuery_Flows_DefaultWireLevelHidesOverlays(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, _, _ := seedFlowWithMixedWireLevels(t, store, "wl-flows")
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{Resource: "flows"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryFlowsResult
+	unmarshalQueryResult(t, result, &out)
+
+	var found *queryFlowsEntry
+	for i := range out.Flows {
+		if out.Flows[i].ID == id {
+			found = &out.Flows[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("seeded flow %s missing from flows list (got %d entries)", id, len(out.Flows))
+	}
+	if found.MessageCount != semCount {
+		t.Errorf("message_count = %d, want %d (semantic only)", found.MessageCount, semCount)
+	}
+}
+
+// TestQuery_Flows_WireLevelAllInflatesCount asserts the flows resource
+// honours filter.wire_level=all and re-includes the overlay rows in the
+// per-flow MessageCount aggregate.
+func TestQuery_Flows_WireLevelAllInflatesCount(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	id, semCount, h2Count, lpmCount := seedFlowWithMixedWireLevels(t, store, "wl-flows-all")
+	totalRows := semCount + h2Count + lpmCount
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "flows",
+		Filter:   &queryFilter{WireLevel: "all"},
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	var out queryFlowsResult
+	unmarshalQueryResult(t, result, &out)
+
+	var found *queryFlowsEntry
+	for i := range out.Flows {
+		if out.Flows[i].ID == id {
+			found = &out.Flows[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("seeded flow %s missing from flows list", id)
+	}
+	if found.MessageCount != totalRows {
+		t.Errorf("message_count = %d, want %d (every wire_level)", found.MessageCount, totalRows)
+	}
+}
+
+// TestResolveWireLevelFilter covers the helper unit-level: empty / unset
+// → semantic default, "all" → empty (no predicate), valid overlay →
+// pass-through, invalid → enum error.
+func TestResolveWireLevelFilter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		filter  *queryFilter
+		want    string
+		wantErr bool
+	}{
+		{"nil filter defaults to semantic", nil, flow.WireLevelSemantic, false},
+		{"empty value defaults to semantic", &queryFilter{}, flow.WireLevelSemantic, false},
+		{"explicit semantic passes through", &queryFilter{WireLevel: flow.WireLevelSemantic}, flow.WireLevelSemantic, false},
+		{"h2-frame passes through", &queryFilter{WireLevel: flow.WireLevelH2Frame}, flow.WireLevelH2Frame, false},
+		{"h1-chunk passes through", &queryFilter{WireLevel: flow.WireLevelHTTP1Chunk}, flow.WireLevelHTTP1Chunk, false},
+		{"grpc-lpm-frame passes through", &queryFilter{WireLevel: flow.WireLevelGRPCLPMFrame}, flow.WireLevelGRPCLPMFrame, false},
+		{"grpcweb-base64 passes through", &queryFilter{WireLevel: flow.WireLevelGRPCWebBase64}, flow.WireLevelGRPCWebBase64, false},
+		{"all disables predicate", &queryFilter{WireLevel: "all"}, "", false},
+		{"unknown value rejected", &queryFilter{WireLevel: "ws-frame"}, "", true},
+		{"case-sensitive rejection", &queryFilter{WireLevel: "Semantic"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveWireLevelFilter(tt.filter)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `filter.wire_level` to the `query` tool input schema (enum: `semantic` / `h2-frame` / `h1-chunk` / `grpc-lpm-frame` / `grpcweb-base64` / `all`).
- Hard-default to `wire_level=semantic` at the MCP query-tool boundary so the L7 view never returns wire-level overlay rows by default. AI agents opt in via `filter.wire_level={overlay value | all}`.
- Wired into all three handlers that re-issue `GetFlows` without the SQL filter:
  - `handleQueryMessages` — fixes the `message_count: 9 -> 5` regression reported in USK-921 (tcp_forwards gRPC) and the same defect on live MITM gRPC, WS-over-h2, SSE-over-h2, SSE-over-h1-chunked, and gRPC-Web-text paths.
  - `handleQueryFlow` — also drives `MessageCount` and `MessagePreview` projections.
  - `handleQueryFlows` — drives the per-flow `MessageCount` aggregate.
- `queryMessagesResult.Total` reflects the filtered count when the `wire_level` predicate is active so pagination stays consistent.
- `queryMessageEntry.wire_level` surfaces the discriminator (omitempty) so callers who opted in to overlay rows can tell which framing view each entry represents.
- DB wire copy is untouched — the default is a cosmetic projection at the MCP transport boundary, not a wire-data modification. L4-capable promise intact (see `docs/rfc/envelope.md` §3.2.3 + CLAUDE.md MITM principle #3).

## Test plan

- [x] Unit + JSON-RPC harness tests in `internal/mcp/query_wire_level_test.go`:
  - Default `query messages` over a mixed-wire_level fixture (5 semantic + 2 h2-frame + 2 grpc-lpm-frame rows) returns only the 5 semantic envelopes (the canonical USK-921 unary RPC count).
  - Explicit `filter.wire_level=h2-frame` returns only the 2 h2-frame rows and surfaces the discriminator on each entry.
  - `filter.wire_level=all` returns every wire_level (9 rows) with the discriminator visible for overlay rows.
  - Invalid `wire_level` value surfaces the canonical enum error listing all accepted values.
  - `query flow` `MessageCount` + `MessagePreview` honour the semantic default; `wire_level=all` re-inflates the count.
  - `query flows` per-flow `MessageCount` honours the semantic default; `wire_level=all` re-inflates.
  - `resolveWireLevelFilter` unit table covers nil filter, empty, every overlay value, `all`, and rejection paths.
- [x] `make lint` clean
- [x] `make build` succeeds
- [x] `make test` passes (fast tier, no regressions in any other package)

## Notes for reviewers

- Single-point fix at the MCP boundary; no changes to data-path code (`internal/layer/`, `internal/proxybuild/`, `internal/session/`, `internal/pipeline/`). Wire-level overlay producers (USK-889 / USK-895 / USK-897 / USK-898 / USK-899) keep emitting overlay rows; only the default cosmetic projection at the AI-agent-facing MCP boundary changes.
- `flow.FlowListOptions.WireLevel` was already in the storage layer (used by `internal/flow/har.go:207-221` for HAR export consistency). This PR just plumbs the same SQL filter into the MCP query path.
- The `Total` correction in `handleQueryMessages` uses `len(allMsgs)` whenever direction OR wire_level filtering reduced the result set; without it `Total` would over-report by the overlay-row count when the default semantic predicate fires.

### Deferred follow-ups (intentionally out of scope)

- Cleanup of `pickGRPCStartFlow` defensive search in `resend_grpc_helpers.go` (USK-920) is unnecessary once overlay rows are filtered, but the existing defensive code remains correct after this fix.
- Advisory message ("hidden N wire-level rows; pass filter.wire_level=... to inspect") for discoverability.
- Export consistency review for JSONL / cURL exports (HAR is already correctly filtered).

Resolves USK-921
Linear: https://linear.app/usk6666/issue/USK-921

🤖 Generated with [Claude Code](https://claude.com/claude-code)