### PR TITLE
feat(mcp,flow): USK-921 follow-up bundle — resend simplification + query advisory + JSONL semantic default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ internal/
                            #   http_source.go, ws_source.go, grpc_source.go, raw_source.go,
                            #   fuzz_http_source.go, fuzz_raw_source.go
   macro/                   # Macro engine: template / guard / extract / encoder
-  flow/                    # Stream/Flow Store (sqlite); HAR / JSONL / cURL export, import
+  flow/                    # Stream/Flow Store (sqlite); HAR / JSONL export, import
   cert/                    # Root CA + dynamic server cert issuance
   config/                  # Configuration loading + validation (incl. Plugins, body-spill, limits)
   encoding/                # Protobuf framing helper

--- a/internal/flow/export.go
+++ b/internal/flow/export.go
@@ -50,6 +50,22 @@ type ExportOptions struct {
 	// MaxFlows limits the number of streams exported.
 	// 0 means no limit.
 	MaxFlows int
+	// WireLevel filters per-flow rows by the schemaV14 wire_level column
+	// (USK-932). Canonical values mirror flow.WireLevel* — "semantic",
+	// "h2-frame", "h1-chunk", "grpc-lpm-frame", "grpcweb-base64". Empty
+	// string disables the predicate at the SQL layer, returning rows of
+	// every wire_level — callers that want "all overlays included" pass
+	// the empty string. The MCP boundary (internal/mcp/manage_tool.go)
+	// resolves an unset user-facing field to WireLevelSemantic so JSONL
+	// export defaults align with the MCP query default and HAR export
+	// behaviour (USK-921 follow-up).
+	//
+	// The HAR exporter ignores this field — its data model (HAR 1.2
+	// request/response pairs) has no slot for per-frame overlay rows, and
+	// HAR enforces the semantic-only projection internally via
+	// filterSemanticFlows. Passing semantic to HAR is redundant; passing
+	// any overlay value is silently ignored.
+	WireLevel string
 }
 
 // ExportRecord represents a single JSONL line in the export format.
@@ -167,7 +183,12 @@ func ExportStreams(ctx context.Context, store Store, w io.Writer, opts ExportOpt
 			continue
 		}
 
-		flows, err := store.GetFlows(ctx, st.ID, FlowListOptions{})
+		// USK-932: pass through opts.WireLevel so JSONL export honors the
+		// MCP-boundary default (semantic) without inflating exports with
+		// overlay rows. The empty-string value (forensic "all" opt-in)
+		// disables the SQL predicate at the Store layer and returns rows
+		// of every wire_level.
+		flows, err := store.GetFlows(ctx, st.ID, FlowListOptions{WireLevel: opts.WireLevel})
 		if err != nil {
 			return exported, fmt.Errorf("get flows for stream %s: %w", st.ID, err)
 		}

--- a/internal/flow/har_test.go
+++ b/internal/flow/har_test.go
@@ -46,6 +46,24 @@ func (m *mockHARStore) CountFlows(_ context.Context, streamID string) (int, erro
 	return len(m.flows[streamID]), nil
 }
 
+func (m *mockHARStore) CountFlowsByWireLevel(_ context.Context, streamID string, opts FlowListOptions) (map[string]int, error) {
+	out := make(map[string]int)
+	for _, f := range m.flows[streamID] {
+		if f == nil {
+			continue
+		}
+		if opts.Direction != "" && f.Direction != opts.Direction {
+			continue
+		}
+		wl := f.WireLevel
+		if wl == "" {
+			wl = WireLevelSemantic
+		}
+		out[wl]++
+	}
+	return out, nil
+}
+
 func (m *mockHARStore) SaveStream(_ context.Context, _ *Stream) error                  { return nil }
 func (m *mockHARStore) UpdateStream(_ context.Context, _ string, _ StreamUpdate) error { return nil }
 func (m *mockHARStore) SaveFlow(_ context.Context, _ *Flow) error                      { return nil }

--- a/internal/flow/sqlite.go
+++ b/internal/flow/sqlite.go
@@ -877,6 +877,47 @@ func (s *SQLiteStore) CountFlows(ctx context.Context, streamID string) (int, err
 	return count, nil
 }
 
+// CountFlowsByWireLevel implements the FlowReader contract. SQL is a
+// single GROUP BY on the wire_level column so we never load per-flow
+// payloads just to count them. Empty-string wire_level rows (pre-V14
+// backfill) are folded into the semantic bucket at scan time so the
+// returned map only carries canonical keys.
+func (s *SQLiteStore) CountFlowsByWireLevel(ctx context.Context, streamID string, opts FlowListOptions) (map[string]int, error) {
+	query := "SELECT wire_level, COUNT(*) FROM flows WHERE stream_id = ?"
+	args := []interface{}{streamID}
+	if opts.Direction != "" {
+		query += " AND direction = ?"
+		args = append(args, opts.Direction)
+	}
+	query += " GROUP BY wire_level"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("count flows by wire_level: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]int)
+	for rows.Next() {
+		var wl string
+		var n int
+		if err := rows.Scan(&wl, &n); err != nil {
+			return nil, fmt.Errorf("scan wire_level count: %w", err)
+		}
+		// Backward compat: pre-V14 backfilled rows or rows whose
+		// producer never stamped wire_level fold into the semantic
+		// bucket per the column-default contract.
+		if wl == "" {
+			wl = WireLevelSemantic
+		}
+		out[wl] += n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iter wire_level rows: %w", err)
+	}
+	return out, nil
+}
+
 // SaveMacro persists a macro definition using upsert semantics.
 // If a macro with the same name exists, it is updated; otherwise a new one is created.
 func (s *SQLiteStore) SaveMacro(ctx context.Context, name, description, configJSON string) error {

--- a/internal/flow/store.go
+++ b/internal/flow/store.go
@@ -42,6 +42,26 @@ type FlowReader interface {
 
 	// CountFlows returns the number of flows for a stream.
 	CountFlows(ctx context.Context, streamID string) (int, error)
+
+	// CountFlowsByWireLevel returns the flow count for a stream grouped
+	// by the schemaV14 wire_level column (USK-931). The result map is
+	// keyed by the canonical wire_level value
+	// (semantic / h2-frame / h1-chunk / grpc-lpm-frame / grpcweb-base64);
+	// empty-string wire_level rows (pre-V14 backfill) are folded into
+	// the semantic bucket so callers do not need to handle both keys.
+	// Direction inside opts narrows the count to a single side; an
+	// empty Direction counts both. opts.WireLevel is ignored — the
+	// method is the GROUP-BY counterpart of CountFlows and always
+	// returns the full breakdown across every wire_level. Returns an
+	// empty map (not nil) when the stream has no flows.
+	//
+	// The MCP query tool (handleQueryFlow / handleQueryFlows /
+	// handleQueryMessages) calls this to derive the
+	// wire_level_advisory hint that surfaces the count of overlay
+	// rows suppressed by the default semantic-only filter (USK-921).
+	// DB-side GROUP BY avoids loading per-flow payloads just to count
+	// them.
+	CountFlowsByWireLevel(ctx context.Context, streamID string, opts FlowListOptions) (map[string]int, error)
 }
 
 // StreamWriter provides write access for creating and updating streams.

--- a/internal/job/http_source_test.go
+++ b/internal/job/http_source_test.go
@@ -74,6 +74,10 @@ func (r *mockFlowReader) CountFlows(_ context.Context, _ string) (int, error) {
 	return 0, nil
 }
 
+func (r *mockFlowReader) CountFlowsByWireLevel(_ context.Context, _ string, _ flow.FlowListOptions) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+
 // --- Test helpers ---
 
 func testURL(rawURL string) *url.URL {

--- a/internal/job/job_integration_test.go
+++ b/internal/job/job_integration_test.go
@@ -128,6 +128,24 @@ func (r *mockReader) CountFlows(_ context.Context, streamID string) (int, error)
 	return len(r.flows[streamID]), nil
 }
 
+func (r *mockReader) CountFlowsByWireLevel(_ context.Context, streamID string, opts flow.FlowListOptions) (map[string]int, error) {
+	out := make(map[string]int)
+	for _, f := range r.flows[streamID] {
+		if f == nil {
+			continue
+		}
+		if opts.Direction != "" && f.Direction != opts.Direction {
+			continue
+		}
+		wl := f.WireLevel
+		if wl == "" {
+			wl = flow.WireLevelSemantic
+		}
+		out[wl]++
+	}
+	return out, nil
+}
+
 // newTestTLSConfig creates a self-signed TLS config for a test server.
 func newTestTLSConfig(t *testing.T) *tls.Config {
 	t.Helper()

--- a/internal/mcp/fuzz_http_integration_test.go
+++ b/internal/mcp/fuzz_http_integration_test.go
@@ -1175,7 +1175,7 @@ func TestFuzzHTTP_PathWithQueryAutoSplit(t *testing.T) {
 			t.Errorf("variant %d has empty stream_id", v.Index)
 			continue
 		}
-		flows, err := store.GetFlows(ctx, v.StreamID, flow.FlowListOptions{Direction: "send"})
+		flows, err := store.GetFlows(ctx, v.StreamID, flow.FlowListOptions{Direction: "send", WireLevel: flow.WireLevelSemantic})
 		if err != nil {
 			t.Fatalf("GetFlows %s: %v", v.StreamID, err)
 		}

--- a/internal/mcp/manage_export_wire_level_test.go
+++ b/internal/mcp/manage_export_wire_level_test.go
@@ -1,0 +1,382 @@
+// Package mcp manage_export_wire_level_test.go — unit + integration
+// coverage for the export_flows wire_level filter (USK-932).
+//
+// USK-921 made MCP `query` default to `wire_level=semantic`; USK-932
+// extends the same default to the JSONL exporter so forensic JSONL output
+// no longer ships per-frame overlay rows (h2-frame / grpc-lpm-frame /
+// h1-chunk / grpcweb-base64) unless the caller passes wire_level="all"
+// (or one of the overlay values to isolate a single diagnostic view).
+//
+// The HAR exporter ignores opts.WireLevel — HAR 1.2 has no slot for
+// per-frame overlays and HAR enforces semantic-only internally via
+// filterSemanticFlows — so these tests focus on the JSONL path.
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+)
+
+// TestResolveExportWireLevel covers the validation + default resolution
+// shared by the JSONL exporter. Mirrors resolveWireLevelFilter (query
+// tool) so the two surfaces stay in lockstep.
+func TestResolveExportWireLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		filter    *exportFilter
+		want      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:   "nil_filter_defaults_to_semantic",
+			filter: nil,
+			want:   flow.WireLevelSemantic,
+		},
+		{
+			name:   "empty_value_defaults_to_semantic",
+			filter: &exportFilter{WireLevel: ""},
+			want:   flow.WireLevelSemantic,
+		},
+		{
+			name:   "all_disables_predicate",
+			filter: &exportFilter{WireLevel: "all"},
+			want:   "",
+		},
+		{
+			name:   "explicit_semantic_passes_through",
+			filter: &exportFilter{WireLevel: flow.WireLevelSemantic},
+			want:   flow.WireLevelSemantic,
+		},
+		{
+			name:   "h2_frame_passes_through",
+			filter: &exportFilter{WireLevel: flow.WireLevelH2Frame},
+			want:   flow.WireLevelH2Frame,
+		},
+		{
+			name:   "h1_chunk_passes_through",
+			filter: &exportFilter{WireLevel: flow.WireLevelHTTP1Chunk},
+			want:   flow.WireLevelHTTP1Chunk,
+		},
+		{
+			name:   "grpc_lpm_passes_through",
+			filter: &exportFilter{WireLevel: flow.WireLevelGRPCLPMFrame},
+			want:   flow.WireLevelGRPCLPMFrame,
+		},
+		{
+			name:   "grpcweb_base64_passes_through",
+			filter: &exportFilter{WireLevel: flow.WireLevelGRPCWebBase64},
+			want:   flow.WireLevelGRPCWebBase64,
+		},
+		{
+			name:      "unknown_value_rejected",
+			filter:    &exportFilter{WireLevel: "raw-frame"},
+			wantErr:   true,
+			errSubstr: "invalid wire_level",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveExportWireLevel(tc.filter)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveExportWireLevel(%+v) = %q, nil; want error containing %q", tc.filter, got, tc.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveExportWireLevel(%+v) returned unexpected error: %v", tc.filter, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveExportWireLevel(%+v) = %q, want %q", tc.filter, got, tc.want)
+			}
+		})
+	}
+}
+
+// makeMixedWireLevelSession creates a stream with one semantic Send
+// envelope, one semantic Receive envelope, AND two overlay rows
+// (h2-frame, grpc-lpm-frame). This shape mirrors the gRPC-over-h2
+// recording path where one Start envelope coexists with per-frame
+// overlay rows under the same stream_id.
+func makeMixedWireLevelSession(t *testing.T, store flow.Store, id string) {
+	t.Helper()
+	ctx := context.Background()
+	ts := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+
+	st := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  "grpc",
+		State:     "complete",
+		Timestamp: ts,
+		Duration:  100 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, st); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+
+	rows := []*flow.Flow{
+		{
+			ID:        "msg-semantic-send-" + id,
+			StreamID:  id,
+			Sequence:  0,
+			Direction: "send",
+			Timestamp: ts,
+			Method:    "POST",
+			WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID:        "msg-h2frame-send-" + id,
+			StreamID:  id,
+			Sequence:  1,
+			Direction: "send",
+			Timestamp: ts,
+			WireLevel: flow.WireLevelH2Frame,
+			RawBytes:  []byte("h2-frame-payload"),
+		},
+		{
+			ID:        "msg-lpm-send-" + id,
+			StreamID:  id,
+			Sequence:  2,
+			Direction: "send",
+			Timestamp: ts,
+			WireLevel: flow.WireLevelGRPCLPMFrame,
+			RawBytes:  []byte("\x00\x00\x00\x00\x04lpm!"),
+		},
+		{
+			ID:        "msg-semantic-recv-" + id,
+			StreamID:  id,
+			Sequence:  3,
+			Direction: "receive",
+			Timestamp: ts,
+			WireLevel: flow.WireLevelSemantic,
+		},
+	}
+	for _, r := range rows {
+		if err := store.SaveFlow(ctx, r); err != nil {
+			t.Fatalf("SaveFlow %s: %v", r.ID, err)
+		}
+	}
+}
+
+// parseJSONLExport unmarshals each line of a JSONL export blob into an
+// ExportRecord. Returns the records in encounter order.
+func parseJSONLExport(t *testing.T, data string) []flow.ExportRecord {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(data))
+	var records []flow.ExportRecord
+	for dec.More() {
+		var rec flow.ExportRecord
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatalf("decode JSONL line: %v", err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+// extractExportResult unmarshals the manage tool's inline export response
+// payload into executeExportFlowsResult.
+func extractExportResult(t *testing.T, result *gomcp.CallToolResult) *executeExportFlowsResult {
+	t.Helper()
+	if result.IsError {
+		t.Fatalf("export returned error: %v", result.Content)
+	}
+	text := extractTextContent(result)
+	var er executeExportFlowsResult
+	if err := json.Unmarshal([]byte(text), &er); err != nil {
+		t.Fatalf("unmarshal export result %q: %v", text, err)
+	}
+	return &er
+}
+
+// TestExportFlows_DefaultSemantic verifies that the JSONL export
+// defaults to wire_level=semantic — overlay rows are excluded unless the
+// caller explicitly opts in (USK-932).
+func TestExportFlows_DefaultSemantic(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	makeMixedWireLevelSession(t, store, "sess-default-semantic")
+
+	result := manageCallTool(t, cs, map[string]any{
+		"action": "export_flows",
+		"params": map[string]any{},
+	})
+	er := extractExportResult(t, result)
+	if er.ExportedCount != 1 {
+		t.Fatalf("ExportedCount = %d, want 1", er.ExportedCount)
+	}
+	records := parseJSONLExport(t, er.Data)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	for _, f := range records[0].Flows {
+		if f.WireLevel != "" && f.WireLevel != flow.WireLevelSemantic {
+			t.Errorf("default export should exclude overlay rows; got flow %q with wire_level %q", f.ID, f.WireLevel)
+		}
+	}
+	// The mixed-stream fixture has two semantic rows; verify both made it
+	// through and overlay rows did not.
+	if got := len(records[0].Flows); got != 2 {
+		t.Errorf("expected 2 semantic flows, got %d", got)
+	}
+}
+
+// TestExportFlows_WireLevelAll verifies that wire_level="all" disables
+// the predicate and ships every overlay row alongside the semantic
+// envelopes (USK-932 forensic opt-in path).
+func TestExportFlows_WireLevelAll(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	makeMixedWireLevelSession(t, store, "sess-wire-all")
+
+	result := manageCallTool(t, cs, map[string]any{
+		"action": "export_flows",
+		"params": map[string]any{
+			"filter": map[string]any{
+				"wire_level": "all",
+			},
+		},
+	})
+	er := extractExportResult(t, result)
+	records := parseJSONLExport(t, er.Data)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if got := len(records[0].Flows); got != 4 {
+		t.Errorf("expected 4 flows (semantic + h2-frame + lpm + semantic recv), got %d", got)
+	}
+	// Verify overlay rows actually round-tripped with their wire_level
+	// stamp preserved.
+	seen := map[string]bool{}
+	for _, f := range records[0].Flows {
+		seen[f.WireLevel] = true
+	}
+	if !seen[flow.WireLevelH2Frame] {
+		t.Errorf("expected h2-frame overlay row in wire_level=all export, missing")
+	}
+	if !seen[flow.WireLevelGRPCLPMFrame] {
+		t.Errorf("expected grpc-lpm-frame overlay row in wire_level=all export, missing")
+	}
+}
+
+// TestExportFlows_WireLevelExplicitOverlay verifies that passing a
+// specific overlay value isolates that single wire_level view in the
+// export.
+func TestExportFlows_WireLevelExplicitOverlay(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	makeMixedWireLevelSession(t, store, "sess-wire-h2frame")
+
+	result := manageCallTool(t, cs, map[string]any{
+		"action": "export_flows",
+		"params": map[string]any{
+			"filter": map[string]any{
+				"wire_level": flow.WireLevelH2Frame,
+			},
+		},
+	})
+	er := extractExportResult(t, result)
+	records := parseJSONLExport(t, er.Data)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if got := len(records[0].Flows); got != 1 {
+		t.Errorf("expected exactly 1 h2-frame flow, got %d", got)
+	}
+	if records[0].Flows[0].WireLevel != flow.WireLevelH2Frame {
+		t.Errorf("expected wire_level=h2-frame, got %q", records[0].Flows[0].WireLevel)
+	}
+	// Verify the raw bytes survived the round trip (overlay diagnostic
+	// value is the raw frame payload, not the semantic message).
+	wantRaw := base64.StdEncoding.EncodeToString([]byte("h2-frame-payload"))
+	if records[0].Flows[0].RawBytes != wantRaw {
+		t.Errorf("expected base64 raw_bytes %q, got %q", wantRaw, records[0].Flows[0].RawBytes)
+	}
+}
+
+// TestExportFlows_InvalidWireLevel verifies the enum validation surface.
+func TestExportFlows_InvalidWireLevel(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	makeMixedWireLevelSession(t, store, "sess-invalid-wire")
+
+	result := manageCallTool(t, cs, map[string]any{
+		"action": "export_flows",
+		"params": map[string]any{
+			"filter": map[string]any{
+				"wire_level": "bogus-overlay",
+			},
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for invalid wire_level, got success")
+	}
+	text := extractTextContent(result)
+	if !strings.Contains(text, "wire_level") {
+		t.Errorf("error text %q does not mention wire_level", text)
+	}
+}
+
+// TestExportFlows_HARIgnoresWireLevel verifies the HAR exporter's data
+// model is unaffected by the wire_level field — HAR has no slot for
+// per-frame overlays and applies semantic-only internally. Passing
+// wire_level=h2-frame to HAR must still produce a valid HAR (or fall
+// back to whatever HAR's own semantic projection yields), not a
+// stream-of-overlay-frames output.
+func TestExportFlows_HARIgnoresWireLevel(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	// Use the HTTP-shaped helper so HAR's protocol gate passes (gRPC is
+	// filtered out by harStreamIncluded).
+	makeExportTestSession(t, store, "sess-har-wire-all")
+
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "out.har")
+	result := manageCallTool(t, cs, map[string]any{
+		"action": "export_flows",
+		"params": map[string]any{
+			"format":      "har",
+			"output_path": outputPath,
+			"filter": map[string]any{
+				"wire_level": "all",
+			},
+		},
+	})
+	// The expectation is that HAR ignores wire_level (it does not affect
+	// HAR semantics), so the call must succeed.
+	if result.IsError {
+		t.Fatalf("HAR export should ignore wire_level filter, got error: %v", result.Content)
+	}
+}

--- a/internal/mcp/manage_tool.go
+++ b/internal/mcp/manage_tool.go
@@ -86,6 +86,17 @@ type exportFilter struct {
 	URLPattern  string  `json:"url_pattern,omitempty"`
 	TimeAfter   string  `json:"time_after,omitempty"`
 	TimeBefore  string  `json:"time_before,omitempty"`
+	// WireLevel filters exported flows by the schemaV14 wire_level
+	// column (USK-932). Canonical enum values mirror query.filter.wire_level:
+	// "semantic" (canonical L7 envelopes — the default), "h2-frame",
+	// "h1-chunk", "grpc-lpm-frame", "grpcweb-base64" (single-overlay
+	// diagnostic views), or "all" (no predicate; every wire_level).
+	// Empty / unset defaults to "semantic" so JSONL export aligns with the
+	// MCP query default and the HAR exporter — overlay rows are excluded
+	// unless the caller explicitly opts in. Forensic consumers who relied
+	// on overlay rows in JSONL export must pass wire_level="all".
+	// Ignored by HAR export (HAR 1.2 has no slot for per-frame overlays).
+	WireLevel string `json:"wire_level,omitempty" jsonschema:"wire_level filter (default: semantic). Accepted: semantic | h2-frame | h1-chunk | grpc-lpm-frame | grpcweb-base64 | all. Mirrors query.filter.wire_level. HAR export ignores this field."`
 }
 
 // availableManageActions lists the valid action names for the manage tool.
@@ -513,6 +524,12 @@ func (s *Server) handleManageExportFlows(ctx context.Context, params manageParam
 }
 
 // buildExportOptions constructs flow.ExportOptions from the manage params.
+//
+// USK-932: the per-flow wire_level filter defaults to flow.WireLevelSemantic
+// so JSONL export aligns with the MCP query default and the HAR exporter —
+// overlay rows (h2-frame, h1-chunk, grpc-lpm-frame, grpcweb-base64) are
+// excluded unless the caller passes filter.wire_level="all" (forensic
+// opt-in) or a specific overlay value (single-overlay diagnostic view).
 func buildExportOptions(params manageParams) (flow.ExportOptions, error) {
 	includeBodies := true
 	if params.IncludeBodies != nil {
@@ -522,6 +539,14 @@ func buildExportOptions(params manageParams) (flow.ExportOptions, error) {
 	opts := flow.ExportOptions{
 		IncludeBodies: includeBodies,
 	}
+
+	// Resolve wire_level even when filter is nil so JSONL export still
+	// applies the semantic default.
+	wireLevel, err := resolveExportWireLevel(params.Filter)
+	if err != nil {
+		return flow.ExportOptions{}, err
+	}
+	opts.WireLevel = wireLevel
 
 	if params.Filter != nil {
 		if err := validateManageExportFilter(params.Filter); err != nil {
@@ -549,6 +574,38 @@ func buildExportOptions(params manageParams) (flow.ExportOptions, error) {
 	}
 
 	return opts, nil
+}
+
+// resolveExportWireLevel validates and translates the user-facing
+// exportFilter.WireLevel into the value persisted on flow.ExportOptions.
+// Mirrors resolveWireLevelFilter (query tool):
+//
+//   - empty / unset → flow.WireLevelSemantic (default for JSONL export so
+//     overlay rows are excluded unless the caller opts in)
+//   - "all"         → "" (disables the SQL predicate, returning every wire_level)
+//   - any canonical wire_level value (semantic, h2-frame, h1-chunk,
+//     grpc-lpm-frame, grpcweb-base64) → passes through verbatim
+//   - any unknown value → validateEnum error with the canonical list
+//
+// USK-932: the HAR exporter ignores opts.WireLevel — its data model has
+// no slot for per-frame overlays — so the resolver runs even on the HAR
+// path purely for input-validation symmetry. Unknown values fail fast
+// before the wire_level reaches storage code.
+func resolveExportWireLevel(filter *exportFilter) (string, error) {
+	value := ""
+	if filter != nil {
+		value = filter.WireLevel
+	}
+	if value == "" {
+		return flow.WireLevelSemantic, nil
+	}
+	if err := validateEnum("wire_level", value, validFilterWireLevels); err != nil {
+		return "", err
+	}
+	if value == wireLevelFilterAll {
+		return "", nil
+	}
+	return value, nil
 }
 
 // writeToFileAtomic validates the output path and atomically writes content

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -43,6 +43,110 @@ const oversizeAdvisoryThreshold = 256 * 1024
 // either size-bounding param explicitly.
 const oversizeAdvisoryMessage = "response contains a body larger than 256 KiB; pass include_bodies=false or body_max_bytes=N to stay under the MCP token limit"
 
+// wireLevelAdvisory carries a structured hint surfaced on query
+// responses when the default semantic wire_level filter (USK-921) hid
+// wire-level overlay rows (h2-frame / grpc-lpm-frame / h1-chunk /
+// grpcweb-base64) from the AI-facing response. Emitted only when the
+// caller did NOT explicitly opt in via filter.wire_level, AND at least
+// one overlay row exists for the queried stream(s). The advisory is
+// purely informational — the wire copy of the overlay rows is
+// unchanged on disk and re-fetchable via filter.wire_level=all (or any
+// specific overlay value).
+//
+// Schema: pointer + omitempty so the field omits from JSON entirely on
+// default-shaped queries (zero overlay rows OR explicit opt-in). When
+// present, Hidden maps wire_level → count for every overlay value that
+// had at least one suppressed row.
+//
+// Sibling of the existing Advisory string — additive change so existing
+// AI-agent consumers parsing the oversize hint are unaffected (USK-931
+// Q1 resolution).
+type wireLevelAdvisory struct {
+	// Filter is the resolved wire_level filter applied to this query.
+	// Always "semantic (default)" today since the advisory is gated on
+	// the caller having NOT opted in — kept as a string field so a
+	// future change (e.g., advisory under a non-default-but-still-
+	// hiding filter) can populate the canonical value.
+	Filter string `json:"wire_level_filter" jsonschema:"the resolved wire_level filter applied to this query (\"semantic (default)\" when the advisory fires)"`
+	// Hidden maps wire_level value → count of suppressed rows.
+	// Zero-count entries are omitted so the map only carries the
+	// overlays that actually contributed to the AI-visible projection
+	// loss (USK-931 Q2 resolution: DB-side GROUP BY via
+	// CountFlowsByWireLevel avoids loading payloads).
+	Hidden map[string]int `json:"hidden_overlay_rows,omitempty" jsonschema:"per-wire_level count of rows suppressed by the semantic-default filter"`
+	// Hint is the operator-facing one-liner describing the opt-in
+	// mechanism. Constant string — the same value for every emit.
+	Hint string `json:"hint" jsonschema:"one-line guidance for opting in to overlay rows"`
+}
+
+// wireLevelAdvisoryHint is the constant operator-facing hint string
+// embedded in wireLevelAdvisory.Hint. Lists every canonical overlay
+// value and the universal "all" sentinel so the AI agent can compose
+// a fully-typed opt-in request from a single response field.
+const wireLevelAdvisoryHint = "Pass filter.wire_level=\"h2-frame\" / \"grpc-lpm-frame\" / \"h1-chunk\" / \"grpcweb-base64\" / \"all\" to inspect raw-frame diagnostics."
+
+// wireLevelAdvisoryDefaultLabel is the value set on
+// wireLevelAdvisory.Filter when the advisory fires. Kept as a constant
+// so the rendered shape is identical across all three query handlers.
+const wireLevelAdvisoryDefaultLabel = "semantic (default)"
+
+// buildWireLevelAdvisory composes a *wireLevelAdvisory from the
+// per-wire_level suppressed-row counts. Returns nil when:
+//
+//   - filter is non-nil AND filter.WireLevel is non-empty (caller opted
+//     in via filter.wire_level={overlay | all}); the advisory only
+//     fires for default-shaped queries.
+//   - hidden is empty (no overlay rows exist for the queried streams).
+//
+// Caller passes the raw map from Store.CountFlowsByWireLevel after
+// subtracting the semantic bucket. Zero entries in the map are dropped.
+func buildWireLevelAdvisory(filter *queryFilter, hidden map[string]int) *wireLevelAdvisory {
+	if filter != nil && filter.WireLevel != "" {
+		return nil
+	}
+	pruned := map[string]int{}
+	for k, v := range hidden {
+		if v > 0 {
+			pruned[k] = v
+		}
+	}
+	if len(pruned) == 0 {
+		return nil
+	}
+	return &wireLevelAdvisory{
+		Filter: wireLevelAdvisoryDefaultLabel,
+		Hidden: pruned,
+		Hint:   wireLevelAdvisoryHint,
+	}
+}
+
+// collectHiddenOverlayCounts queries the wire_level breakdown for a
+// single stream and returns the count of overlay rows (every wire_level
+// other than semantic). Direction inside opts narrows the count to a
+// single side; an empty Direction counts both. The semantic bucket is
+// dropped from the returned map. Returns nil on the underlying SQL
+// error path.
+func (s *Server) collectHiddenOverlayCounts(ctx context.Context, streamID string, opts flow.FlowListOptions) (map[string]int, error) {
+	if s.flowStore.store == nil {
+		return nil, nil
+	}
+	breakdown, err := s.flowStore.store.CountFlowsByWireLevel(ctx, streamID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("count flows by wire_level: %w", err)
+	}
+	if len(breakdown) == 0 {
+		return nil, nil
+	}
+	hidden := make(map[string]int, len(breakdown))
+	for wl, n := range breakdown {
+		if wl == flow.WireLevelSemantic {
+			continue
+		}
+		hidden[wl] = n
+	}
+	return hidden, nil
+}
+
 // queryInput is the typed input for the query tool.
 type queryInput struct {
 	// Resource specifies what to query: flows, flow, messages, status, config, ca_cert, intercept_queue, macros, macro, fuzz_jobs, fuzz_results.
@@ -708,6 +812,13 @@ type queryFlowsResult struct {
 	Flows []queryFlowsEntry `json:"flows"`
 	Count int               `json:"count"`
 	Total int               `json:"total"`
+	// WireLevelAdvisory carries a structured hint when the default
+	// semantic wire_level filter hid overlay rows on the listed streams
+	// AND the caller did NOT opt in via filter.wire_level. Counts are
+	// summed across every Stream in the response so the operator-visible
+	// inflation signal (per-Stream MessageCount) is matched at the
+	// result level rather than per-row (USK-931).
+	WireLevelAdvisory *wireLevelAdvisory `json:"wire_level_advisory,omitempty"`
 }
 
 // buildFlowListOptions constructs flow.StreamListOptions from query input parameters.
@@ -800,6 +911,12 @@ func (s *Server) handleQueryFlows(ctx context.Context, input queryInput) (*gomcp
 	msgListOpts := flow.FlowListOptions{WireLevel: wireLevel}
 
 	entries := make([]queryFlowsEntry, 0, len(flowList))
+	// USK-931: accumulate overlay-row counts across every Stream in the
+	// page so the result-level WireLevelAdvisory reflects the AI-visible
+	// inflation signal (per-Stream MessageCount). Accept the N+1 cost
+	// here per the design review — per-Stream MessageCount IS the
+	// operator-visible signal that motivates the advisory.
+	hiddenAggregate := map[string]int{}
 	for _, fl := range flowList {
 		// Fetch messages for method/url/status_code/message_count via JOIN data.
 		msgs, err := s.flowStore.store.GetFlows(ctx, fl.ID, msgListOpts)
@@ -835,12 +952,29 @@ func (s *Server) handleQueryFlows(ctx context.Context, input queryInput) (*gomcp
 			WaitMs:     fl.WaitMs,
 			ReceiveMs:  fl.ReceiveMs,
 		})
+
+		// USK-931: per-Stream overlay count contributes to the
+		// result-level hidden map. Errors are non-fatal — the advisory
+		// is informational and a failed sub-query should not block the
+		// rest of the response.
+		hidden, advisoryErr := s.collectHiddenOverlayCounts(ctx, fl.ID, flow.FlowListOptions{})
+		if advisoryErr != nil {
+			// Log + continue: do not block the AI agent from seeing
+			// the listing because the advisory could not be computed.
+			slog.DebugContext(ctx, "wire_level_advisory: hidden count failed",
+				"flow_id", fl.ID, "error", advisoryErr)
+			continue
+		}
+		for wl, n := range hidden {
+			hiddenAggregate[wl] += n
+		}
 	}
 
 	result := &queryFlowsResult{
-		Flows: entries,
-		Count: len(entries),
-		Total: total,
+		Flows:             entries,
+		Count:             len(entries),
+		Total:             total,
+		WireLevelAdvisory: buildWireLevelAdvisory(input.Filter, hiddenAggregate),
 	}
 	return nil, result, nil
 }
@@ -952,6 +1086,12 @@ type queryFlowResult struct {
 	// include_bodies or body_max_bytes and the unbounded response contains a
 	// body above oversizeAdvisoryThreshold. Empty otherwise.
 	Advisory string `json:"advisory,omitempty"`
+	// WireLevelAdvisory carries a structured hint when the default
+	// semantic wire_level filter hid overlay rows on this Stream AND the
+	// caller did NOT opt in via filter.wire_level. Sibling of Advisory —
+	// additive, omitempty, does NOT mutate the existing oversize hint
+	// (USK-931).
+	WireLevelAdvisory *wireLevelAdvisory `json:"wire_level_advisory,omitempty"`
 }
 
 // queryDecodeAnomaly is a structured anomaly entry surfaced when
@@ -1530,6 +1670,18 @@ func (s *Server) handleQueryFlow(ctx context.Context, input queryInput) (*gomcp.
 		result.Advisory = oversizeAdvisoryMessage
 	}
 
+	// USK-931: surface the per-Stream overlay breakdown when the
+	// semantic default suppressed any rows. The hidden map is empty
+	// when the caller opted in (filter.wire_level != "") so the
+	// advisory is suppressed by buildWireLevelAdvisory's first gate.
+	hidden, advisoryErr := s.collectHiddenOverlayCounts(ctx, fl.ID, flow.FlowListOptions{})
+	if advisoryErr != nil {
+		slog.DebugContext(ctx, "wire_level_advisory: hidden count failed",
+			"flow_id", fl.ID, "error", advisoryErr)
+	} else {
+		result.WireLevelAdvisory = buildWireLevelAdvisory(input.Filter, hidden)
+	}
+
 	return nil, result, nil
 }
 
@@ -1690,6 +1842,10 @@ type queryMessagesResult struct {
 	// include_bodies or body_max_bytes and the unbounded response contains a
 	// message body above oversizeAdvisoryThreshold. Empty otherwise.
 	Advisory string `json:"advisory,omitempty"`
+	// WireLevelAdvisory carries a structured hint when the default
+	// semantic wire_level filter hid overlay rows on the paged Stream
+	// AND the caller did NOT opt in via filter.wire_level (USK-931).
+	WireLevelAdvisory *wireLevelAdvisory `json:"wire_level_advisory,omitempty"`
 }
 
 // convertMessagesToEntries converts flow messages to queryMessageEntry slice.
@@ -1884,6 +2040,18 @@ func (s *Server) handleQueryMessages(ctx context.Context, input queryInput) (*go
 	// response and at least one body in the page exceeded the threshold.
 	if !limit.explicitlyBounded && messagesHaveOversizedBody(pageMsgs) {
 		result.Advisory = oversizeAdvisoryMessage
+	}
+
+	// USK-931: scope the overlay-count to the same direction filter the
+	// caller applied to the page so the advisory reflects what was
+	// actually suppressed. msgOpts.Direction may be empty (count both
+	// sides), "send", or "receive".
+	hidden, advisoryErr := s.collectHiddenOverlayCounts(ctx, fl.ID, flow.FlowListOptions{Direction: msgOpts.Direction})
+	if advisoryErr != nil {
+		slog.DebugContext(ctx, "wire_level_advisory: hidden count failed",
+			"flow_id", fl.ID, "error", advisoryErr)
+	} else {
+		result.WireLevelAdvisory = buildWireLevelAdvisory(input.Filter, hidden)
 	}
 
 	return nil, result, nil

--- a/internal/mcp/query_wire_level_advisory_test.go
+++ b/internal/mcp/query_wire_level_advisory_test.go
@@ -1,0 +1,414 @@
+// Package mcp query_wire_level_advisory_test.go — coverage for the
+// USK-931 wire_level_advisory hint emitted on query responses when the
+// default semantic wire_level filter (USK-921) hid overlay rows.
+//
+// The advisory is informational only — the wire copy of the overlay
+// rows is unchanged on disk and re-fetchable via
+// filter.wire_level=all (or any specific overlay value). These tests
+// cover:
+//
+//   - the buildWireLevelAdvisory helper (pure unit shape)
+//   - integration round-trip through the MCP transport for all three
+//     query handlers (query flow, query flows, query messages)
+//   - the gate on filter.wire_level (advisory absent when the caller
+//     opted in to overlays)
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+)
+
+// TestBuildWireLevelAdvisory exercises the pure-helper shape: emit
+// gates, zero-entry pruning, and the constant Hint/Filter values.
+func TestBuildWireLevelAdvisory(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		filter      *queryFilter
+		hidden      map[string]int
+		wantNil     bool
+		wantHidden  map[string]int
+		wantFilter  string
+		wantHintHas string
+	}{
+		{
+			name:    "nil_filter_no_overlay_rows",
+			filter:  nil,
+			hidden:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "nil_filter_empty_hidden_map",
+			filter:  nil,
+			hidden:  map[string]int{},
+			wantNil: true,
+		},
+		{
+			name:    "nil_filter_with_h2frame_overlays",
+			filter:  nil,
+			hidden:  map[string]int{flow.WireLevelH2Frame: 3},
+			wantNil: false,
+			wantHidden: map[string]int{
+				flow.WireLevelH2Frame: 3,
+			},
+			wantFilter:  wireLevelAdvisoryDefaultLabel,
+			wantHintHas: "wire_level",
+		},
+		{
+			name:    "nil_filter_multi_overlay",
+			filter:  nil,
+			hidden:  map[string]int{flow.WireLevelH2Frame: 3, flow.WireLevelGRPCLPMFrame: 7},
+			wantNil: false,
+			wantHidden: map[string]int{
+				flow.WireLevelH2Frame:      3,
+				flow.WireLevelGRPCLPMFrame: 7,
+			},
+			wantFilter: wireLevelAdvisoryDefaultLabel,
+		},
+		{
+			name:    "zero_entries_pruned",
+			filter:  nil,
+			hidden:  map[string]int{flow.WireLevelH2Frame: 0, flow.WireLevelGRPCLPMFrame: 4},
+			wantNil: false,
+			wantHidden: map[string]int{
+				flow.WireLevelGRPCLPMFrame: 4,
+			},
+		},
+		{
+			name:    "all_zero_entries_pruned_to_nil",
+			filter:  nil,
+			hidden:  map[string]int{flow.WireLevelH2Frame: 0},
+			wantNil: true,
+		},
+		{
+			name:    "explicit_opt_in_suppresses_advisory_even_with_hidden_rows",
+			filter:  &queryFilter{WireLevel: "all"},
+			hidden:  map[string]int{flow.WireLevelH2Frame: 3},
+			wantNil: true,
+		},
+		{
+			name:    "explicit_overlay_opt_in_suppresses_advisory",
+			filter:  &queryFilter{WireLevel: flow.WireLevelH2Frame},
+			hidden:  map[string]int{flow.WireLevelGRPCLPMFrame: 2},
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildWireLevelAdvisory(tc.filter, tc.hidden)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("buildWireLevelAdvisory returned %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("buildWireLevelAdvisory returned nil, want non-nil")
+			}
+			if got.Filter != tc.wantFilter && tc.wantFilter != "" {
+				t.Errorf("Filter = %q, want %q", got.Filter, tc.wantFilter)
+			}
+			if len(got.Hidden) != len(tc.wantHidden) {
+				t.Errorf("Hidden = %+v, want %+v", got.Hidden, tc.wantHidden)
+			}
+			for k, want := range tc.wantHidden {
+				if got.Hidden[k] != want {
+					t.Errorf("Hidden[%q] = %d, want %d", k, got.Hidden[k], want)
+				}
+			}
+			if got.Hint == "" {
+				t.Errorf("Hint is empty")
+			}
+		})
+	}
+}
+
+// saveOverlayStream stores a Stream with one semantic Send envelope, one
+// semantic Receive envelope, and two overlay rows (h2-frame + lpm).
+// Mirrors makeMixedWireLevelSession but lives here so tests stay
+// independent of the manage-export test fixtures.
+func saveOverlayStream(t *testing.T, store flow.Store, id, protocol string) {
+	t.Helper()
+	ctx := context.Background()
+	ts := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+
+	st := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  protocol,
+		State:     "complete",
+		Timestamp: ts,
+		Duration:  100 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, st); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+
+	rows := []*flow.Flow{
+		{
+			ID: "msg-sem-send-" + id, StreamID: id, Sequence: 0, Direction: "send",
+			Timestamp: ts, Method: "POST", WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: "msg-h2f-send-" + id, StreamID: id, Sequence: 1, Direction: "send",
+			Timestamp: ts, WireLevel: flow.WireLevelH2Frame, RawBytes: []byte("h2f"),
+		},
+		{
+			ID: "msg-lpm-send-" + id, StreamID: id, Sequence: 2, Direction: "send",
+			Timestamp: ts, WireLevel: flow.WireLevelGRPCLPMFrame, RawBytes: []byte("lpm"),
+		},
+		{
+			ID: "msg-sem-recv-" + id, StreamID: id, Sequence: 3, Direction: "receive",
+			Timestamp: ts, WireLevel: flow.WireLevelSemantic,
+		},
+	}
+	for _, r := range rows {
+		if err := store.SaveFlow(ctx, r); err != nil {
+			t.Fatalf("SaveFlow %s: %v", r.ID, err)
+		}
+	}
+}
+
+// saveSemanticOnlyStream stores a Stream with only semantic envelopes
+// (no overlays) — used to verify the advisory is absent on default
+// queries when no overlay rows exist.
+func saveSemanticOnlyStream(t *testing.T, store flow.Store, id string) {
+	t.Helper()
+	ctx := context.Background()
+	ts := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+
+	st := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  "http",
+		State:     "complete",
+		Timestamp: ts,
+		Duration:  100 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, st); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+	rows := []*flow.Flow{
+		{
+			ID: "msg-send-" + id, StreamID: id, Sequence: 0, Direction: "send",
+			Timestamp: ts, Method: "GET", WireLevel: flow.WireLevelSemantic,
+		},
+		{
+			ID: "msg-recv-" + id, StreamID: id, Sequence: 1, Direction: "receive",
+			Timestamp: ts, StatusCode: 200, WireLevel: flow.WireLevelSemantic,
+		},
+	}
+	for _, r := range rows {
+		if err := store.SaveFlow(ctx, r); err != nil {
+			t.Fatalf("SaveFlow %s: %v", r.ID, err)
+		}
+	}
+}
+
+// queryCallTool wraps the MCP query tool call so tests can assert the
+// JSON-encoded transport payload shape — confirming the advisory
+// survives the MCP boundary serialization (the design review's
+// JSON-RPC round-trip check).
+func queryCallTool(t *testing.T, cs *gomcp.ClientSession, args map[string]any) *gomcp.CallToolResult {
+	t.Helper()
+	result, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "query",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("CallTool(query): %v", err)
+	}
+	return result
+}
+
+func TestQueryWireLevelAdvisory_QueryFlow_DefaultShowsAdvisory(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveOverlayStream(t, store, "stream-qf-default", "grpc")
+
+	result := queryCallTool(t, cs, map[string]any{
+		"resource": "flow",
+		"id":       "stream-qf-default",
+	})
+	if result.IsError {
+		t.Fatalf("query flow returned error: %v", result.Content)
+	}
+	text := extractTextContent(result)
+	var qr queryFlowResult
+	if err := json.Unmarshal([]byte(text), &qr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if qr.WireLevelAdvisory == nil {
+		t.Fatalf("expected WireLevelAdvisory, got nil; payload=%s", text)
+	}
+	if got := qr.WireLevelAdvisory.Hidden[flow.WireLevelH2Frame]; got != 1 {
+		t.Errorf("Hidden[h2-frame] = %d, want 1", got)
+	}
+	if got := qr.WireLevelAdvisory.Hidden[flow.WireLevelGRPCLPMFrame]; got != 1 {
+		t.Errorf("Hidden[grpc-lpm-frame] = %d, want 1", got)
+	}
+	// Confirm the on-wire JSON field name matches the schema contract
+	// — load-bearing for AI agent consumers.
+	if !jsonHasField(text, "wire_level_advisory") {
+		t.Errorf("JSON missing wire_level_advisory field; payload=%s", text)
+	}
+	if !jsonHasField(text, "hidden_overlay_rows") {
+		t.Errorf("JSON missing hidden_overlay_rows field; payload=%s", text)
+	}
+}
+
+func TestQueryWireLevelAdvisory_QueryFlow_NoOverlayRowsAbsentAdvisory(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveSemanticOnlyStream(t, store, "stream-qf-semonly")
+
+	result := queryCallTool(t, cs, map[string]any{
+		"resource": "flow",
+		"id":       "stream-qf-semonly",
+	})
+	text := extractTextContent(result)
+	var qr queryFlowResult
+	if err := json.Unmarshal([]byte(text), &qr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if qr.WireLevelAdvisory != nil {
+		t.Errorf("expected nil WireLevelAdvisory on semantic-only stream, got %+v", qr.WireLevelAdvisory)
+	}
+	if jsonHasField(text, "wire_level_advisory") {
+		t.Errorf("expected omitempty to drop wire_level_advisory from JSON; payload=%s", text)
+	}
+}
+
+func TestQueryWireLevelAdvisory_QueryFlow_ExplicitOptInSuppresses(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveOverlayStream(t, store, "stream-qf-explicit", "grpc")
+
+	for _, wl := range []string{"all", flow.WireLevelH2Frame, flow.WireLevelGRPCLPMFrame} {
+		t.Run("wire_level="+wl, func(t *testing.T) {
+			result := queryCallTool(t, cs, map[string]any{
+				"resource": "flow",
+				"id":       "stream-qf-explicit",
+				"filter":   map[string]any{"wire_level": wl},
+			})
+			text := extractTextContent(result)
+			var qr queryFlowResult
+			if err := json.Unmarshal([]byte(text), &qr); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if qr.WireLevelAdvisory != nil {
+				t.Errorf("expected nil advisory on explicit wire_level=%s, got %+v", wl, qr.WireLevelAdvisory)
+			}
+		})
+	}
+}
+
+func TestQueryWireLevelAdvisory_QueryFlows_AggregatesAcrossStreams(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveOverlayStream(t, store, "stream-qfs-1", "grpc")
+	saveOverlayStream(t, store, "stream-qfs-2", "grpc")
+	saveSemanticOnlyStream(t, store, "stream-qfs-3")
+
+	result := queryCallTool(t, cs, map[string]any{
+		"resource": "flows",
+	})
+	text := extractTextContent(result)
+	var qr queryFlowsResult
+	if err := json.Unmarshal([]byte(text), &qr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if qr.WireLevelAdvisory == nil {
+		t.Fatalf("expected WireLevelAdvisory, got nil; payload=%s", text)
+	}
+	// Two overlay streams * (1 h2-frame + 1 grpc-lpm-frame) = 2 each.
+	if got := qr.WireLevelAdvisory.Hidden[flow.WireLevelH2Frame]; got != 2 {
+		t.Errorf("aggregated Hidden[h2-frame] = %d, want 2", got)
+	}
+	if got := qr.WireLevelAdvisory.Hidden[flow.WireLevelGRPCLPMFrame]; got != 2 {
+		t.Errorf("aggregated Hidden[grpc-lpm-frame] = %d, want 2", got)
+	}
+}
+
+func TestQueryWireLevelAdvisory_QueryMessages_DefaultShowsAdvisory(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveOverlayStream(t, store, "stream-qm-default", "grpc")
+
+	result := queryCallTool(t, cs, map[string]any{
+		"resource": "messages",
+		"id":       "stream-qm-default",
+	})
+	text := extractTextContent(result)
+	var qr queryMessagesResult
+	if err := json.Unmarshal([]byte(text), &qr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if qr.WireLevelAdvisory == nil {
+		t.Fatalf("expected WireLevelAdvisory, got nil; payload=%s", text)
+	}
+	if got := qr.WireLevelAdvisory.Hidden[flow.WireLevelH2Frame]; got != 1 {
+		t.Errorf("Hidden[h2-frame] = %d, want 1", got)
+	}
+}
+
+func TestQueryWireLevelAdvisory_QueryMessages_ExplicitOptInSuppresses(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ca := newTestCA(t)
+	cs := setupTestSession(t, ca, store)
+
+	saveOverlayStream(t, store, "stream-qm-explicit", "grpc")
+
+	result := queryCallTool(t, cs, map[string]any{
+		"resource": "messages",
+		"id":       "stream-qm-explicit",
+		"filter":   map[string]any{"wire_level": "all"},
+	})
+	text := extractTextContent(result)
+	var qr queryMessagesResult
+	if err := json.Unmarshal([]byte(text), &qr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if qr.WireLevelAdvisory != nil {
+		t.Errorf("expected nil advisory on explicit opt-in, got %+v", qr.WireLevelAdvisory)
+	}
+}
+
+// jsonHasField is a coarse JSON-string field probe — sufficient for
+// asserting the on-wire schema contract on small fixtures. Uses a
+// substring match rather than a full unmarshal so we exercise the raw
+// serialized payload (catches omitempty mistakes and field renames).
+func jsonHasField(payload, field string) bool {
+	needle := "\"" + field + "\""
+	for i := 0; i+len(needle) <= len(payload); i++ {
+		if payload[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/resend_grpc_helpers.go
+++ b/internal/mcp/resend_grpc_helpers.go
@@ -423,13 +423,14 @@ func extractResendGRPCStartFields(f *flow.Flow) (authority, service, method, sch
 // GRPCStart Flows. The Receive Flow is allowed to be missing (a request
 // that never got a response is still resendable).
 //
-// USK-920: the live data path records additional non-Start Flows on the
-// Send direction (h2-frame wire chunks, LPM wire chunks via
-// session.GRPCH2DataFrameRecordOption / GRPCLPMRecordOption), so the first
-// Send Flow returned by the store is NOT guaranteed to be the GRPCStart
-// envelope. We scan for the first Flow whose Metadata["grpc_event"]=="start"
-// and fall back to sendFlows[0] only when no semantic Start flow exists
-// (e.g. an in-process resend that recorded only synthesized envelopes).
+// USK-930: requests flow.WireLevelSemantic explicitly on every GetFlows
+// call. The MCP query boundary defaults to semantic (USK-921) but the
+// flow.Store layer returns rows of every wire_level when the predicate
+// is empty (intentional backward compatibility), so the resend helpers
+// must opt in for the semantic-only projection to skip overlay rows
+// (h2-frame / grpc-lpm-frame). Under that opt-in, the first Send Flow IS
+// the GRPCStart envelope per the RecordStep projection invariant
+// (projectGRPCStart writes Start first, then Data*, optionally End).
 func (s *Server) loadResendGRPCFlows(ctx context.Context, flowID string) (*flow.Stream, *flow.Flow, *flow.Flow, error) {
 	if s.flowStore.store == nil {
 		return nil, nil, nil, errors.New("resend_grpc: flow store is not initialized")
@@ -438,40 +439,38 @@ func (s *Server) loadResendGRPCFlows(ctx context.Context, flowID string) (*flow.
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_grpc: get stream %s: %w", flowID, err)
 	}
-	sendFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send"})
+	sendFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send", WireLevel: flow.WireLevelSemantic})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_grpc: get send flows %s: %w", flowID, err)
 	}
 	if len(sendFlows) == 0 {
 		return nil, nil, nil, fmt.Errorf("resend_grpc: stream %s has no send-direction flows", flowID)
 	}
-	recvFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "receive"})
+	recvFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "receive", WireLevel: flow.WireLevelSemantic})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_grpc: get receive flows %s: %w", flowID, err)
 	}
 	return stream, pickGRPCStartFlow(sendFlows), pickGRPCStartFlow(recvFlows), nil
 }
 
-// pickGRPCStartFlow returns the first Flow in flows that the RecordStep
-// projection tagged as the GRPCStart envelope (Metadata["grpc_event"]
-// == "start"). When no such Flow exists, the first Flow is returned so
-// legacy / synthetic streams (which never carried per-event Metadata)
-// keep working. A nil / empty input yields nil.
+// pickGRPCStartFlow returns the first Flow in flows, which the
+// projection-ordered semantic stream guarantees to be the GRPCStart
+// envelope when callers pass FlowListOptions{WireLevel:
+// flow.WireLevelSemantic} (RecordStep.projectGRPCStart writes Start
+// first, then Data*, optionally End — see internal/pipeline/record_step.go).
+// Returns nil when flows is empty.
 //
-// USK-920: the live data path emits additional Send-direction Flows for
-// per-frame wire-byte snapshots (LPM and H2 DATA recording callbacks),
-// so "the first Send Flow" is not equivalent to "the GRPCStart Flow".
+// Historical context: USK-920 introduced a defensive
+// Metadata["grpc_event"]=="start" scan to work around per-frame
+// wire_level overlay rows (h2-frame / grpc-lpm-frame) that were
+// interleaved at the Store layer. USK-921 made semantic the MCP-default
+// filter, and USK-930 lifted explicit semantic to callers below the
+// MCP boundary, so this wrapper became a one-liner. The wrapper is
+// retained (rather than inlined) as the single contract surface so
+// future overlay additions only need a single audit point.
 func pickGRPCStartFlow(flows []*flow.Flow) *flow.Flow {
 	if len(flows) == 0 {
 		return nil
-	}
-	for _, fl := range flows {
-		if fl == nil || fl.Metadata == nil {
-			continue
-		}
-		if fl.Metadata["grpc_event"] == "start" {
-			return fl
-		}
 	}
 	return flows[0]
 }
@@ -1045,7 +1044,10 @@ func (s *Server) collectResendGRPCUnknownFieldWarnings(ctx context.Context, inpu
 	if spec == nil || spec.InputDesc == nil {
 		return nil
 	}
-	sendFlows, err := s.flowStore.store.GetFlows(ctx, input.FlowID, flow.FlowListOptions{Direction: "send"})
+	// USK-930: pass explicit semantic so we only inspect canonical L7 Data
+	// envelopes against the schema, skipping wire-level overlay rows
+	// (h2-frame / grpc-lpm-frame).
+	sendFlows, err := s.flowStore.store.GetFlows(ctx, input.FlowID, flow.FlowListOptions{Direction: "send", WireLevel: flow.WireLevelSemantic})
 	if err != nil || len(sendFlows) == 0 {
 		return nil
 	}

--- a/internal/mcp/resend_grpc_helpers_test.go
+++ b/internal/mcp/resend_grpc_helpers_test.go
@@ -129,3 +129,67 @@ func TestExtractResendGRPCStartFields(t *testing.T) {
 		})
 	}
 }
+
+// TestPickGRPCStartFlow_Empty verifies the wrapper returns nil for a nil
+// or empty input slice. USK-930 simplification post-condition: callers
+// already passed FlowListOptions{WireLevel: flow.WireLevelSemantic} when
+// loading these flows, so the wrapper does not need to defend against
+// overlay rows.
+func TestPickGRPCStartFlow_Empty(t *testing.T) {
+	t.Parallel()
+	if got := pickGRPCStartFlow(nil); got != nil {
+		t.Errorf("pickGRPCStartFlow(nil) = %v, want nil", got)
+	}
+	if got := pickGRPCStartFlow([]*flow.Flow{}); got != nil {
+		t.Errorf("pickGRPCStartFlow(empty) = %v, want nil", got)
+	}
+}
+
+// TestPickGRPCStartFlow_FirstFlow verifies the wrapper unconditionally
+// returns the first element regardless of Metadata (USK-930 lifted the
+// defensive Metadata["grpc_event"]=="start" scan now that callers pass
+// the semantic wire_level filter, so the GRPCStart envelope is
+// guaranteed to be flows[0] by the RecordStep projection invariant).
+func TestPickGRPCStartFlow_FirstFlow(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		flows []*flow.Flow
+	}{
+		{
+			name: "single_flow_with_start_metadata",
+			flows: []*flow.Flow{
+				{ID: "first", Metadata: map[string]string{"grpc_event": "start"}},
+			},
+		},
+		{
+			name: "single_flow_no_metadata",
+			flows: []*flow.Flow{
+				{ID: "first"},
+			},
+		},
+		{
+			name: "multi_flow_start_first",
+			flows: []*flow.Flow{
+				{ID: "first", Metadata: map[string]string{"grpc_event": "start"}},
+				{ID: "second", Metadata: map[string]string{"grpc_event": "data"}},
+			},
+		},
+		{
+			name: "multi_flow_no_metadata_at_all",
+			flows: []*flow.Flow{
+				{ID: "first"},
+				{ID: "second"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pickGRPCStartFlow(tc.flows)
+			if got == nil || got.ID != "first" {
+				t.Fatalf("pickGRPCStartFlow returned %v, want flow ID 'first'", got)
+			}
+		})
+	}
+}

--- a/internal/mcp/resend_http_helpers.go
+++ b/internal/mcp/resend_http_helpers.go
@@ -262,7 +262,11 @@ func (s *Server) loadResendHTTPSendFlow(ctx context.Context, flowID string) (*fl
 	if err != nil {
 		return nil, nil, fmt.Errorf("resend_http: get stream %s: %w", flowID, err)
 	}
-	flows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send"})
+	// USK-930: pass explicit semantic so future SSE-over-h1-chunked
+	// / WS-over-h2 overlay rows do not bleed into the resend helper's
+	// [0]-index assumption (the projection invariant guarantees the
+	// canonical HTTP request envelope is the first semantic send Flow).
+	flows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send", WireLevel: flow.WireLevelSemantic})
 	if err != nil {
 		return nil, nil, fmt.Errorf("resend_http: get flows %s: %w", flowID, err)
 	}

--- a/internal/mcp/resend_ws_helpers.go
+++ b/internal/mcp/resend_ws_helpers.go
@@ -339,14 +339,19 @@ func (s *Server) loadResendWSFlows(ctx context.Context, flowID string) (*flow.St
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_ws: get stream %s: %w", flowID, err)
 	}
-	sendFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send"})
+	// USK-930: pass explicit semantic so future WS-over-h2 / WS-over-h1
+	// overlay rows do not bleed into the resend helper's [0]-index
+	// assumption (the projection invariant guarantees the GET upgrade is
+	// the first semantic send envelope and the 101 response is the first
+	// semantic receive envelope).
+	sendFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "send", WireLevel: flow.WireLevelSemantic})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_ws: get send flows %s: %w", flowID, err)
 	}
 	if len(sendFlows) == 0 {
 		return nil, nil, nil, fmt.Errorf("resend_ws: stream %s has no send-direction flows", flowID)
 	}
-	recvFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "receive"})
+	recvFlows, err := s.flowStore.store.GetFlows(ctx, flowID, flow.FlowListOptions{Direction: "receive", WireLevel: flow.WireLevelSemantic})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resend_ws: get receive flows %s: %w", flowID, err)
 	}


### PR DESCRIPTION
## Summary

USK-921 (PR #14) made MCP `query` default to `wire_level=semantic` so wire-level overlay rows (h2-frame / grpc-lpm-frame / h1-chunk / grpcweb-base64) are no longer surfaced to AI agents by default. This bundle picks up the three follow-up Issues deferred from that PR's Phase 1.5 design review.

Bundled into one PR per request (all three are tightly coupled to the same USK-921 surface area; isolated review would just be churn).

### USK-930 — refactor(mcp,resend): explicit semantic wire_level + pickGRPCStartFlow simplification
- Pass `WireLevel: flow.WireLevelSemantic` explicitly to `Store.GetFlows` in all resend/fuzz helpers below the MCP boundary.
- Simplify `pickGRPCStartFlow` defensive `grpc_event=="start"` scan to a one-line `flows[0]` (the projection invariant holds under semantic filter).
- Sites: `resend_grpc_helpers.go` (3 sites), `resend_ws_helpers.go` (2), `resend_http_helpers.go` (1), `fuzz_http_integration_test.go` (1).

### USK-931 — feat(mcp,query): wire-level advisory hint
- New top-level `wire_level_advisory` field on `query flows` / `query flow` / `query messages` responses, populated only when the default semantic filter hid overlay rows AND the caller did not opt in via `filter.wire_level`.
- Shape: `{wire_level_filter, hidden_overlay_rows: {h2-frame: N, grpc-lpm-frame: M, ...}, hint}`.
- `Advisory string` (the existing oversize hint) is untouched — additive schema change only.
- DB-side `Store.CountFlowsByWireLevel` GROUP BY avoids loading per-flow payloads just to count them.

### USK-932 — chore(flow,export): JSONL export aligned with HAR semantic-default
- JSONL export now defaults to `wire_level=semantic` (was: every row, including overlays).
- New `wire_level` enum field on `manage.export_flows` filter; values mirror `query.filter.wire_level` (`semantic` | `h2-frame` | `h1-chunk` | `grpc-lpm-frame` | `grpcweb-base64` | `all`); default `semantic`.
- HAR export unchanged (already semantic-only; data model has no slot for overlays).
- **Behavior change**: forensic consumers who relied on overlay rows in JSONL export must explicitly pass `wire_level: "all"`.
- Side fix: `CLAUDE.md` `internal/flow/` package-layout comment had a stale "cURL export" reference (no such exporter exists); struck.

## Test plan

- [x] `make test` passes after each of the 3 commits (verified before push)
- [x] `make lint` clean
- [x] New unit tests: `pickGRPCStartFlow_{Empty,FirstFlow}`, `TestResolveExportWireLevel` (9 cases), `TestBuildWireLevelAdvisory` (8 cases)
- [x] Integration tests: JSONL export default-semantic + opt-in `wire_level=all` + explicit-overlay isolation + invalid-value enum error + HAR-ignores-wire_level; query advisory round-trip for all three handlers; query advisory absent when caller opts in; multi-stream aggregation on query flows
- [x] Existing resend / fuzz integration tests still pass (especially listener-captured gRPC from USK-920)

Resolves USK-930
Resolves USK-931
Resolves USK-932

Linear:
- https://linear.app/usk6666/issue/USK-930
- https://linear.app/usk6666/issue/USK-931
- https://linear.app/usk6666/issue/USK-932

🤖 Generated with [Claude Code](https://claude.com/claude-code)