### PR TITLE
feat(tcp_forwards,config,mcp): upstream_insecure_skip_verify per-entry override (USK-918)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,12 @@ func isValidProjectNameRune(r rune) bool {
 // Both fields default to false, which preserves the existing raw-forward
 // behavior. Target's scheme/port are advisory only; they do not change the
 // effective TLS / UpstreamTLS values.
+//
+// Upstream TLS certificate verification defaults to the global
+// Config.InsecureSkipVerify setting; a per-entry
+// UpstreamInsecureSkipVerify (*bool, nil/true/false) overrides that global
+// when set (USK-918). The override is scoped to the tcp_forwards entry and
+// is independent of the CONNECT-MITM tls_passthrough path.
 type ForwardConfig struct {
 	// Target is the upstream address (e.g. "api.example.com:50051").
 	Target string `json:"target"`
@@ -427,6 +433,19 @@ type ForwardConfig struct {
 	// independent of TLS and is not inferred from Target's scheme/port.
 	// See the type-level godoc for the full TLS × UpstreamTLS matrix.
 	UpstreamTLS bool `json:"upstream_tls,omitempty"`
+
+	// UpstreamInsecureSkipVerify is a per-entry override for upstream TLS
+	// certificate verification when UpstreamTLS=true. Tri-state semantics:
+	//   - nil   = inherit the global Config.InsecureSkipVerify (default)
+	//   - true  = skip verification on this entry (insecure; equivalent of
+	//             grpcurl -insecure / curl -k, but scoped per tcp_forwards
+	//             entry)
+	//   - false = enforce verification on this entry even when the global
+	//             flag is true
+	//
+	// Used for MITM-debugging local upstreams whose self-signed certs lack
+	// SAN entries for the dialled host/IP (e.g. moul/grpcbin). USK-918.
+	UpstreamInsecureSkipVerify *bool `json:"upstream_insecure_skip_verify,omitempty"`
 }
 
 // validForwardProtocols is the set of valid protocol values for ForwardConfig.

--- a/internal/config/forward_config_test.go
+++ b/internal/config/forward_config_test.go
@@ -115,6 +115,11 @@ func TestForwardConfig_UnmarshalJSON_TLSUpstreamTLSMatrix(t *testing.T) {
 // omitempty tag on UpstreamTLS prevents the field from leaking false
 // defaults into the serialized output, matching the existing TLS
 // behavior. USK-911.
+//
+// USK-918: also asserts that the *bool UpstreamInsecureSkipVerify is
+// omitted when nil but emitted (including the explicit `false`) when
+// non-nil. The tri-state distinguishes "inherit global" from
+// "explicitly enforce" — the explicit false MUST survive Marshal.
 func TestForwardConfig_MarshalJSON_OmitEmptyDefaults(t *testing.T) {
 	fc := &ForwardConfig{Target: "h:9000", Protocol: "raw"}
 	data, err := json.Marshal(fc)
@@ -128,6 +133,9 @@ func TestForwardConfig_MarshalJSON_OmitEmptyDefaults(t *testing.T) {
 	if strings.Contains(s, `"tls"`) {
 		t.Errorf("Marshal output should omit tls when false, got %s", s)
 	}
+	if strings.Contains(s, "upstream_insecure_skip_verify") {
+		t.Errorf("Marshal output should omit upstream_insecure_skip_verify when nil, got %s", s)
+	}
 
 	fc2 := &ForwardConfig{Target: "h:9000", Protocol: "raw", UpstreamTLS: true}
 	data2, err := json.Marshal(fc2)
@@ -137,12 +145,37 @@ func TestForwardConfig_MarshalJSON_OmitEmptyDefaults(t *testing.T) {
 	if !strings.Contains(string(data2), `"upstream_tls":true`) {
 		t.Errorf("Marshal output should include upstream_tls=true, got %s", string(data2))
 	}
+
+	// USK-918: *bool=true must Marshal to "upstream_insecure_skip_verify":true.
+	skip := true
+	fc3 := &ForwardConfig{Target: "h:9000", Protocol: "raw", UpstreamInsecureSkipVerify: &skip}
+	data3, err := json.Marshal(fc3)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data3), `"upstream_insecure_skip_verify":true`) {
+		t.Errorf("Marshal output should include upstream_insecure_skip_verify=true, got %s", string(data3))
+	}
+
+	// USK-918: *bool=false MUST also Marshal (NOT be omitted) — it
+	// distinguishes "explicitly enforce" from "inherit global".
+	enforce := false
+	fc4 := &ForwardConfig{Target: "h:9000", Protocol: "raw", UpstreamInsecureSkipVerify: &enforce}
+	data4, err := json.Marshal(fc4)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data4), `"upstream_insecure_skip_verify":false`) {
+		t.Errorf("Marshal output should include upstream_insecure_skip_verify=false (tri-state preserves explicit enforce), got %s", string(data4))
+	}
 }
 
 // TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations confirms the
-// (tls, upstream_tls) bits survive a Marshal → Unmarshal cycle in every
-// combination. USK-911.
+// (tls, upstream_tls, upstream_insecure_skip_verify) bits survive a
+// Marshal → Unmarshal cycle in every combination. USK-911 / USK-918.
 func TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations(t *testing.T) {
+	skip := true
+	enforce := false
 	cases := []struct {
 		name string
 		fc   ForwardConfig
@@ -151,6 +184,10 @@ func TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations(t *testing.T) {
 		{"tls only", ForwardConfig{Target: "h:9000", Protocol: "http", TLS: true}},
 		{"upstream_tls only", ForwardConfig{Target: "h:9000", Protocol: "http", UpstreamTLS: true}},
 		{"both true", ForwardConfig{Target: "h:9000", Protocol: "http", TLS: true, UpstreamTLS: true}},
+		// USK-918: tri-state UpstreamInsecureSkipVerify must round-trip.
+		{"upstream_tls + skip true", ForwardConfig{Target: "h:9000", Protocol: "http", UpstreamTLS: true, UpstreamInsecureSkipVerify: &skip}},
+		{"upstream_tls + skip false (enforce)", ForwardConfig{Target: "h:9000", Protocol: "http", UpstreamTLS: true, UpstreamInsecureSkipVerify: &enforce}},
+		{"both true + skip true", ForwardConfig{Target: "h:9000", Protocol: "http", TLS: true, UpstreamTLS: true, UpstreamInsecureSkipVerify: &skip}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -167,6 +204,73 @@ func TestForwardConfig_MarshalJSON_RoundTrip_AllCombinations(t *testing.T) {
 			}
 			if got.UpstreamTLS != tc.fc.UpstreamTLS {
 				t.Errorf("UpstreamTLS round-trip = %v, want %v (json=%s)", got.UpstreamTLS, tc.fc.UpstreamTLS, string(data))
+			}
+			// USK-918: pointer-aware comparison so nil round-trips to nil
+			// (inherit) and explicit true/false survive.
+			switch {
+			case tc.fc.UpstreamInsecureSkipVerify == nil && got.UpstreamInsecureSkipVerify != nil:
+				t.Errorf("UpstreamInsecureSkipVerify round-trip = %v, want nil (json=%s)", *got.UpstreamInsecureSkipVerify, string(data))
+			case tc.fc.UpstreamInsecureSkipVerify != nil && got.UpstreamInsecureSkipVerify == nil:
+				t.Errorf("UpstreamInsecureSkipVerify round-trip = nil, want %v (json=%s)", *tc.fc.UpstreamInsecureSkipVerify, string(data))
+			case tc.fc.UpstreamInsecureSkipVerify != nil && got.UpstreamInsecureSkipVerify != nil:
+				if *got.UpstreamInsecureSkipVerify != *tc.fc.UpstreamInsecureSkipVerify {
+					t.Errorf("UpstreamInsecureSkipVerify round-trip = %v, want %v (json=%s)",
+						*got.UpstreamInsecureSkipVerify, *tc.fc.UpstreamInsecureSkipVerify, string(data))
+				}
+			}
+		})
+	}
+}
+
+// TestForwardConfig_UnmarshalJSON_UpstreamInsecureSkipVerify pins the
+// JSON-unmarshal handling of the USK-918 tri-state field across nil/true/
+// false inputs.
+func TestForwardConfig_UnmarshalJSON_UpstreamInsecureSkipVerify(t *testing.T) {
+	cases := []struct {
+		name     string
+		json     string
+		wantNil  bool
+		wantBool bool
+	}{
+		{
+			name:    "omitted -> nil (inherit global)",
+			json:    `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "upstream_tls": true}}}`,
+			wantNil: true,
+		},
+		{
+			name:     "true -> *true (skip verify)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "upstream_tls": true, "upstream_insecure_skip_verify": true}}}`,
+			wantNil:  false,
+			wantBool: true,
+		},
+		{
+			name:     "false -> *false (enforce verify)",
+			json:     `{"tcp_forwards": {"9000": {"target": "h:9000", "protocol": "http", "upstream_tls": true, "upstream_insecure_skip_verify": false}}}`,
+			wantNil:  false,
+			wantBool: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg ProxyConfig
+			if err := json.Unmarshal([]byte(tc.json), &cfg); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			fc := cfg.TCPForwards["9000"]
+			if fc == nil {
+				t.Fatal("TCPForwards[9000] is nil")
+			}
+			if tc.wantNil {
+				if fc.UpstreamInsecureSkipVerify != nil {
+					t.Errorf("UpstreamInsecureSkipVerify = %v (non-nil), want nil", *fc.UpstreamInsecureSkipVerify)
+				}
+				return
+			}
+			if fc.UpstreamInsecureSkipVerify == nil {
+				t.Fatal("UpstreamInsecureSkipVerify = nil, want non-nil")
+			}
+			if *fc.UpstreamInsecureSkipVerify != tc.wantBool {
+				t.Errorf("UpstreamInsecureSkipVerify = %v, want %v", *fc.UpstreamInsecureSkipVerify, tc.wantBool)
 			}
 		})
 	}
@@ -369,6 +473,27 @@ func TestValidateForwardConfig(t *testing.T) {
 			name: "valid sse",
 			port: "8080",
 			fc:   &ForwardConfig{Target: "web:8080", Protocol: "sse"},
+		},
+		{
+			// USK-918: the per-entry verify-skip override is structurally
+			// validated by JSON schema and does not affect
+			// ValidateForwardConfig. Any *bool value is accepted; the
+			// MCP layer warns on the meaningless combination
+			// (skip=true && upstream_tls=false).
+			name: "valid upstream_tls + skip true",
+			port: "8443",
+			fc: func() *ForwardConfig {
+				b := true
+				return &ForwardConfig{Target: "h:8443", Protocol: "http", UpstreamTLS: true, UpstreamInsecureSkipVerify: &b}
+			}(),
+		},
+		{
+			name: "valid upstream_tls + skip false (enforce)",
+			port: "8443",
+			fc: func() *ForwardConfig {
+				b := false
+				return &ForwardConfig{Target: "h:8443", Protocol: "http", UpstreamTLS: true, UpstreamInsecureSkipVerify: &b}
+			}(),
 		},
 	}
 

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -86,7 +86,7 @@ type proxyStartInput struct {
 	// both formats in the MCP JSON schema; parsed into *config.ForwardConfig
 	// by parseTCPForwardsAny. See yorishiro://help/proxy_start for the full
 	// TLS × upstream_tls matrix.
-	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string (legacy) or {target, protocol, tls, upstream_tls} object. protocol: auto|raw|http|http2|grpc|websocket|sse (empty=auto). tls=client-side TLS MITM termination on the forwarded port; upstream_tls=upstream-dial TLS encryption to target. Both default false and are independent (4 combinations: plaintext/plaintext, TLS-terminate/plaintext, plaintext/TLS, TLS-terminate/TLS). See yorishiro://help/proxy_start for the full matrix."`
+	TCPForwards map[string]any `json:"tcp_forwards,omitempty" jsonschema:"TCP forwarding map: local port -> upstream host:port string (legacy) or {target, protocol, tls, upstream_tls, upstream_insecure_skip_verify} object. protocol: auto|raw|http|http2|grpc|websocket|sse (empty=auto). tls=client-side TLS MITM termination on the forwarded port; upstream_tls=upstream-dial TLS encryption to target. Both default false and are independent (4 combinations: plaintext/plaintext, TLS-terminate/plaintext, plaintext/TLS, TLS-terminate/TLS). upstream_insecure_skip_verify (optional bool) is a per-entry override: skip upstream TLS certificate verification for this forward; default inherits global insecure_skip_verify. See yorishiro://help/proxy_start for the full matrix."`
 
 	// SOCKS5Auth specifies the SOCKS5 authentication method.
 	// Valid values: "none" (default), "password".
@@ -168,6 +168,13 @@ func parseTCPForwardsAny(raw map[string]any) (map[string]*config.ForwardConfig, 
 			}
 			if utls, ok := v["upstream_tls"].(bool); ok {
 				fc.UpstreamTLS = utls
+			}
+			// USK-918: per-entry override for upstream TLS certificate
+			// verification. Tri-state preserves "nil = inherit global"
+			// distinct from "explicitly false = enforce".
+			if uisv, ok := v["upstream_insecure_skip_verify"].(bool); ok {
+				b := uisv
+				fc.UpstreamInsecureSkipVerify = &b
 			}
 			result[port] = fc
 		default:
@@ -741,27 +748,9 @@ func validateTCPForwardsConfig(forwards map[string]*config.ForwardConfig) error 
 		if err := config.ValidateForwardConfig(port, fc); err != nil {
 			return err
 		}
-		// Warn about unusual but valid combination: TLS termination without L7 parsing.
-		if fc.TLS && fc.Protocol == "raw" {
-			slog.Warn("TCP forward: tls=true with protocol=raw means TLS termination without L7 parsing",
-				"port", port, "target", fc.Target)
-		}
-		// Warn about unusual but valid combination: upstream TLS encryption
-		// wrapping an opaque byte stream (USK-911). Permitted, but typically
-		// the operator wants L7 parsing in front of upstream TLS too.
-		if fc.UpstreamTLS && fc.Protocol == "raw" {
-			slog.Warn("TCP forward: upstream_tls=true with protocol=raw means upstream TLS encryption without L7 parsing",
-				"port", port, "target", fc.Target)
-		}
-		// Inform operators that the TLS field's semantics are now strictly
-		// scoped to client-side termination (USK-911). Users who previously
-		// set tls=true expecting upstream encryption must now also set
-		// upstream_tls=true. Emitted per-entry whenever TLS=true so the
-		// notice reliably reaches operators of any matching config.
-		if fc.TLS {
-			slog.Info("TCP forward: tls now means client-side termination only; for upstream TLS use upstream_tls=true",
-				"port", port, "target", fc.Target, "upstream_tls", fc.UpstreamTLS)
-		}
+		// Emit warn/info diagnostics for surprising but valid field
+		// combinations. Pure logging — does not gate the validation.
+		logTCPForwardEntryDiagnostics(port, fc)
 		// Validate target is host:port format.
 		host, p, err := net.SplitHostPort(fc.Target)
 		if err != nil {
@@ -778,6 +767,52 @@ func validateTCPForwardsConfig(forwards map[string]*config.ForwardConfig) error 
 		}
 	}
 	return nil
+}
+
+// logTCPForwardEntryDiagnostics emits the operator-facing warn/info logs
+// for a single tcp_forwards entry. Pure logging path — every code path
+// here is informational and never rejects the config. Extracted from
+// validateTCPForwardsConfig to keep its cyclomatic complexity below the
+// project lint threshold.
+func logTCPForwardEntryDiagnostics(port string, fc *config.ForwardConfig) {
+	// Warn about unusual but valid combination: TLS termination without L7 parsing.
+	if fc.TLS && fc.Protocol == "raw" {
+		slog.Warn("TCP forward: tls=true with protocol=raw means TLS termination without L7 parsing",
+			"port", port, "target", fc.Target)
+	}
+	// Warn about unusual but valid combination: upstream TLS encryption
+	// wrapping an opaque byte stream (USK-911). Permitted, but typically
+	// the operator wants L7 parsing in front of upstream TLS too.
+	if fc.UpstreamTLS && fc.Protocol == "raw" {
+		slog.Warn("TCP forward: upstream_tls=true with protocol=raw means upstream TLS encryption without L7 parsing",
+			"port", port, "target", fc.Target)
+	}
+	// Inform operators that the TLS field's semantics are now strictly
+	// scoped to client-side termination (USK-911). Users who previously
+	// set tls=true expecting upstream encryption must now also set
+	// upstream_tls=true. Emitted per-entry whenever TLS=true so the
+	// notice reliably reaches operators of any matching config.
+	if fc.TLS {
+		slog.Info("TCP forward: tls now means client-side termination only; for upstream TLS use upstream_tls=true",
+			"port", port, "target", fc.Target, "upstream_tls", fc.UpstreamTLS)
+	}
+	// USK-918: warn when the per-entry verify-skip override is set true
+	// without upstream_tls — the override only takes effect on the
+	// upstream-TLS dial path, so this combination is meaningless and
+	// likely a misconfiguration. Accept (do not reject) per the
+	// existing warn-only sibling pattern above.
+	if fc.UpstreamInsecureSkipVerify != nil && *fc.UpstreamInsecureSkipVerify && !fc.UpstreamTLS {
+		slog.Warn("TCP forward: upstream_insecure_skip_verify=true with upstream_tls=false has no effect; the override only applies when dialling upstream over TLS",
+			"port", port, "target", fc.Target)
+	}
+	// USK-918: surface the security event when the per-entry override
+	// resolves to "skip" (insecure) and upstream TLS is in play.
+	// Logged at Info per CLAUDE.md Log Level Guidelines (security
+	// event the operator should see by default).
+	if fc.UpstreamInsecureSkipVerify != nil && *fc.UpstreamInsecureSkipVerify && fc.UpstreamTLS {
+		slog.Info("TCP forward: upstream TLS certificate verification BYPASSED for this entry (insecure)",
+			"port", port, "target", fc.Target)
+	}
 }
 
 // validatePortNumber checks that s is a valid TCP port number.

--- a/internal/mcp/proxy_start_tool_test.go
+++ b/internal/mcp/proxy_start_tool_test.go
@@ -1109,6 +1109,96 @@ func TestParseTCPForwardsAny_UpstreamTLS(t *testing.T) {
 	}
 }
 
+// TestParseTCPForwardsAny_UpstreamInsecureSkipVerify verifies the
+// MCP input parser extracts the USK-918 tri-state
+// `upstream_insecure_skip_verify` field from the
+// map[string]any branch (the live MCP path), preserving the
+// nil/true/false distinction and defensively ignoring non-bool input.
+// The default-branch JSON round-trip path is already covered by
+// TestForwardConfig_UnmarshalJSON_UpstreamInsecureSkipVerify in
+// internal/config; this test pins the explicit field-extraction branch
+// in parseTCPForwardsAny that the MCP go-sdk currently feeds.
+func TestParseTCPForwardsAny_UpstreamInsecureSkipVerify(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    map[string]any
+		wantNil  bool
+		wantBool bool
+	}{
+		{
+			// Field omitted → nil (inherit global default).
+			name: "omitted -> nil (inherit global)",
+			input: map[string]any{
+				"9000": map[string]any{"target": "h:9000", "protocol": "http", "upstream_tls": true},
+			},
+			wantNil: true,
+		},
+		{
+			// USK-918 motivating shape: explicit true → *true (skip verify).
+			name: "true -> *true (skip verify)",
+			input: map[string]any{
+				"9000": map[string]any{
+					"target": "h:9000", "protocol": "http",
+					"upstream_tls": true, "upstream_insecure_skip_verify": true,
+				},
+			},
+			wantNil:  false,
+			wantBool: true,
+		},
+		{
+			// Explicit false must survive parsing — distinguishes
+			// "explicitly enforce" from "inherit global" (which may itself be true).
+			name: "false -> *false (enforce verify)",
+			input: map[string]any{
+				"9000": map[string]any{
+					"target": "h:9000", "protocol": "http",
+					"upstream_tls": true, "upstream_insecure_skip_verify": false,
+				},
+			},
+			wantNil:  false,
+			wantBool: false,
+		},
+		{
+			// Defensive: non-bool input is silently ignored (field stays nil),
+			// matching the sibling upstream_tls non-bool behavior above.
+			name: "non-bool is ignored -> nil",
+			input: map[string]any{
+				"9000": map[string]any{
+					"target": "h:9000", "protocol": "http",
+					"upstream_tls": true, "upstream_insecure_skip_verify": "yes",
+				},
+			},
+			wantNil: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseTCPForwardsAny(tc.input)
+			if err != nil {
+				t.Fatalf("parseTCPForwardsAny: %v", err)
+			}
+			fc := parsed["9000"]
+			if fc == nil {
+				t.Fatal("parsed[9000] is nil")
+			}
+			if tc.wantNil {
+				if fc.UpstreamInsecureSkipVerify != nil {
+					t.Errorf("UpstreamInsecureSkipVerify = %v (non-nil), want nil",
+						*fc.UpstreamInsecureSkipVerify)
+				}
+				return
+			}
+			if fc.UpstreamInsecureSkipVerify == nil {
+				t.Fatal("UpstreamInsecureSkipVerify = nil, want non-nil")
+			}
+			if *fc.UpstreamInsecureSkipVerify != tc.wantBool {
+				t.Errorf("UpstreamInsecureSkipVerify = %v, want %v",
+					*fc.UpstreamInsecureSkipVerify, tc.wantBool)
+			}
+		})
+	}
+}
+
 func TestApplyProxyDefaults_InterceptRules(t *testing.T) {
 	rulesJSON := json.RawMessage(`[{
 		"id": "default-rule",

--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -54,6 +54,8 @@ Each entry maps a local port number (string key) to either:
     When true, the proxy presents a dynamically-issued certificate to the local client and terminates TLS before applying L7 parsing.
   - **upstream_tls** (boolean, optional): Enable upstream-dial TLS encryption to `target`. Default: `false`.
     When true, the proxy wraps the upstream-direction connection in TLS (using the global TLS fingerprint, SNI derived from `target`, and the configured verification / client-cert settings).
+  - **upstream_insecure_skip_verify** (boolean, optional): Per-entry override: skip upstream TLS certificate verification for this forward. Default: inherits global `insecure_skip_verify`.
+    Useful for MITM-debugging local upstreams whose self-signed certs lack SAN entries for the dialled host/IP (e.g. `moul/grpcbin`). Scoped per `tcp_forwards` entry and independent of the CONNECT MITM `tls_passthrough` path.
 
 `tls` and `upstream_tls` are **independent** and are never inferred from `target`'s scheme or port:
 

--- a/internal/mcp/resources/schema_proxy_start.json
+++ b/internal/mcp/resources/schema_proxy_start.json
@@ -65,6 +65,10 @@
               "upstream_tls": {
                 "type": "boolean",
                 "description": "Enable upstream-dial TLS encryption to target. Independent of tls; not inferred from target scheme. Default: false."
+              },
+              "upstream_insecure_skip_verify": {
+                "type": "boolean",
+                "description": "Per-entry override: skip upstream TLS certificate verification for this forward. Default: inherits global insecure_skip_verify."
               }
             },
             "additionalProperties": false

--- a/internal/proxybuild/tcp_forward_tls.go
+++ b/internal/proxybuild/tcp_forward_tls.go
@@ -505,8 +505,13 @@ func dialForwardUpstream(
 	//
 	// USK-918: a per-entry UpstreamInsecureSkipVerify (*bool) overrides
 	// the global flag when non-nil. Tri-state: nil inherits global; true
-	// forces skip; false forces enforce. Mirrors the HostTLSEntry.TLSVerify
-	// pattern at internal/connector/transport/tlstransport.go.
+	// forces skip; false forces enforce. The shape (*bool tri-state, per-entry
+	// overrides global) mirrors the sibling HostTLSEntry.TLSVerify pattern at
+	// internal/connector/transport/tlstransport.go, but the semantic axis is
+	// inverted: TLSVerify is true=enforce / false=skip whereas
+	// UpstreamInsecureSkipVerify is true=skip / false=enforce. The latter
+	// matches the existing global Config.InsecureSkipVerify field that this
+	// per-entry override resolves against.
 	dialOpts.InsecureSkipVerify = resolveUpstreamInsecureSkipVerify(entry.fc, parentStack)
 
 	conn, snap, err := connector.DialUpstreamRaw(ctx, entry.target, dialOpts)
@@ -555,9 +560,12 @@ func dialForwardUpstream(
 //
 // Extracted as a pure helper so the resolution is unit-testable
 // independently of the dial path that builds *tls.Config and performs the
-// TCP/TLS handshake. Mirrors the sibling
-// HostTLSEntry.TLSVerify resolution at
-// internal/connector/transport/tlstransport.go.
+// TCP/TLS handshake. The (*bool, per-entry overrides global) resolution
+// shape mirrors the sibling HostTLSEntry.TLSVerify resolution at
+// internal/connector/transport/tlstransport.go, but the semantic axis is
+// inverted: TLSVerify uses true=enforce / false=skip; this field uses
+// true=skip / false=enforce (consistent with the existing global
+// Config.InsecureSkipVerify field it overrides).
 func resolveUpstreamInsecureSkipVerify(fc *config.ForwardConfig, parentStack *Stack) bool {
 	if fc != nil && fc.UpstreamInsecureSkipVerify != nil {
 		return *fc.UpstreamInsecureSkipVerify

--- a/internal/proxybuild/tcp_forward_tls.go
+++ b/internal/proxybuild/tcp_forward_tls.go
@@ -500,11 +500,14 @@ func dialForwardUpstream(
 
 	dialOpts.TLSConfig = tlsCfg
 	dialOpts.OfferALPN = tlsCfg.NextProtos
-	// USK-916 scope: only the global InsecureSkipVerify flag is honoured;
+	// USK-916 scope: only the InsecureSkipVerify axis is honoured;
 	// per-host TLS material (mTLS / uTLS / HostTLSRegistry) is deferred.
-	if parentStack != nil && parentStack.BuildConfig != nil {
-		dialOpts.InsecureSkipVerify = parentStack.BuildConfig.InsecureSkipVerify
-	}
+	//
+	// USK-918: a per-entry UpstreamInsecureSkipVerify (*bool) overrides
+	// the global flag when non-nil. Tri-state: nil inherits global; true
+	// forces skip; false forces enforce. Mirrors the HostTLSEntry.TLSVerify
+	// pattern at internal/connector/transport/tlstransport.go.
+	dialOpts.InsecureSkipVerify = resolveUpstreamInsecureSkipVerify(entry.fc, parentStack)
 
 	conn, snap, err := connector.DialUpstreamRaw(ctx, entry.target, dialOpts)
 	if err != nil {
@@ -537,6 +540,32 @@ func dialForwardUpstream(
 	}
 
 	return conn, snap, nil
+}
+
+// resolveUpstreamInsecureSkipVerify computes the effective
+// InsecureSkipVerify value for an upstream-TLS dial on a tcp_forwards entry.
+// USK-918 tri-state precedence:
+//
+//   - fc.UpstreamInsecureSkipVerify != nil → use *fc.UpstreamInsecureSkipVerify
+//     (per-entry override; explicit true skips verify, explicit false
+//     enforces verify even when the global flag is true).
+//   - fc.UpstreamInsecureSkipVerify == nil → inherit
+//     parentStack.BuildConfig.InsecureSkipVerify (global default).
+//   - either operand missing → false (verify enforced).
+//
+// Extracted as a pure helper so the resolution is unit-testable
+// independently of the dial path that builds *tls.Config and performs the
+// TCP/TLS handshake. Mirrors the sibling
+// HostTLSEntry.TLSVerify resolution at
+// internal/connector/transport/tlstransport.go.
+func resolveUpstreamInsecureSkipVerify(fc *config.ForwardConfig, parentStack *Stack) bool {
+	if fc != nil && fc.UpstreamInsecureSkipVerify != nil {
+		return *fc.UpstreamInsecureSkipVerify
+	}
+	if parentStack != nil && parentStack.BuildConfig != nil {
+		return parentStack.BuildConfig.InsecureSkipVerify
+	}
+	return false
 }
 
 // configureForwardTLS prepares the per-entry MITM tls.Config cache.

--- a/internal/proxybuild/tcp_forward_tls_test.go
+++ b/internal/proxybuild/tcp_forward_tls_test.go
@@ -407,3 +407,88 @@ func TestUpstreamALPNOffersForForward_AutoOverrideNilSnapshot(t *testing.T) {
 		t.Errorf("upstreamALPNOffersForForward(auto, nil-snapshot) = %v, want %v", got, want)
 	}
 }
+
+// TestResolveUpstreamInsecureSkipVerify pins the USK-918 tri-state
+// precedence: per-entry *bool override > global BuildConfig flag > false.
+// Verifies the eight cross-product cases of (per-entry value × global flag).
+func TestResolveUpstreamInsecureSkipVerify(t *testing.T) {
+	skip := true
+	enforce := false
+	makeStack := func(globalSkip bool) *Stack {
+		return &Stack{BuildConfig: &connector.BuildConfig{
+			ProxyConfig:        &config.ProxyConfig{},
+			InsecureSkipVerify: globalSkip,
+		}}
+	}
+	cases := []struct {
+		name        string
+		fc          *config.ForwardConfig
+		parentStack *Stack
+		want        bool
+	}{
+		{
+			// Per-entry &true overrides global=false (the moul/grpcbin
+			// motivating case for USK-918).
+			name:        "per-entry true overrides global false → true (skip)",
+			fc:          &config.ForwardConfig{UpstreamInsecureSkipVerify: &skip},
+			parentStack: makeStack(false),
+			want:        true,
+		},
+		{
+			// Per-entry &false overrides global=true (operator forces
+			// enforce for one entry while leaving the global insecure).
+			name:        "per-entry false overrides global true → false (enforce)",
+			fc:          &config.ForwardConfig{UpstreamInsecureSkipVerify: &enforce},
+			parentStack: makeStack(true),
+			want:        false,
+		},
+		{
+			// Per-entry &true matches global=true (idempotent).
+			name:        "per-entry true with global true → true",
+			fc:          &config.ForwardConfig{UpstreamInsecureSkipVerify: &skip},
+			parentStack: makeStack(true),
+			want:        true,
+		},
+		{
+			// Per-entry &false matches global=false (idempotent).
+			name:        "per-entry false with global false → false",
+			fc:          &config.ForwardConfig{UpstreamInsecureSkipVerify: &enforce},
+			parentStack: makeStack(false),
+			want:        false,
+		},
+		{
+			// nil per-entry inherits global=true.
+			name:        "nil per-entry inherits global true → true",
+			fc:          &config.ForwardConfig{},
+			parentStack: makeStack(true),
+			want:        true,
+		},
+		{
+			// nil per-entry inherits global=false.
+			name:        "nil per-entry inherits global false → false",
+			fc:          &config.ForwardConfig{},
+			parentStack: makeStack(false),
+			want:        false,
+		},
+		{
+			// nil fc + nil parentStack → defensive default false.
+			name: "nil fc + nil parentStack → false",
+			want: false,
+		},
+		{
+			// non-nil fc with nil ptr + nil parentStack → false.
+			name: "nil per-entry + nil parentStack → false",
+			fc:   &config.ForwardConfig{},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveUpstreamInsecureSkipVerify(tc.fc, tc.parentStack)
+			if got != tc.want {
+				t.Errorf("resolveUpstreamInsecureSkipVerify(fc=%+v, parent=%v) = %v, want %v",
+					tc.fc, tc.parentStack != nil, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
+++ b/internal/proxybuild/tcp_forward_upstream_tls_integration_test.go
@@ -49,7 +49,11 @@ type upstreamTLSFixtureOpts struct {
 	clientTLS    bool // fc.TLS=true
 	upstreamTLS  bool // fc.UpstreamTLS=true (always true in USK-916 tests)
 	insecureSkip bool // BuildConfig.InsecureSkipVerify
-	pluginEngine *pluginv2.Engine
+	// perEntryInsecureSkipVerify (USK-918) sets
+	// ForwardConfig.UpstreamInsecureSkipVerify when non-nil; tri-state
+	// override of the global insecureSkip above.
+	perEntryInsecureSkipVerify *bool
+	pluginEngine               *pluginv2.Engine
 }
 
 // newUpstreamTLSFixture spins up a Manager with a forward listener whose
@@ -99,10 +103,11 @@ func newUpstreamTLSFixture(t *testing.T, ctx context.Context, upstreamAddr strin
 	if err := mgr.StartTCPForwards(ctx, proxybuild.TCPForwardParams{
 		Forwards: map[string]*config.ForwardConfig{
 			"0": {
-				Target:      upstreamAddr,
-				Protocol:    opts.protocol,
-				TLS:         opts.clientTLS,
-				UpstreamTLS: opts.upstreamTLS,
+				Target:                     upstreamAddr,
+				Protocol:                   opts.protocol,
+				TLS:                        opts.clientTLS,
+				UpstreamTLS:                opts.upstreamTLS,
+				UpstreamInsecureSkipVerify: opts.perEntryInsecureSkipVerify,
 			},
 		},
 	}); err != nil {
@@ -592,6 +597,108 @@ func TestProxybuild_UpstreamTLS_CertVerifyFailure_RecordsError(t *testing.T) {
 	if !waitForUpstreamTLSErrorStream(t, fix.store, 3*time.Second) {
 		t.Errorf("no Stream recorded with FailureReason=upstream_tls_error; got %v",
 			summarizeStreams(fix.store.Streams()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3a) Per-entry upstream_insecure_skip_verify override (USK-918).
+// ---------------------------------------------------------------------------
+
+// TestTCPForward_UpstreamTLS_PerEntryInsecureSkipVerify drives the tri-state
+// override matrix introduced by USK-918. Each cell exercises a different
+// (global × per-entry) combination against a self-signed httptest upstream
+// and asserts whether the dial succeeds (recorded as a complete Stream) or
+// fails (recorded as a FailureReason="upstream_tls_error" Stream).
+//
+// The single dial site (dialForwardUpstream) covers both H1 and H2 forward
+// arms; the H1 protocol is exercised here as the cheapest probe. The pure
+// resolution logic is independently covered by
+// TestResolveUpstreamInsecureSkipVerify.
+func TestTCPForward_UpstreamTLS_PerEntryInsecureSkipVerify(t *testing.T) {
+	skip := true
+	enforce := false
+	cases := []struct {
+		name            string
+		globalSkip      bool
+		perEntry        *bool
+		wantHandshakeOK bool
+	}{
+		{
+			// USK-918 motivating case: global enforce, per-entry skip → succeed.
+			name:            "global_false_per_entry_true_succeeds",
+			globalSkip:      false,
+			perEntry:        &skip,
+			wantHandshakeOK: true,
+		},
+		{
+			// Per-entry enforce wins over global skip → fail.
+			name:            "global_true_per_entry_false_fails",
+			globalSkip:      true,
+			perEntry:        &enforce,
+			wantHandshakeOK: false,
+		},
+		{
+			// nil per-entry inherits global skip → succeed.
+			name:            "global_true_per_entry_nil_inherits_succeeds",
+			globalSkip:      true,
+			perEntry:        nil,
+			wantHandshakeOK: true,
+		},
+		{
+			// nil per-entry inherits global enforce → fail.
+			name:            "global_false_per_entry_nil_inherits_fails",
+			globalSkip:      false,
+			perEntry:        nil,
+			wantHandshakeOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			upAddr, _, stopUp := startTLSHTTPEchoUpstream(t)
+			defer stopUp()
+
+			fix := newUpstreamTLSFixture(t, ctx, upAddr, upstreamTLSFixtureOpts{
+				protocol:                   "http",
+				clientTLS:                  false,
+				upstreamTLS:                true,
+				insecureSkip:               tc.globalSkip,
+				perEntryInsecureSkipVerify: tc.perEntry,
+			})
+
+			req := "GET /usk918-matrix HTTP/1.1\r\nHost: upstream.example.test\r\nConnection: close\r\n\r\n"
+			conn, err := net.Dial("tcp", fix.fwdAddr)
+			if err != nil {
+				t.Fatalf("net.Dial: %v", err)
+			}
+			defer conn.Close()
+			if _, err := conn.Write([]byte(req)); err != nil {
+				t.Fatalf("conn.Write: %v", err)
+			}
+			buf, _ := io.ReadAll(conn)
+
+			if tc.wantHandshakeOK {
+				// Handshake-succeeds path: assert echo body reached the
+				// client (proof the upstream-TLS dial completed and the
+				// proxy forwarded the response back).
+				if !strings.Contains(string(buf), "tls-echo:/usk918-matrix") {
+					t.Errorf("response missing echo body; got=%q (handshake-succeeds case should succeed)", string(buf))
+				}
+				if !waitForCompleteStream(t, fix.store, 3*time.Second) {
+					t.Errorf("no Stream reached state=complete on handshake-succeeds case; got %v",
+						summarizeStreams(fix.store.Streams()))
+				}
+			} else {
+				// Handshake-fails path: assert the recorder produced a
+				// state="error" Stream with FailureReason="upstream_tls_error".
+				if !waitForUpstreamTLSErrorStream(t, fix.store, 3*time.Second) {
+					t.Errorf("no Stream recorded with FailureReason=upstream_tls_error on handshake-fails case; got %v",
+						summarizeStreams(fix.store.Streams()))
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `upstream_insecure_skip_verify *bool` to `ForwardConfig` with tri-state semantics: `nil` = inherit global `insecure_skip_verify`, `true` = skip verify (insecure), `false` = enforce verify.
- Threads the per-entry value through `dialForwardUpstream` (single dial site covers both H1 and H2 forward arms). Resolution extracted as a pure helper `resolveUpstreamInsecureSkipVerify` for unit testability.
- Mirrors the sibling `HostTLSEntry.TLSVerify *bool` pattern exactly.
- MCP wiring: `parseTCPForwardsAny` explicit field handling, `validateTCPForwardsConfig` warns on `skip=true && upstream_tls=false` and info-logs when the resolved value is `true` (security event).
- JSON Schema + `help_proxy_start.md` updated.

Use case: MITM-debugging a local h2-TLS gRPC server (e.g. `moul/grpcbin`) with a self-signed cert that lacks IP SANs. Scoped per-entry so the HTTP CONNECT MITM path (`tls_passthrough`) is unaffected.

## Test plan

- [x] Unit: `internal/config/forward_config_test.go` matrix extended (Unmarshal tri-state, Marshal omitempty + explicit true/false survival, RoundTrip, Validate)
- [x] Unit: `internal/proxybuild/tcp_forward_tls_test.go` `TestResolveUpstreamInsecureSkipVerify` covers 8 cross-product cells (per-entry × global)
- [x] Integration: `tcp_forward_upstream_tls_integration_test.go` `TestTCPForward_UpstreamTLS_PerEntryInsecureSkipVerify` global × per-entry matrix (nil/true/false against self-signed upstream)
- [x] `make lint` clean
- [x] `make build` succeeds
- [x] `make test` passes
- [x] `make test-e2e-smoke` passes

Resolves USK-918
Linear: https://linear.app/usk6666/issue/USK-918

🤖 Generated with [Claude Code](https://claude.com/claude-code)