### PR TITLE
docs(help_proxy_start): clarify url_prefix matches gRPC :path (USK-919)

### DIFF
--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -138,7 +138,12 @@ Use `capture_scope` to suppress noise from third-party CDNs / analytics / fonts 
 
 Each rule is AND-evaluated across `hostname` / `url_prefix` / `method`; at least one field per rule must be non-empty. `excludes` are evaluated before `includes`. Empty `includes` means "all flows are eligible". `*.example.com` wildcard matches subdomains but NOT the apex `example.com`.
 
-Non-HTTP envelopes (WebSocket frames, gRPC frames, SSE events, raw TCP) carry no method/path; rules that require either field never match those envelopes. To capture an entire WebSocket / gRPC stream by hostname, set the rule on the upgrade / first-Send envelope (HTTP) — the recording decision is cached per-stream and applied to subsequent frames.
+Per-protocol matching of `url_prefix` / `method`:
+
+- **HTTP/1.x and HTTP/2 envelopes** — method and path are matched directly against the request line / `:path`.
+- **gRPC envelopes** — the request-side `GRPCStart` envelope carries the HTTP/2 `:path` value (`/Service/Method`) and an implicit `:method = POST`, so `url_prefix` and `method` rules match against gRPC streams. Example: `{"url_prefix": "/hello.HelloService/"}` in `excludes` will skip every RPC under that service while still recording other RPCs on the same connection. A malformed `:path` that leaves Service or Method empty does not synthesize a partial path, so `/Service/` cannot spuriously prefix-match.
+- **WebSocket frame envelopes and SSE event envelopes** — individual frames / events carry no method/path, so `url_prefix` and `method` rules do not match against them. The initial HTTP upgrade envelope IS subject to those rules, and the recording decision is cached per-stream and applied to subsequent frames — set the rule on the upgrade request to capture an entire WS / SSE stream.
+- **Raw TCP envelopes** — no method/path; `url_prefix` and `method` rules never match. Use `hostname` (resolved from the CONNECT/SOCKS5 target or TLS SNI) to scope raw TCP recording.
 
 Blocked flows (target_scope deny / rate_limit / safety_filter blocks) are recorded by their respective recorder paths; capture_scope governs only the normal Pipeline-Record code path.
 


### PR DESCRIPTION
## Summary

- Fixes incorrect `capture_scope` help text in `help_proxy_start.md` that misled operators (and AI agents) into thinking `url_prefix` rules never match gRPC envelopes. In practice gRPC carries the HTTP/2 `:path` (`/Service/Method`) so `url_prefix` matches and `include` / `exclude` works correctly for gRPC. `method` also matches (the proxy synthesizes the implicit `POST` from gRPC's HTTP/2 binding).
- Adds clarifying language for WS frame / SSE event envelopes (frames do not carry method/path; the upgrade-time HTTP envelope DOES, and the recording decision is cached per-stream) and for raw TCP (never matches `url_prefix` / `method`; scope via `hostname` instead).
- Implementation verified in `internal/flow/record_scope.go:189-200` — `extractScopeFields` synthesizes `path = /Service/Method` and `method = POST` for `*envelope.GRPCStartMessage`, while `*envelope.WSMessage` / `*envelope.SSEMessage` / `*envelope.RawMessage` fall through with empty method/path.
- Docs-only change. No `.go` files modified.

## Test plan

- [x] Manually re-read the updated `capture_scope` section in `help_proxy_start.md` for accuracy
- [x] `make lint` clean
- [x] `make build` clean
- [x] `make test` clean (no test asserted the old verbatim sentence)
- [ ] On-merge: verify the help text renders correctly in the MCP `help_proxy_start` resource

Resolves USK-919
Linear: https://linear.app/usk6666/issue/USK-919

Generated with [Claude Code](https://claude.com/claude-code)