### PR TITLE
USK-924/925: protobuf encode depth cap + fuzz_grpc proto-schemaless JSON-path positions

### DIFF
--- a/internal/encoding/protobuf/encode.go
+++ b/internal/encoding/protobuf/encode.go
@@ -16,7 +16,7 @@ func Encode(jsonStr string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("protobuf encode: %w", err)
 	}
-	return encodeFields(fields)
+	return encodeFieldsWithDepth(fields, 0)
 }
 
 // parseJSON parses the JSON string into field entries preserving order.
@@ -63,14 +63,21 @@ type fieldEntry struct {
 	raw json.RawMessage
 }
 
-// encodeFields serializes field entries to protobuf binary.
+// encodeFieldsWithDepth serializes field entries to protobuf binary with
+// recursion-depth tracking. depth is incremented at each embedded-message
+// boundary; exceeding maxRecursionDepth returns an error symmetric with
+// the Decode-side guard (CWE-674).
+//
 // Fields are sorted by ordinal to ensure deterministic output matching PacketProxy.
-func encodeFields(entries []fieldEntry) ([]byte, error) {
+func encodeFieldsWithDepth(entries []fieldEntry, depth int) ([]byte, error) {
+	if depth > maxRecursionDepth {
+		return nil, fmt.Errorf("recursion depth %d exceeds maximum %d", depth, maxRecursionDepth)
+	}
 	sorted := sortEntries(entries)
 
 	var w writer
 	for _, e := range sorted {
-		if err := encodeField(&w, e); err != nil {
+		if err := encodeField(&w, e, depth); err != nil {
 			return nil, err
 		}
 	}
@@ -78,7 +85,7 @@ func encodeFields(entries []fieldEntry) ([]byte, error) {
 }
 
 // encodeField writes a single field entry to the writer.
-func encodeField(w *writer, e fieldEntry) error {
+func encodeField(w *writer, e fieldEntry, depth int) error {
 	parts := parseKeyParts(e.key)
 	if parts == nil {
 		return fmt.Errorf("invalid key format: %q", e.key)
@@ -100,7 +107,7 @@ func encodeField(w *writer, e fieldEntry) error {
 	case "repeated":
 		return encodeRepeatedField(w, fieldNumber, e)
 	case "embedded message":
-		return encodeEmbeddedField(w, fieldNumber, e)
+		return encodeEmbeddedField(w, fieldNumber, e, depth)
 	case "bytes":
 		return encodeBytesField(w, fieldNumber, e)
 	default:
@@ -172,13 +179,13 @@ func encodeRepeatedField(w *writer, fieldNumber uint64, e fieldEntry) error {
 	return nil
 }
 
-func encodeEmbeddedField(w *writer, fieldNumber uint64, e fieldEntry) error {
+func encodeEmbeddedField(w *writer, fieldNumber uint64, e fieldEntry, depth int) error {
 	w.writeVarint((fieldNumber << 3) | uint64(wireLengthDelimited))
 	subEntries, err := parseJSONObject(e.raw)
 	if err != nil {
 		return fmt.Errorf("field %q: %w", e.key, err)
 	}
-	subBytes, err := encodeFields(subEntries)
+	subBytes, err := encodeFieldsWithDepth(subEntries, depth+1)
 	if err != nil {
 		return fmt.Errorf("field %q: %w", e.key, err)
 	}

--- a/internal/encoding/protobuf/encode_test.go
+++ b/internal/encoding/protobuf/encode_test.go
@@ -2,6 +2,7 @@ package protobuf
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -101,6 +102,51 @@ func TestEncode_RepeatedField(t *testing.T) {
 		t.Fatalf("Encode round-trip: %v", err)
 	}
 	assertBytesEqual(t, result, result2)
+}
+
+// TestEncode_RecursionDepthExceeded pins the symmetric depth cap with
+// Decode (USK-924). Maps depth 70 (above the 64-cap) onto a deeply nested
+// embedded-message JSON tree and asserts the encoder rejects it before
+// recurring into Go's call stack.
+func TestEncode_RecursionDepthExceeded(t *testing.T) {
+	const depth = 70
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`{"0001:0000:embedded message":`)
+	}
+	sb.WriteString(`{"0001:0000:Varint":42}`)
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`}`)
+	}
+	_, err := Encode(sb.String())
+	if err == nil {
+		t.Fatal("expected recursion-depth error for deeply nested embedded message, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursion depth") {
+		t.Errorf("error %q must mention recursion depth", err)
+	}
+}
+
+// TestEncode_RecursionDepthBoundary asserts depth 64 still succeeds —
+// the cap rejects strictly greater depths only. Round-trips through
+// Decode so the boundary is anchored symmetrically.
+func TestEncode_RecursionDepthBoundary(t *testing.T) {
+	const depth = 64
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`{"0001:0000:embedded message":`)
+	}
+	sb.WriteString(`{"0001:0000:Varint":7}`)
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`}`)
+	}
+	encoded, err := Encode(sb.String())
+	if err != nil {
+		t.Fatalf("Encode at depth %d should succeed: %v", depth, err)
+	}
+	if _, err := Decode(encoded); err != nil {
+		t.Fatalf("Decode round-trip at depth %d should succeed: %v", depth, err)
+	}
 }
 
 // TestEncode_EmbeddedMessage tests encoding a nested message.

--- a/internal/mcp/fuzz_grpc.go
+++ b/internal/mcp/fuzz_grpc.go
@@ -20,16 +20,26 @@
 // Position path syntax (typed reference into the GRPCStart + GRPCData
 // envelope shape):
 //
-//	"service"               → GRPCStartMessage.Service
-//	"method"                → GRPCStartMessage.Method
-//	"metadata[N].name"      → GRPCStartMessage.Metadata[N].Name
-//	"metadata[N].value"     → GRPCStartMessage.Metadata[N].Value
-//	"messages[N].payload"   → GRPCDataMessage.Payload (variant N)
+//	"service"                                → GRPCStartMessage.Service
+//	"method"                                 → GRPCStartMessage.Method
+//	"metadata[N].name"                       → GRPCStartMessage.Metadata[N].Name
+//	"metadata[N].value"                      → GRPCStartMessage.Metadata[N].Value
+//	"messages[N].payload"                    → GRPCDataMessage.Payload (variant N) — raw bytes
+//	"messages[N].payload.<FFFF:OOOO:type>"   → one scalar field inside the proto-schemaless-json
+//	                                           source for messages[N] (USK-925). The targeted
+//	                                           message must have been supplied with
+//	                                           body_encoding="proto-schemaless-json"; supported
+//	                                           wire types are String / Varint / 32-bit / 64-bit / bytes.
 //
 // scheme / target_addr / encoding are intentionally NOT fuzz positions —
 // they affect connection setup and would change the dial target rather
 // than the on-wire envelope content. Callers that need to fuzz across
 // schemes should issue separate fuzz_grpc calls.
+//
+// A bytes-level messages[N].payload position and a JSON-path
+// messages[N].payload.<key> position cannot coexist for the same N —
+// the bytes form would silently overwrite the JSON-mutation result.
+// Pick one.
 //
 // Variant generation: cartesian product across positions (full N-way
 // product). Total variant count is capped at maxFuzzGRPCVariants=1000
@@ -97,7 +107,7 @@ type fuzzGRPCInput struct {
 // Encoding: each payload is interpreted per encoding ("text" or
 // "base64"); defaults to "text".
 type fuzzGRPCPosition struct {
-	Path     string   `json:"path" jsonschema:"typed path: service | method | metadata[N].name | metadata[N].value | messages[N].payload"`
+	Path     string   `json:"path" jsonschema:"typed path: service | method | metadata[N].name | metadata[N].value | messages[N].payload | messages[N].payload.<FFFF:OOOO:type> (JSON-path against a proto-schemaless-json message; supported wire types: String, Varint, 32-bit, 64-bit, bytes)"`
 	Payloads []string `json:"payloads" jsonschema:"REQUIRED list of payload values to substitute at this path; at least one element"`
 	Encoding string   `json:"encoding,omitempty" jsonschema:"text|base64 — applies to every payload; default text"`
 }
@@ -143,9 +153,10 @@ func (s *Server) registerFuzzGRPC() {
 		Name: "fuzz_grpc",
 		Description: "Synchronously fuzz a gRPC unary RPC. Schema mirrors resend_grpc plus a positions[] list — " +
 			"each position is a typed path (service | method | metadata[N].name | metadata[N].value | " +
-			"messages[N].payload) with payloads[]. The cartesian product of positions yields the variant " +
-			"sequence (capped at 1000 per call). Each variant runs on an independent stream. " +
-			"stop_on_non_ok aborts on the first non-OK gRPC status. See yorishiro://help/fuzz_grpc.",
+			"messages[N].payload | messages[N].payload.<FFFF:OOOO:type>) with payloads[]. The JSON-path form " +
+			"mutates one scalar field inside a proto-schemaless-json payload (USK-925). The cartesian product " +
+			"of positions yields the variant sequence (capped at 1000 per call). Each variant runs on an " +
+			"independent stream. stop_on_non_ok aborts on the first non-OK gRPC status. See yorishiro://help/fuzz_grpc.",
 	}, s.handleFuzzGRPC)
 }
 

--- a/internal/mcp/fuzz_grpc_helpers.go
+++ b/internal/mcp/fuzz_grpc_helpers.go
@@ -38,10 +38,12 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/pipeline"
@@ -81,6 +83,34 @@ var fuzzGRPCMetadataPathRE = regexp.MustCompile(`^metadata\[(\d+)\]\.(name|value
 // fuzzGRPCMessagePathRE matches "messages[N].payload" where N is a
 // non-negative decimal integer. Captures the index.
 var fuzzGRPCMessagePathRE = regexp.MustCompile(`^messages\[(\d+)\]\.payload$`)
+
+// fuzzGRPCMessageJSONPathRE matches
+// "messages[N].payload.FFFF:OOOO:type" — a JSON-path position into a
+// proto-schemaless-json payload (USK-925). Captures the message index and
+// the proto field key.
+//
+// The remainder after `payload.` is intentionally permissive (`(.+)`) —
+// it can include spaces (the protobuf "embedded message" / "32-bit" /
+// "64-bit" wire-type names) and colons (the `field:ordinal:type`
+// separators). Strict parsing against parseKeyParts happens in
+// validateFuzzGRPCPositionAgainstPlan once the targeted message's JSON
+// has been resolved.
+var fuzzGRPCMessageJSONPathRE = regexp.MustCompile(`^messages\[(\d+)\]\.payload\.(.+)$`)
+
+// fuzzGRPCSupportedJSONFieldTypes lists the proto wire-type names a
+// JSON-path position may target. Composite types ("repeated",
+// "embedded message") are intentionally excluded for v1 — they require
+// a structurally-typed payload (array / object) but the fuzz iterator
+// supplies a single string per position. Callers that need to mutate
+// nested fields can supply the entire embedded-message subtree via the
+// `messages[N].payload` (root) path with body_encoding="proto-schemaless-json".
+var fuzzGRPCSupportedJSONFieldTypes = map[string]bool{
+	"String": true,
+	"Varint": true,
+	"32-bit": true,
+	"64-bit": true,
+	"bytes":  true,
+}
 
 // validateFuzzGRPCInput rejects malformed inputs at the schema boundary
 // before any expensive lookups (flow store, dial) run.
@@ -128,7 +158,7 @@ func validateFuzzGRPCPosition(index int, p fuzzGRPCPosition) error {
 		return fmt.Errorf("positions[%d]: path must not be empty", index)
 	}
 	if !isValidFuzzGRPCPath(p.Path) {
-		return fmt.Errorf("positions[%d]: unsupported path %q (valid: service, method, metadata[N].name, metadata[N].value, messages[N].payload)", index, p.Path)
+		return fmt.Errorf("positions[%d]: unsupported path %q (valid: service, method, metadata[N].name, metadata[N].value, messages[N].payload, messages[N].payload.<FFFF:OOOO:type>)", index, p.Path)
 	}
 	if len(p.Payloads) == 0 {
 		return fmt.Errorf("positions[%d]: payloads must contain at least one element", index)
@@ -141,7 +171,11 @@ func validateFuzzGRPCPosition(index int, p fuzzGRPCPosition) error {
 
 // isValidFuzzGRPCPath reports whether path resolves to a supported
 // field. Scalar paths are exact-match against validFuzzGRPCRoots;
-// indexed paths are regex-matched.
+// indexed paths are regex-matched. The JSON-path form
+// `messages[N].payload.<key>` (USK-925) is recognised here at the
+// schema-shape layer; deeper validation (parseable key, supported wire
+// type, json-path target message uses proto-schemaless-json) happens in
+// validateFuzzGRPCPositionAgainstPlan once the base plan is resolved.
 func isValidFuzzGRPCPath(path string) bool {
 	if validFuzzGRPCRoots[path] {
 		return true
@@ -149,7 +183,10 @@ func isValidFuzzGRPCPath(path string) bool {
 	if fuzzGRPCMetadataPathRE.MatchString(path) {
 		return true
 	}
-	return fuzzGRPCMessagePathRE.MatchString(path)
+	if fuzzGRPCMessagePathRE.MatchString(path) {
+		return true
+	}
+	return fuzzGRPCMessageJSONPathRE.MatchString(path)
 }
 
 // fuzzGRPCInputToResendGRPC projects fuzz_grpc base fields onto a
@@ -200,6 +237,9 @@ func (s *Server) buildFuzzGRPCPlan(ctx context.Context, input *fuzzGRPCInput) (*
 			return nil, err
 		}
 	}
+	if err := validateFuzzGRPCMessagePathConflicts(input.Positions); err != nil {
+		return nil, err
+	}
 
 	totalVariants := 1
 	for _, p := range input.Positions {
@@ -214,30 +254,135 @@ func (s *Server) buildFuzzGRPCPlan(ctx context.Context, input *fuzzGRPCInput) (*
 }
 
 // validateFuzzGRPCPositionAgainstPlan runs the index-range checks for
-// indexed paths (metadata[N], messages[N]) against the resolved base
-// plan. Scalar paths (service, method) need no plan-side check.
+// indexed paths (metadata[N], messages[N], messages[N].payload.<key>)
+// against the resolved base plan. Scalar paths (service, method) need
+// no plan-side check.
+//
+// For JSON-path positions (USK-925) the targeted message must have been
+// supplied with body_encoding="proto-schemaless-json"; otherwise the
+// JSON source string isn't available for mutation. The proto field key
+// must parse, must reference a field present in the input JSON, and
+// must point at a supported scalar wire type (String / Varint / 32-bit
+// / 64-bit / bytes).
 func validateFuzzGRPCPositionAgainstPlan(idx int, pos fuzzGRPCPosition, plan *resendGRPCPlan) error {
 	if matches := fuzzGRPCMetadataPathRE.FindStringSubmatch(pos.Path); matches != nil {
-		mIdx, err := strconv.Atoi(matches[1])
-		if err != nil {
-			return fmt.Errorf("positions[%d]: invalid metadata index %q: %w", idx, matches[1], err)
-		}
-		if mIdx < 0 || mIdx >= len(plan.metadata) {
-			return fmt.Errorf("positions[%d]: metadata index %d out of range [0, %d) — base plan has %d metadata entries", idx, mIdx, len(plan.metadata), len(plan.metadata))
-		}
-		return nil
+		return validateFuzzGRPCMetadataIndex(idx, matches[1], plan)
+	}
+	if matches := fuzzGRPCMessageJSONPathRE.FindStringSubmatch(pos.Path); matches != nil {
+		return validateFuzzGRPCJSONPathTarget(idx, pos.Path, matches[1], matches[2], plan)
 	}
 	if matches := fuzzGRPCMessagePathRE.FindStringSubmatch(pos.Path); matches != nil {
-		mIdx, err := strconv.Atoi(matches[1])
-		if err != nil {
-			return fmt.Errorf("positions[%d]: invalid messages index %q: %w", idx, matches[1], err)
-		}
-		if mIdx < 0 || mIdx >= len(plan.messages) {
-			return fmt.Errorf("positions[%d]: messages index %d out of range [0, %d) — base plan has %d messages", idx, mIdx, len(plan.messages), len(plan.messages))
-		}
-		return nil
+		return validateFuzzGRPCMessageIndex(idx, matches[1], plan)
 	}
 	return nil
+}
+
+// validateFuzzGRPCMetadataIndex pins the index-range check for
+// metadata[N].name|value paths. Extracted from
+// validateFuzzGRPCPositionAgainstPlan to keep cyclomatic complexity low.
+func validateFuzzGRPCMetadataIndex(idx int, rawIdx string, plan *resendGRPCPlan) error {
+	mIdx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("positions[%d]: invalid metadata index %q: %w", idx, rawIdx, err)
+	}
+	if mIdx < 0 || mIdx >= len(plan.metadata) {
+		return fmt.Errorf("positions[%d]: metadata index %d out of range [0, %d) — base plan has %d metadata entries", idx, mIdx, len(plan.metadata), len(plan.metadata))
+	}
+	return nil
+}
+
+// validateFuzzGRPCMessageIndex pins the index-range check for the
+// bytes-level messages[N].payload path. Mirror helper of
+// validateFuzzGRPCMetadataIndex.
+func validateFuzzGRPCMessageIndex(idx int, rawIdx string, plan *resendGRPCPlan) error {
+	mIdx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("positions[%d]: invalid messages index %q: %w", idx, rawIdx, err)
+	}
+	if mIdx < 0 || mIdx >= len(plan.messages) {
+		return fmt.Errorf("positions[%d]: messages index %d out of range [0, %d) — base plan has %d messages", idx, mIdx, len(plan.messages), len(plan.messages))
+	}
+	return nil
+}
+
+// validateFuzzGRPCJSONPathTarget runs the layered checks for
+// messages[N].payload.<key>: index range, body_encoding requirement,
+// key parseability, supported wire type, and presence-in-source.
+// USK-925 introduces this path; the validator block is extracted to
+// keep validateFuzzGRPCPositionAgainstPlan under the lint cyclomatic
+// cap.
+func validateFuzzGRPCJSONPathTarget(idx int, path, rawIdx, key string, plan *resendGRPCPlan) error {
+	mIdx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("positions[%d]: invalid messages index %q: %w", idx, rawIdx, err)
+	}
+	if mIdx < 0 || mIdx >= len(plan.messages) {
+		return fmt.Errorf("positions[%d]: messages index %d out of range [0, %d) — base plan has %d messages", idx, mIdx, len(plan.messages), len(plan.messages))
+	}
+	if plan.messages[mIdx].bodyEncoding != "proto-schemaless-json" {
+		return fmt.Errorf("positions[%d]: JSON-path %q requires messages[%d].body_encoding=\"proto-schemaless-json\" (got %q)", idx, path, mIdx, plan.messages[mIdx].bodyEncoding)
+	}
+	parts := parseProtoKeyParts(key)
+	if parts == nil {
+		return fmt.Errorf("positions[%d]: invalid proto field key %q in JSON path (expected FFFF:OOOO:type)", idx, key)
+	}
+	if !fuzzGRPCSupportedJSONFieldTypes[parts[2]] {
+		return fmt.Errorf("positions[%d]: unsupported proto wire type %q in JSON path %q (supported: String, Varint, 32-bit, 64-bit, bytes)", idx, parts[2], path)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(plan.messages[mIdx].jsonPayload), &m); err != nil {
+		return fmt.Errorf("positions[%d]: messages[%d].payload is not valid proto-schemaless-json: %w", idx, mIdx, err)
+	}
+	if _, ok := m[key]; !ok {
+		return fmt.Errorf("positions[%d]: proto field key %q not present in messages[%d].payload — fuzz JSON-path positions cannot add new fields", idx, key, mIdx)
+	}
+	return nil
+}
+
+// validateFuzzGRPCMessagePathConflicts rejects the (bytes, JSON-path)
+// pair targeting the same message index. The bytes-level
+// messages[N].payload position overwrites the LPM payload outright,
+// which would silently lose any same-message JSON-path mutation
+// (JSON commit re-derives from plan.messages[N].jsonPayload, not the
+// just-overwritten bytes), so we surface the conflict up-front rather
+// than have the AI agent debug a missing mutation.
+func validateFuzzGRPCMessagePathConflicts(positions []fuzzGRPCPosition) error {
+	bytesPos := make(map[int]int)
+	jsonPos := make(map[int]int)
+	for i, p := range positions {
+		if matches := fuzzGRPCMessagePathRE.FindStringSubmatch(p.Path); matches != nil {
+			idx, _ := strconv.Atoi(matches[1])
+			bytesPos[idx] = i
+			continue
+		}
+		if matches := fuzzGRPCMessageJSONPathRE.FindStringSubmatch(p.Path); matches != nil {
+			idx, _ := strconv.Atoi(matches[1])
+			jsonPos[idx] = i
+		}
+	}
+	for idx, bi := range bytesPos {
+		if ji, ok := jsonPos[idx]; ok {
+			return fmt.Errorf("positions[%d] and positions[%d]: cannot combine messages[%d].payload (bytes-level) and messages[%d].payload.<key> (JSON-path) on the same message — pick one", bi, ji, idx, idx)
+		}
+	}
+	return nil
+}
+
+// parseProtoKeyParts mirrors internal/encoding/protobuf parseKeyParts —
+// duplicated here because that helper is package-private. Splits
+// "FFFF:OOOO:type" into [fieldNumber, ordinal, type]; returns nil on
+// malformed input.
+func parseProtoKeyParts(key string) []string {
+	i1 := strings.Index(key, ":")
+	if i1 < 0 {
+		return nil
+	}
+	rest := key[i1+1:]
+	i2 := strings.Index(rest, ":")
+	if i2 < 0 {
+		return nil
+	}
+	return []string{key[:i1], rest[:i2], rest[i2+1:]}
 }
 
 // runFuzzGRPCVariants iterates the cartesian product of all positions,
@@ -530,14 +675,22 @@ func (s *Server) runFuzzGRPCSingleVariant(ctx context.Context, plan *fuzzGRPCPla
 	}
 
 	variantPlan := cloneFuzzGRPCPlan(plan.basePlan)
+	// Collected JSON-path mutations (USK-925) keyed by message index, then
+	// proto field key. Committed after all positions are processed so
+	// multiple JSON-path positions on the same message share one
+	// Decode→mutate→Encode round-trip.
+	jsonMuts := make(map[int]map[string]json.RawMessage)
 	for _, pos := range plan.positions {
 		payload, ok := payloads[pos.Path]
 		if !ok {
 			continue
 		}
-		if err := applyFuzzGRPCPosition(variantPlan, pos.Path, payload); err != nil {
+		if err := applyFuzzGRPCPosition(variantPlan, pos.Path, payload, jsonMuts); err != nil {
 			return row, 0, fmt.Errorf("apply position %q: %w", pos.Path, err)
 		}
+	}
+	if err := commitFuzzGRPCJSONMutations(variantPlan, jsonMuts); err != nil {
+		return row, 0, fmt.Errorf("commit JSON-path mutations: %w", err)
 	}
 	// Re-derive the canonical URL after potential service/method mutation
 	// so the safety filter and any downstream consumer see the substituted
@@ -631,7 +784,13 @@ func decodeFuzzGRPCPayloads(positions []fuzzGRPCPosition, indices []int) (map[st
 // variant plan. Unknown paths are rejected (validation runs upfront +
 // against-plan, so this is a defensive catch — should never fire in
 // practice).
-func applyFuzzGRPCPosition(plan *resendGRPCPlan, path, payload string) error {
+//
+// JSON-path positions (messages[N].payload.<key>, USK-925) are NOT
+// applied here — they are batched per message and committed via
+// commitFuzzGRPCJSONMutations after every position has been processed,
+// so multiple JSON-path positions targeting the same message share a
+// single Decode/Encode round-trip and one cohesive JSON tree mutation.
+func applyFuzzGRPCPosition(plan *resendGRPCPlan, path, payload string, jsonMuts map[int]map[string]json.RawMessage) error {
 	switch path {
 	case "service":
 		plan.service = payload
@@ -641,33 +800,212 @@ func applyFuzzGRPCPosition(plan *resendGRPCPlan, path, payload string) error {
 		return nil
 	}
 	if matches := fuzzGRPCMetadataPathRE.FindStringSubmatch(path); matches != nil {
-		idx, err := strconv.Atoi(matches[1])
-		if err != nil {
-			return fmt.Errorf("invalid metadata index %q: %w", matches[1], err)
-		}
-		if idx < 0 || idx >= len(plan.metadata) {
-			return fmt.Errorf("metadata index %d out of range [0, %d)", idx, len(plan.metadata))
-		}
-		switch matches[2] {
-		case "name":
-			plan.metadata[idx].Name = payload
-		case "value":
-			plan.metadata[idx].Value = payload
-		}
-		return nil
+		return applyFuzzGRPCMetadataPosition(plan, matches[1], matches[2], payload)
+	}
+	if matches := fuzzGRPCMessageJSONPathRE.FindStringSubmatch(path); matches != nil {
+		return applyFuzzGRPCMessageJSONPathPosition(plan, matches[1], matches[2], payload, jsonMuts)
 	}
 	if matches := fuzzGRPCMessagePathRE.FindStringSubmatch(path); matches != nil {
-		idx, err := strconv.Atoi(matches[1])
+		return applyFuzzGRPCMessagePosition(plan, matches[1], payload)
+	}
+	return fmt.Errorf("unsupported path %q", path)
+}
+
+// applyFuzzGRPCMetadataPosition writes payload to plan.metadata[idx].
+// field is "name" or "value" per the regex shape.
+func applyFuzzGRPCMetadataPosition(plan *resendGRPCPlan, rawIdx, field, payload string) error {
+	idx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("invalid metadata index %q: %w", rawIdx, err)
+	}
+	if idx < 0 || idx >= len(plan.metadata) {
+		return fmt.Errorf("metadata index %d out of range [0, %d)", idx, len(plan.metadata))
+	}
+	switch field {
+	case "name":
+		plan.metadata[idx].Name = payload
+	case "value":
+		plan.metadata[idx].Value = payload
+	}
+	return nil
+}
+
+// applyFuzzGRPCMessageJSONPathPosition stages a JSON-path mutation
+// (USK-925) onto the per-variant jsonMuts map. The commit pass folds
+// these into the message's proto-schemaless source and re-encodes once
+// per message; see commitFuzzGRPCJSONMutations.
+func applyFuzzGRPCMessageJSONPathPosition(plan *resendGRPCPlan, rawIdx, key, payload string, jsonMuts map[int]map[string]json.RawMessage) error {
+	idx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("invalid messages index %q: %w", rawIdx, err)
+	}
+	if idx < 0 || idx >= len(plan.messages) {
+		return fmt.Errorf("messages index %d out of range [0, %d)", idx, len(plan.messages))
+	}
+	val, err := encodeFuzzGRPCJSONFieldValue(key, payload)
+	if err != nil {
+		return fmt.Errorf("encode proto field value for %q: %w", key, err)
+	}
+	if jsonMuts[idx] == nil {
+		jsonMuts[idx] = make(map[string]json.RawMessage)
+	}
+	jsonMuts[idx][key] = val
+	return nil
+}
+
+// applyFuzzGRPCMessagePosition overwrites plan.messages[idx].payload
+// with the raw bytes form. Mirror helper of the metadata variant.
+func applyFuzzGRPCMessagePosition(plan *resendGRPCPlan, rawIdx, payload string) error {
+	idx, err := strconv.Atoi(rawIdx)
+	if err != nil {
+		return fmt.Errorf("invalid messages index %q: %w", rawIdx, err)
+	}
+	if idx < 0 || idx >= len(plan.messages) {
+		return fmt.Errorf("messages index %d out of range [0, %d)", idx, len(plan.messages))
+	}
+	plan.messages[idx].payload = []byte(payload)
+	return nil
+}
+
+// encodeFuzzGRPCJSONFieldValue converts a fuzz-iterator payload string
+// into the JSON literal a proto-schemaless-json object expects for the
+// given key's wire type. Supported types match
+// fuzzGRPCSupportedJSONFieldTypes; the caller has already
+// type-validated, so this returns an error only on malformed numeric
+// payloads (range, syntax) — never on type lookup miss.
+//
+// For String/bytes the payload is JSON-string-quoted verbatim; for
+// integer wire types the payload must parse as a base-10 integer (signed
+// for Varint/64-bit to round-trip negative values via two's-complement,
+// like Decode emits). Range checks mirror the encoder
+// (32-bit ⇒ fits uint32; bytes accepts the colon-hex form used by the
+// rest of the proto-schemaless surface).
+func encodeFuzzGRPCJSONFieldValue(key, payload string) (json.RawMessage, error) {
+	parts := parseProtoKeyParts(key)
+	if parts == nil {
+		return nil, fmt.Errorf("invalid proto field key %q", key)
+	}
+	switch parts[2] {
+	case "String":
+		b, err := json.Marshal(payload)
 		if err != nil {
-			return fmt.Errorf("invalid messages index %q: %w", matches[1], err)
+			return nil, fmt.Errorf("marshal string payload: %w", err)
 		}
+		return b, nil
+	case "bytes":
+		// The proto-schemaless encoder accepts colon-hex via
+		// decodeHexColon. Validate the payload eagerly so a bad hex
+		// surfaces here rather than during Encode where the error
+		// shape would obscure which fuzz position failed.
+		if _, err := hexColonDecode(payload); err != nil {
+			return nil, fmt.Errorf("invalid bytes payload %q (expected colon-separated hex): %w", payload, err)
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal bytes payload: %w", err)
+		}
+		return b, nil
+	case "Varint", "64-bit":
+		// Accept either int64 (allows negative round-trip via two's
+		// complement) or uint64 (allows values > int64 max). Mirrors
+		// parseJSONNumber on the encoder side.
+		if _, err := strconv.ParseInt(payload, 10, 64); err == nil {
+			return json.RawMessage(payload), nil
+		}
+		if _, err := strconv.ParseUint(payload, 10, 64); err == nil {
+			return json.RawMessage(payload), nil
+		}
+		return nil, fmt.Errorf("invalid integer payload %q for type %q", payload, parts[2])
+	case "32-bit":
+		// 32-bit must fit uint32 — the encoder rejects anything larger.
+		if _, err := strconv.ParseUint(payload, 10, 32); err != nil {
+			return nil, fmt.Errorf("invalid 32-bit payload %q: %w", payload, err)
+		}
+		return json.RawMessage(payload), nil
+	default:
+		return nil, fmt.Errorf("unsupported proto wire type %q", parts[2])
+	}
+}
+
+// hexColonDecode validates the colon-separated hex form used by the
+// proto-schemaless bytes wire type. Empty payload is treated as the
+// empty byte slice (matches the encoder's decodeHexColon).
+func hexColonDecode(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	clean := strings.ReplaceAll(s, ":", "")
+	out := make([]byte, len(clean)/2)
+	if len(clean)%2 != 0 {
+		return nil, fmt.Errorf("odd hex length %d", len(clean))
+	}
+	for i := 0; i < len(clean); i += 2 {
+		hi, err := hexNibble(clean[i])
+		if err != nil {
+			return nil, err
+		}
+		lo, err := hexNibble(clean[i+1])
+		if err != nil {
+			return nil, err
+		}
+		out[i/2] = (hi << 4) | lo
+	}
+	return out, nil
+}
+
+func hexNibble(c byte) (byte, error) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', nil
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, nil
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, nil
+	}
+	return 0, fmt.Errorf("invalid hex char %q", c)
+}
+
+// commitFuzzGRPCJSONMutations folds the per-variant JSON-path mutations
+// into each affected message's proto-schemaless-json source, re-encodes
+// to proto wire bytes via protobuf.Encode, and writes the bytes back to
+// plan.messages[idx].payload. Idempotent on an empty mutation map.
+//
+// The size cap (maxResendGRPCPayload) is intentionally not re-checked
+// here — populateResendGRPCMessages enforced it on the source payload
+// during plan build, and the fuzz path payload cap
+// (maxFuzzGRPCPayloadSize) bounds each substituted value; the
+// re-encoded byte length is therefore bounded by their sum, well below
+// the gRPC Layer's own framing limits.
+func commitFuzzGRPCJSONMutations(plan *resendGRPCPlan, jsonMuts map[int]map[string]json.RawMessage) error {
+	for idx, muts := range jsonMuts {
 		if idx < 0 || idx >= len(plan.messages) {
 			return fmt.Errorf("messages index %d out of range [0, %d)", idx, len(plan.messages))
 		}
-		plan.messages[idx].payload = []byte(payload)
-		return nil
+		src := plan.messages[idx].jsonPayload
+		if src == "" {
+			return fmt.Errorf("messages[%d]: JSON-path mutation requires body_encoding=\"proto-schemaless-json\" (no source JSON on the plan)", idx)
+		}
+		var tree map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(src), &tree); err != nil {
+			return fmt.Errorf("messages[%d]: parse JSON payload: %w", idx, err)
+		}
+		for k, v := range muts {
+			if _, ok := tree[k]; !ok {
+				return fmt.Errorf("messages[%d]: proto field key %q not present in source JSON", idx, k)
+			}
+			tree[k] = v
+		}
+		merged, err := json.Marshal(tree)
+		if err != nil {
+			return fmt.Errorf("messages[%d]: marshal mutated JSON: %w", idx, err)
+		}
+		encoded, err := protobuf.Encode(string(merged))
+		if err != nil {
+			return fmt.Errorf("messages[%d]: re-encode proto bytes: %w", idx, err)
+		}
+		plan.messages[idx].payload = encoded
 	}
-	return fmt.Errorf("unsupported path %q", path)
+	return nil
 }
 
 // cloneFuzzGRPCPlan returns a deep copy of plan suitable for per-variant
@@ -695,8 +1033,10 @@ func cloneFuzzGRPCPlan(base *resendGRPCPlan) *resendGRPCPlan {
 			payloadCopy := make([]byte, len(m.payload))
 			copy(payloadCopy, m.payload)
 			ms[i] = resendGRPCDataPlan{
-				payload:    payloadCopy,
-				compressed: m.compressed,
+				payload:      payloadCopy,
+				compressed:   m.compressed,
+				jsonPayload:  m.jsonPayload,
+				bodyEncoding: m.bodyEncoding,
 			}
 		}
 		out.messages = ms

--- a/internal/mcp/fuzz_grpc_integration_test.go
+++ b/internal/mcp/fuzz_grpc_integration_test.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/connector/transport"
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/pluginv2"
 )
@@ -557,6 +558,118 @@ func TestFuzzGRPC_TwoPositionCartesian(t *testing.T) {
 			}
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON-path positions (USK-925) — mutate one proto field per variant.
+// ---------------------------------------------------------------------------
+
+func TestFuzzGRPC_ProtoSchemalessJSONPathGeneratesVariants(t *testing.T) {
+	cs, _, _ := setupFuzzGRPCSession(t)
+	upstream := &fuzzGRPCEchoServer{}
+	addr, shutdown := startFuzzGRPCUpstream(t, upstream)
+	defer shutdown()
+
+	// Each variant mutates field 0001:0000:String inside a
+	// proto-schemaless-json source. The upstream observes one independent
+	// proto wire payload per variant; we verify (a) the byte sequences
+	// differ across variants and (b) each substituted string round-trips
+	// back to the recorded payload via protobuf.Decode.
+	names := []string{"alice", "bob", "carol"}
+	result := callFuzzGRPC(t, cs, map[string]any{
+		"target_addr": addr,
+		"scheme":      "https",
+		"service":     fuzzGRPCServiceName,
+		"method":      fuzzGRPCMethodUnary,
+		"messages": []map[string]any{
+			{
+				"payload":       `{"0001:0000:String":"seed","0002:0001:Varint":1}`,
+				"body_encoding": "proto-schemaless-json",
+			},
+		},
+		"positions": []map[string]any{
+			{
+				"path":     "messages[0].payload.0001:0000:String",
+				"payloads": names,
+			},
+		},
+		"timeout_ms": 10000,
+	})
+
+	if result.CompletedVariants != len(names) {
+		t.Fatalf("CompletedVariants = %d, want %d", result.CompletedVariants, len(names))
+	}
+	observed := upstream.snapshot()
+	if len(observed) != len(names) {
+		t.Fatalf("upstream hits = %d, want %d", len(observed), len(names))
+	}
+
+	seenBytes := map[string]bool{}
+	seenStrings := map[string]bool{}
+	for i, o := range observed {
+		if seenBytes[string(o.Payload)] {
+			t.Errorf("variants[%d]: duplicate wire bytes %x — fuzz did not differentiate", i, o.Payload)
+		}
+		seenBytes[string(o.Payload)] = true
+
+		// Decode the recorded wire bytes via the proto-schemaless decoder
+		// and confirm the mutated field appears with the iterator value.
+		decoded, err := protobufDecodeJSON(o.Payload)
+		if err != nil {
+			t.Fatalf("variants[%d]: Decode upstream payload: %v", i, err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(decoded), &fields); err != nil {
+			t.Fatalf("variants[%d]: unmarshal decoded JSON: %v\nraw=%s", i, err, decoded)
+		}
+		var s string
+		if err := json.Unmarshal(fields["0001:0000:String"], &s); err != nil {
+			t.Fatalf("variants[%d]: unmarshal String field: %v\nraw=%s", i, err, fields["0001:0000:String"])
+		}
+		seenStrings[s] = true
+	}
+	for _, name := range names {
+		if !seenStrings[name] {
+			t.Errorf("upstream did not see mutated String=%q (saw %v)", name, seenStrings)
+		}
+	}
+}
+
+// TestFuzzGRPC_ProtoSchemalessJSONPathRejectsByteAndJSONConflict pins
+// the cross-position guard: same-message bytes-level and JSON-path
+// positions cannot coexist (the bytes form would silently overwrite
+// the JSON commit's re-encoded payload).
+func TestFuzzGRPC_ProtoSchemalessJSONPathRejectsByteAndJSONConflict(t *testing.T) {
+	cs, _, _ := setupFuzzGRPCSession(t)
+	res, _ := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_grpc",
+		Arguments: map[string]any{
+			"target_addr": "127.0.0.1:9999",
+			"scheme":      "https",
+			"service":     "Svc",
+			"method":      "M",
+			"messages": []map[string]any{
+				{
+					"payload":       `{"0001:0000:String":"hi"}`,
+					"body_encoding": "proto-schemaless-json",
+				},
+			},
+			"positions": []map[string]any{
+				{"path": "messages[0].payload", "payloads": []string{"raw"}},
+				{"path": "messages[0].payload.0001:0000:String", "payloads": []string{"x"}},
+			},
+		},
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected conflict error for same-message bytes+JSON positions; got %+v", res)
+	}
+}
+
+// protobufDecodeJSON is a small wrapper so the assertion code reads as
+// "decode the upstream wire bytes" rather than reaching directly into
+// the codec package within the test body.
+func protobufDecodeJSON(b []byte) (string, error) {
+	return protobuf.Decode(b)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/fuzz_grpc_proto_schemaless_test.go
+++ b/internal/mcp/fuzz_grpc_proto_schemaless_test.go
@@ -1,0 +1,312 @@
+// Package mcp fuzz_grpc_proto_schemaless_test.go covers the
+// proto-schemaless-json JSON-path positions added by USK-925 — the
+// validation surface, the per-key value encoder, and the per-variant
+// commit pass. The integration suite (fuzz_grpc_integration_test.go,
+// e2e tag) exercises the end-to-end wire effect; this file is the unit
+// tier and avoids the gRPC server.
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protobuf"
+)
+
+// TestIsValidFuzzGRPCPath_AcceptsJSONPath asserts the shape-layer
+// validator recognises the new path family. parseProtoKeyParts /
+// per-key checks happen in validateFuzzGRPCPositionAgainstPlan and are
+// covered by the table tests below.
+func TestIsValidFuzzGRPCPath_AcceptsJSONPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		ok   bool
+	}{
+		{"messages[0].payload.0001:0000:String", true},
+		{"messages[12].payload.000a:0003:embedded message", true}, // shape OK; deeper validator rejects type
+		{"messages[0].payload.", false},                           // empty key
+		{"messages[0].payload", true},                             // bytes-level — still valid
+		{"service", true},
+		{"metadata[0].value", true},
+		{"nope", false},
+	}
+	for _, tc := range cases {
+		got := isValidFuzzGRPCPath(tc.path)
+		if got != tc.ok {
+			t.Errorf("isValidFuzzGRPCPath(%q) = %v, want %v", tc.path, got, tc.ok)
+		}
+	}
+}
+
+// TestValidateFuzzGRPCPositionAgainstPlan_JSONPathHappyPath asserts that
+// every prerequisite (proto-schemaless source on the targeted message,
+// parseable key, supported wire type, key present in source) lining up
+// produces no error.
+func TestValidateFuzzGRPCPositionAgainstPlan_JSONPathHappyPath(t *testing.T) {
+	t.Parallel()
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				bodyEncoding: "proto-schemaless-json",
+				jsonPayload:  `{"0001:0000:String":"hi"}`,
+			},
+		},
+	}
+	pos := fuzzGRPCPosition{
+		Path:     "messages[0].payload.0001:0000:String",
+		Payloads: []string{"hi", "bye"},
+	}
+	if err := validateFuzzGRPCPositionAgainstPlan(0, pos, plan); err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+}
+
+// TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsNonSchemaless
+// pins the body_encoding gate. A JSON-path position against a base64
+// message has no source JSON to mutate, so it must be rejected before
+// any iterator runs.
+func TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsNonSchemaless(t *testing.T) {
+	t.Parallel()
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{bodyEncoding: "base64"}, // no jsonPayload
+		},
+	}
+	pos := fuzzGRPCPosition{
+		Path:     "messages[0].payload.0001:0000:String",
+		Payloads: []string{"x"},
+	}
+	err := validateFuzzGRPCPositionAgainstPlan(0, pos, plan)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "proto-schemaless-json") {
+		t.Errorf("error must name the required body_encoding: %q", err)
+	}
+}
+
+// TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsUnsupportedWireType
+// pins the v1 type allowlist — composite types (`repeated`, `embedded
+// message`) are out of scope until structured payload iterators land.
+func TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsUnsupportedWireType(t *testing.T) {
+	t.Parallel()
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				bodyEncoding: "proto-schemaless-json",
+				jsonPayload:  `{"0001:0000:embedded message":{"0002:0000:Varint":1}}`,
+			},
+		},
+	}
+	pos := fuzzGRPCPosition{
+		Path:     "messages[0].payload.0001:0000:embedded message",
+		Payloads: []string{"x"},
+	}
+	err := validateFuzzGRPCPositionAgainstPlan(0, pos, plan)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "embedded message") || !strings.Contains(err.Error(), "supported") {
+		t.Errorf("error must name the unsupported type and list supported ones: %q", err)
+	}
+}
+
+// TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsMissingKey
+// pins the no-silent-noop rule: if the iterator targets a key the
+// source JSON doesn't carry, the AI agent must learn at validation
+// time, not by inspecting unchanged wire bytes.
+func TestValidateFuzzGRPCPositionAgainstPlan_JSONPathRejectsMissingKey(t *testing.T) {
+	t.Parallel()
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				bodyEncoding: "proto-schemaless-json",
+				jsonPayload:  `{"0001:0000:String":"hi"}`,
+			},
+		},
+	}
+	pos := fuzzGRPCPosition{
+		Path:     "messages[0].payload.0002:0001:Varint",
+		Payloads: []string{"42"},
+	}
+	err := validateFuzzGRPCPositionAgainstPlan(0, pos, plan)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not present") {
+		t.Errorf("error must signal the missing key: %q", err)
+	}
+}
+
+// TestValidateFuzzGRPCMessagePathConflicts_RejectsByteAndJSONSameMessage
+// asserts a single message cannot be addressed by both a bytes-level
+// position and a JSON-path position — the bytes form would silently
+// clobber the JSON mutation result during the commit pass.
+func TestValidateFuzzGRPCMessagePathConflicts_RejectsByteAndJSONSameMessage(t *testing.T) {
+	t.Parallel()
+	err := validateFuzzGRPCMessagePathConflicts([]fuzzGRPCPosition{
+		{Path: "messages[0].payload", Payloads: []string{"raw"}},
+		{Path: "messages[0].payload.0001:0000:String", Payloads: []string{"x"}},
+	})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot combine") {
+		t.Errorf("error must explain the conflict: %q", err)
+	}
+}
+
+// TestValidateFuzzGRPCMessagePathConflicts_AllowsBytesAndJSONOnDifferentMessages
+// pins that the conflict gate is per-message — independent N's are fine.
+func TestValidateFuzzGRPCMessagePathConflicts_AllowsBytesAndJSONOnDifferentMessages(t *testing.T) {
+	t.Parallel()
+	err := validateFuzzGRPCMessagePathConflicts([]fuzzGRPCPosition{
+		{Path: "messages[0].payload", Payloads: []string{"raw"}},
+		{Path: "messages[1].payload.0001:0000:String", Payloads: []string{"x"}},
+	})
+	if err != nil {
+		t.Errorf("expected no conflict across distinct messages: %v", err)
+	}
+}
+
+// TestEncodeFuzzGRPCJSONFieldValue_PerWireType covers the value-encoder
+// translation table — each supported wire type accepts the payload form
+// documented in help_fuzz_grpc.md.
+func TestEncodeFuzzGRPCJSONFieldValue_PerWireType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		key     string
+		payload string
+		want    string
+		errCt   string
+	}{
+		{"String_text", "0001:0000:String", "alice", `"alice"`, ""},
+		{"String_with_quotes", "0001:0000:String", `a"b`, `"a\"b"`, ""},
+		{"Varint_signed_negative", "0001:0000:Varint", "-1", `-1`, ""},
+		{"Varint_uint64_max", "0001:0000:Varint", "18446744073709551615", `18446744073709551615`, ""},
+		{"Varint_bad", "0001:0000:Varint", "not-a-number", "", "invalid integer"},
+		{"32-bit_ok", "0001:0000:32-bit", "4294967295", `4294967295`, ""},
+		{"32-bit_overflow", "0001:0000:32-bit", "4294967296", "", "invalid 32-bit"},
+		{"64-bit_signed", "0001:0000:64-bit", "-9223372036854775808", `-9223372036854775808`, ""},
+		{"bytes_ok", "0001:0000:bytes", "de:ad:be:ef", `"de:ad:be:ef"`, ""},
+		{"bytes_empty", "0001:0000:bytes", "", `""`, ""},
+		{"bytes_bad_hex", "0001:0000:bytes", "zz", "", "invalid bytes payload"},
+		{"unsupported_type", "0001:0000:repeated", "1", "", "unsupported proto wire type"},
+		{"bad_key", "bad", "x", "", "invalid proto field key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := encodeFuzzGRPCJSONFieldValue(tc.key, tc.payload)
+			if tc.errCt != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got %q", tc.errCt, got)
+				}
+				if !strings.Contains(err.Error(), tc.errCt) {
+					t.Fatalf("error %q must contain %q", err, tc.errCt)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCommitFuzzGRPCJSONMutations_RoundTrip pins the per-variant commit
+// behaviour: a mutation against a single proto field rewrites
+// plan.messages[idx].payload to the proto bytes the standalone Encode
+// would emit for the same merged JSON tree.
+func TestCommitFuzzGRPCJSONMutations_RoundTrip(t *testing.T) {
+	t.Parallel()
+	src := `{"0001:0000:String":"original","0002:0001:Varint":1}`
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				bodyEncoding: "proto-schemaless-json",
+				jsonPayload:  src,
+			},
+		},
+	}
+	muts := map[int]map[string]json.RawMessage{
+		0: {
+			"0001:0000:String": json.RawMessage(`"mutated"`),
+			"0002:0001:Varint": json.RawMessage(`42`),
+		},
+	}
+	if err := commitFuzzGRPCJSONMutations(plan, muts); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	want, err := protobuf.Encode(`{"0001:0000:String":"mutated","0002:0001:Varint":42}`)
+	if err != nil {
+		t.Fatalf("standalone Encode: %v", err)
+	}
+	if got := plan.messages[0].payload; string(got) != string(want) {
+		t.Errorf("payload diverges from standalone Encode\n got: %x\nwant: %x", got, want)
+	}
+}
+
+// TestCommitFuzzGRPCJSONMutations_NoopOnEmpty asserts the commit pass
+// is a no-op when no positions targeted any message — important so
+// non-JSON-path runs don't accidentally re-encode messages that may
+// have been base64-decoded into binary bytes the proto-schemaless
+// parser would heuristic-type into something else.
+func TestCommitFuzzGRPCJSONMutations_NoopOnEmpty(t *testing.T) {
+	t.Parallel()
+	originalBytes := []byte{0x12, 0x03, 'h', 'i'}
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				payload:      append([]byte(nil), originalBytes...),
+				bodyEncoding: "base64",
+				// jsonPayload intentionally empty
+			},
+		},
+	}
+	if err := commitFuzzGRPCJSONMutations(plan, nil); err != nil {
+		t.Fatalf("nil mutations: %v", err)
+	}
+	if string(plan.messages[0].payload) != string(originalBytes) {
+		t.Errorf("payload mutated despite empty mutations: got %x, want %x", plan.messages[0].payload, originalBytes)
+	}
+}
+
+// TestApplyFuzzGRPCPosition_JSONPathQueuesMutation pins that the
+// JSON-path branch in applyFuzzGRPCPosition does NOT mutate
+// plan.messages[idx].payload directly — it stages the mutation on the
+// jsonMuts map for the commit pass to fold in.
+func TestApplyFuzzGRPCPosition_JSONPathQueuesMutation(t *testing.T) {
+	t.Parallel()
+	originalBytes := []byte{0x0a, 0x05, 'a', 'l', 'i', 'c', 'e'}
+	plan := &resendGRPCPlan{
+		messages: []resendGRPCDataPlan{
+			{
+				payload:      append([]byte(nil), originalBytes...),
+				bodyEncoding: "proto-schemaless-json",
+				jsonPayload:  `{"0001:0000:String":"alice"}`,
+			},
+		},
+	}
+	jsonMuts := map[int]map[string]json.RawMessage{}
+	if err := applyFuzzGRPCPosition(plan, "messages[0].payload.0001:0000:String", "bob", jsonMuts); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Bytes payload is unchanged at this point — commit pass owns the
+	// rewrite.
+	if string(plan.messages[0].payload) != string(originalBytes) {
+		t.Errorf("apply mutated payload prematurely: got %x, want %x", plan.messages[0].payload, originalBytes)
+	}
+	got, ok := jsonMuts[0]["0001:0000:String"]
+	if !ok {
+		t.Fatal("apply did not stage the JSON mutation")
+	}
+	if string(got) != `"bob"` {
+		t.Errorf("queued value = %s, want %q", got, `"bob"`)
+	}
+}

--- a/internal/mcp/resend_grpc_helpers.go
+++ b/internal/mcp/resend_grpc_helpers.go
@@ -217,9 +217,18 @@ type resendGRPCPlan struct {
 }
 
 // resendGRPCDataPlan is one LPM ready for envelope construction.
+//
+// jsonPayload holds the original proto-schemaless-json source string when
+// body_encoding=="proto-schemaless-json" was used at plan resolution time;
+// empty for any other encoding. Used by fuzz_grpc (USK-925) to drive JSON-
+// path position substitution against the proto field tree without
+// round-tripping through Decode (which heuristic-types raw bytes and could
+// reshape the tree).
 type resendGRPCDataPlan struct {
-	payload    []byte
-	compressed bool
+	payload      []byte
+	compressed   bool
+	jsonPayload  string
+	bodyEncoding string
 }
 
 // buildResendGRPCPlan resolves the input into a fully-specified plan.
@@ -560,10 +569,19 @@ func (s *Server) populateResendGRPCMessages(input *resendGRPCInput, plan *resend
 		if m.Compressed && plan.encoding == "" {
 			return fmt.Errorf("messages[%d]: compressed=true requires encoding to be set (identity or gzip)", i)
 		}
-		plan.messages = append(plan.messages, resendGRPCDataPlan{
-			payload:    decoded,
-			compressed: m.Compressed,
-		})
+		entry := resendGRPCDataPlan{
+			payload:      decoded,
+			compressed:   m.Compressed,
+			bodyEncoding: m.BodyEncoding,
+		}
+		// Preserve the proto-schemaless-json source string so fuzz_grpc can
+		// mutate individual proto fields by JSON path without re-decoding
+		// the raw bytes (USK-925). Stored verbatim — re-encoding is the
+		// caller's responsibility.
+		if m.BodyEncoding == "proto-schemaless-json" {
+			entry.jsonPayload = m.Payload
+		}
+		plan.messages = append(plan.messages, entry)
 	}
 	return nil
 }

--- a/internal/mcp/resources/help_fuzz_grpc.md
+++ b/internal/mcp/resources/help_fuzz_grpc.md
@@ -14,9 +14,31 @@ The schema mirrors `resend_grpc` plus a `positions[]` list. The cartesian produc
 | `method` | `GRPCStartMessage.Method` |
 | `metadata[N].name` | `GRPCStartMessage.Metadata[N].Name` |
 | `metadata[N].value` | `GRPCStartMessage.Metadata[N].Value` |
-| `messages[N].payload` | `GRPCDataMessage.Payload` (variant N) |
+| `messages[N].payload` | `GRPCDataMessage.Payload` (variant N) — raw bytes |
+| `messages[N].payload.<FFFF:OOOO:type>` | One scalar proto field inside a `proto-schemaless-json` payload (USK-925) |
 
 `scheme` / `target_addr` / `encoding` are intentionally NOT fuzz positions — they affect connection setup and would change the dial target rather than the on-wire envelope content. Callers that need to fuzz across schemes should issue separate `fuzz_grpc` calls.
+
+### JSON-path positions (`messages[N].payload.<key>`)
+
+When the targeted message uses `body_encoding="proto-schemaless-json"`, individual proto fields can be fuzzed by appending the `FFFF:OOOO:type` key after `.payload.`. The path syntax follows the proto-schemaless surface introduced by USK-922 — `FFFF` is the protobuf field number (4-digit lowercase hex), `OOOO` is the ordinal (4-digit lowercase hex, in input-order), and `type` is the wire-type label (`String`, `Varint`, `32-bit`, `64-bit`, `bytes`). Composite types (`repeated`, `embedded message`) are not supported in v1 — they require a structurally-typed payload but the fuzz iterator supplies one string per position.
+
+Per-position payload interpretation:
+
+| Target wire type | Payload format |
+|-------------------|----------------|
+| `String` | UTF-8 text, used verbatim (JSON-string-quoted internally) |
+| `bytes` | Colon-separated hex (matches Decode emission, e.g. `de:ad:be:ef`) |
+| `Varint`, `64-bit` | Base-10 integer (signed allowed; two's-complement round-trips via uint64) |
+| `32-bit` | Base-10 integer that fits in `uint32` |
+
+Multiple JSON-path positions on the same message share a single re-encode — for variant V, all matched proto fields are mutated in the original JSON tree before `protobuf.Encode` rewrites the LPM payload.
+
+A bytes-level `messages[N].payload` position and a JSON-path `messages[N].payload.<key>` position **cannot coexist** for the same N — the bytes form would silently overwrite the JSON-mutation result. Pick one.
+
+### Re-open trigger note (USK-924)
+
+The proto-schemaless-json fuzz path makes `internal/encoding/protobuf.Encode` consume position-mutated JSON every variant. Encode now caps the embedded-message recursion depth symmetrically with Decode (`maxRecursionDepth = 64`, CWE-674); a deeply-nested JSON-path mutation surfaces the cap as `recursion depth N exceeds maximum 64` on the offending variant rather than the proxy walking the goroutine stack.
 
 ## Two operating modes
 
@@ -131,6 +153,33 @@ Variant Streams are stamped `origin = "fuzz"`, so `query { resource: "flows", fi
   ]
 }
 ```
+
+### JSON-path fuzz on a proto-schemaless-json payload (USK-925)
+```json
+{
+  "target_addr": "grpc.target.com:443",
+  "scheme": "https",
+  "service": "pkg.Greeter",
+  "method": "SayHello",
+  "messages": [
+    {
+      "payload": "{\"0001:0000:String\":\"alice\",\"0002:0001:Varint\":42}",
+      "body_encoding": "proto-schemaless-json"
+    }
+  ],
+  "positions": [
+    {
+      "path": "messages[0].payload.0001:0000:String",
+      "payloads": ["alice", "bob", "../../etc/passwd", "<script>"]
+    },
+    {
+      "path": "messages[0].payload.0002:0001:Varint",
+      "payloads": ["0", "1", "2147483647", "-1"]
+    }
+  ]
+}
+```
+Both positions target the same message — the per-variant re-encode merges both mutations into one proto wire payload.
 
 ### Two-position (method x first message payload)
 ```json


### PR DESCRIPTION
## Summary
- **USK-925** — `fuzz_grpc` accepts a new position path `messages[N].payload.<FFFF:OOOO:type>` that mutates one scalar field inside a `proto-schemaless-json` LPM payload per variant (String / Varint / 32-bit / 64-bit / bytes). Multiple JSON-path positions on the same message fold into a single Decode→mutate→Encode round-trip; same-message bytes + JSON-path positions are rejected up-front.
- **USK-924** — `internal/encoding/protobuf.Encode` now caps embedded-message recursion at `maxRecursionDepth = 64`, symmetric with `Decode` (CWE-674). USK-925 satisfies USK-924's re-open triggers (Encode now consumes per-variant fuzz-mutated JSON), so the two ship together.

## Closes
- USK-925
- USK-924

## Implementation notes
- `resendGRPCDataPlan` gains `jsonPayload` / `bodyEncoding` fields so fuzz can mutate the JSON tree without re-Decoding bytes (Decode heuristic-typing could reshape it).
- Validation rejects: non-schemaless source, unsupported wire type, missing key, bytes/JSON conflict on the same message.
- Per-variant value encoder respects each wire type (signed/unsigned ranges for ints, colon-hex for bytes, JSON-escaping for strings).
- gocyclo: validate / apply functions split into per-shape helpers to stay under the lint cap.

## Test plan
- [x] `make build` — UI build + vet + go build pass
- [x] `make test` (fast tier) — full unit suite green
- [x] `make test-e2e-smoke` (smoke tier) — merge gate green
- [x] `make lint` — gofmt / vet / staticcheck / ineffassign / gocyclo green
- [x] Targeted e2e: `TestFuzzGRPC_*` (incl. new `ProtoSchemalessJSONPathGeneratesVariants` + `RejectsByteAndJSONConflict`) green
- [x] Targeted unit: `TestEncode_RecursionDepth{Boundary,Exceeded}` + new `fuzz_grpc_proto_schemaless_test.go` table green

🤖 Generated with [Claude Code](https://claude.com/claude-code)