### PR TITLE
feat(grpc,config,mcp): grpc_schema source="file" host protoc invocation (USK-926)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           go-version: "1.25.x"
 
+      - name: Install protoc
+        # protoc is required by the USK-926 grpc_schema source="file"
+        # e2e test (internal/mcp/grpc_schema_file_source_integration_test.go).
+        # Tests that need protoc gate on exec.LookPath and t.Skip when
+        # absent, so this step is a soft requirement: without it, the
+        # file-source happy-path tests skip silently.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Build UI
         run: make build-ui
 

--- a/cmd/yorishiro-proxy/client.go
+++ b/cmd/yorishiro-proxy/client.go
@@ -411,11 +411,17 @@ Parameters (key=value):
     clear                           Remove every registered schema
 
   Register parameters (key=value with params. prefix):
-    params.source=descriptor_set    Input shape (only "descriptor_set" is supported)
+    params.source=descriptor_set    Descriptor-set source (recommended). Pair with descriptor_set_b64.
+    params.source=file              File source. Pair with proto_paths; invokes a host protoc binary.
     params.descriptor_set_b64=<b64> Base64-encoded FileDescriptorSet payload (max 16 MiB decoded).
                                     Generate via:
                                       protoc --include_imports --descriptor_set_out=<file> <protos>
                                     then base64-encode the result.
+    params.proto_paths=<abs.proto>  Absolute path to a .proto file (repeatable). Required for source=file.
+                                    Each path must be canonical and fall under the proxy CWD or one of
+                                    import_paths.
+    params.import_paths=<abs-dir>   Absolute -I root for protoc (repeatable). Defaults to the parent
+                                    directory of each proto_paths entry.
     params.service_filter=<svc>     Restrict registration to a fully-qualified service name
                                     (repeatable). Empty means register every service.
     params.source_label=<label>     Free-form label preserved in list output.
@@ -426,6 +432,7 @@ Parameters (key=value):
 Examples:
   yorishiro-proxy client grpc_schema action=list
   yorishiro-proxy client grpc_schema action=register params.source=descriptor_set params.descriptor_set_b64=<base64>
+  yorishiro-proxy client grpc_schema action=register params.source=file params.proto_paths=/srv/protos/hello.proto
   yorishiro-proxy client grpc_schema action=unregister params.service=pkg.Greeter
   yorishiro-proxy client grpc_schema action=clear
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -692,6 +692,12 @@ type ProxyConfig struct {
 	// SSE configures the SSE Layer runtime limits (max event size).
 	SSE *SSELimits `json:"sse,omitempty"`
 
+	// GRPCSchema configures the grpc_schema MCP tool's runtime knobs
+	// (USK-926). Currently only the protoc binary path is exposed; see
+	// GRPCSchemaConfig for details. Nil/omitted = defaults (protoc on
+	// PATH).
+	GRPCSchema *GRPCSchemaConfig `json:"grpc_schema,omitempty"`
+
 	// MaxBodySize is the per-message body wire cap enforced at parse time
 	// by the HTTP/1, HTTP/2 and gRPC channels — same category as
 	// WebSocket.MaxFrameSize / GRPC.MaxMessageSize / SSE.MaxEventSize.
@@ -796,6 +802,9 @@ func (c *ProxyConfig) Validate() error {
 		}
 	}
 	if err := c.validateInterceptQueue(); err != nil {
+		return err
+	}
+	if err := c.GRPCSchema.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/config/grpc_schema.go
+++ b/internal/config/grpc_schema.go
@@ -1,0 +1,94 @@
+// Package config grpc_schema.go declares the GRPCSchemaConfig nested
+// substruct (USK-926). The struct is mounted under ProxyConfig.GRPCSchema
+// and configures runtime knobs for the `grpc_schema` MCP tool's
+// host-protoc invocation path (source="file"). See
+// internal/encoding/protoschema/protoc_runner.go for the consumer.
+//
+// The "no bundled protoc" stance (USK-923 user preference) means this
+// substruct is OPTIONAL — a config that omits "grpc_schema" entirely
+// keeps the default protoc binary lookup ("protoc" on PATH) and is
+// indistinguishable from one with an empty struct.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GRPCSchemaConfig holds runtime knobs for the grpc_schema MCP tool.
+//
+// Currently a single field — ProtocBinary — but kept as a substruct so
+// future register-tool knobs (e.g. additional source modes, cache
+// settings) can land here without restructuring ProxyConfig. Mirrors
+// the WebSocket / GRPC / SSE / SafetyFilter substruct convention.
+type GRPCSchemaConfig struct {
+	// ProtocBinary is the path to (or bare name of) the protoc binary
+	// invoked when grpc_schema register is called with source="file".
+	// Empty (or omitted) selects the default "protoc" and relies on the
+	// host PATH. Validation rejects an all-whitespace value but does
+	// NOT call exec.LookPath at config load — the binary may be
+	// installed by a later step, and config validation must be
+	// hermetic (USK-926 Resolved #27).
+	ProtocBinary string `json:"protoc_binary,omitempty"`
+}
+
+// DefaultProtocBinary is the bare-name fallback when neither the env
+// var nor the config supplies a protoc path. exec.LookPath resolves
+// this against $PATH at invocation time.
+const DefaultProtocBinary = "protoc"
+
+// ProtocBinaryEnvVar is the environment variable name consulted by
+// ResolveProtocBinary. Project house style is YP_* uppercase (see
+// internal/mcpserver/server.go EnvVarMap); the Issue text's
+// "yorishiro_proxy_protoc" lowercase form is intentionally rejected.
+const ProtocBinaryEnvVar = "YP_PROTOC_BINARY"
+
+// Validate enforces the syntactic invariants on GRPCSchemaConfig. An
+// empty ProtocBinary (the "use default" case) is accepted; a value
+// that trims to empty is rejected because that indicates a config
+// authoring error (the user supplied something but it is meaningless).
+//
+// exec.LookPath is intentionally NOT called here — the binary may be
+// installed by a later step and config validation must be hermetic
+// (Resolved #27).
+func (c *GRPCSchemaConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.ProtocBinary != "" && strings.TrimSpace(c.ProtocBinary) == "" {
+		return fmt.Errorf("grpc_schema.protoc_binary must not be whitespace-only")
+	}
+	return nil
+}
+
+// ResolveProtocBinary returns the protoc binary name (or path) to
+// invoke. Precedence (Resolved #6):
+//
+//  1. YP_PROTOC_BINARY environment variable (when set and non-empty)
+//  2. ProxyConfig.GRPCSchema.ProtocBinary (when set and non-empty)
+//  3. DefaultProtocBinary ("protoc")
+//
+// os.LookupEnv is consulted at invocation time (not init time) so a
+// parent setup step that mutates PATH or the env var affects the
+// resolution as expected.
+//
+// There is intentionally NO per-MCP-call override. Allowing the
+// grpc_schema MCP tool to specify an arbitrary host binary would let
+// any MCP caller pivot the protoc subprocess into an arbitrary code-
+// execution gadget — a clear control-plane regression. Operators who
+// need a different binary set it in the config file or in the env
+// var; both of those surfaces are server-side authoritative.
+func ResolveProtocBinary(c *ProxyConfig) string {
+	if v, ok := os.LookupEnv(ProtocBinaryEnvVar); ok {
+		if v = strings.TrimSpace(v); v != "" {
+			return v
+		}
+	}
+	if c != nil && c.GRPCSchema != nil {
+		if v := strings.TrimSpace(c.GRPCSchema.ProtocBinary); v != "" {
+			return v
+		}
+	}
+	return DefaultProtocBinary
+}

--- a/internal/config/grpc_schema_test.go
+++ b/internal/config/grpc_schema_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGRPCSchemaConfig_Validate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   *GRPCSchemaConfig
+		wantErr string // substring match; "" = expect no error
+	}{
+		{"nil receiver", nil, ""},
+		{"empty struct (use default)", &GRPCSchemaConfig{}, ""},
+		{"explicit path", &GRPCSchemaConfig{ProtocBinary: "/opt/protoc/bin/protoc"}, ""},
+		{"bare name", &GRPCSchemaConfig{ProtocBinary: "protoc"}, ""},
+		{"all-whitespace rejected", &GRPCSchemaConfig{ProtocBinary: "   "}, "whitespace-only"},
+		{"tab-only rejected", &GRPCSchemaConfig{ProtocBinary: "\t"}, "whitespace-only"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.input.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveProtocBinary_Precedence(t *testing.T) {
+	// Cannot t.Parallel — sub-tests mutate the process env.
+
+	t.Run("default when nothing set", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "")
+		if got := ResolveProtocBinary(nil); got != DefaultProtocBinary {
+			t.Errorf("got %q, want %q", got, DefaultProtocBinary)
+		}
+	})
+
+	t.Run("config overrides default", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "")
+		cfg := &ProxyConfig{GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "/opt/protoc"}}
+		if got := ResolveProtocBinary(cfg); got != "/opt/protoc" {
+			t.Errorf("got %q, want /opt/protoc", got)
+		}
+	})
+
+	t.Run("env var overrides config", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "/env/protoc")
+		cfg := &ProxyConfig{GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "/opt/protoc"}}
+		if got := ResolveProtocBinary(cfg); got != "/env/protoc" {
+			t.Errorf("got %q, want /env/protoc", got)
+		}
+	})
+
+	t.Run("empty env var falls through to config", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "")
+		cfg := &ProxyConfig{GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "/opt/protoc"}}
+		if got := ResolveProtocBinary(cfg); got != "/opt/protoc" {
+			t.Errorf("got %q, want /opt/protoc", got)
+		}
+	})
+
+	t.Run("whitespace env var falls through to config", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "   ")
+		cfg := &ProxyConfig{GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "/opt/protoc"}}
+		if got := ResolveProtocBinary(cfg); got != "/opt/protoc" {
+			t.Errorf("got %q, want /opt/protoc", got)
+		}
+	})
+
+	t.Run("whitespace config falls through to default", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "")
+		cfg := &ProxyConfig{GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "  "}}
+		if got := ResolveProtocBinary(cfg); got != DefaultProtocBinary {
+			t.Errorf("got %q, want %q", got, DefaultProtocBinary)
+		}
+	})
+
+	t.Run("nil GRPCSchema substruct uses default", func(t *testing.T) {
+		t.Setenv(ProtocBinaryEnvVar, "")
+		cfg := &ProxyConfig{}
+		if got := ResolveProtocBinary(cfg); got != DefaultProtocBinary {
+			t.Errorf("got %q, want %q", got, DefaultProtocBinary)
+		}
+	})
+}
+
+func TestProxyConfig_Validate_GRPCSchema(t *testing.T) {
+	t.Parallel()
+	c := &ProxyConfig{
+		GRPCSchema: &GRPCSchemaConfig{ProtocBinary: "\t"},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "whitespace-only") {
+		t.Fatalf("want whitespace-only error, got %v", err)
+	}
+}

--- a/internal/encoding/protoschema/protoc_runner.go
+++ b/internal/encoding/protoschema/protoc_runner.go
@@ -1,0 +1,392 @@
+// Package protoschema protoc_runner.go invokes a host protoc binary to
+// compile a list of .proto files into a FileDescriptorSet payload that
+// the existing LoadFileDescriptorSet path can consume (USK-926).
+//
+// This is the runner side of the grpc_schema MCP tool's source="file"
+// path. Lives in the protoschema package so internal/mcp/ stays free of
+// os/exec. The MCP handler (handleGRPCSchemaRegister) calls
+// RunProtoc(ctx, opts) and feeds the returned bytes into
+// LoadFileDescriptorSet + SaveGRPCSchema → Registry.Register — i.e. the
+// runner is a strict adaptor and the persistence semantics are byte-
+// identical to source="descriptor_set" (Resolved #18).
+//
+// Security stance — every concern is enumerated below so a reader can
+// audit the surface in one read (Resolved decisions 7–17):
+//
+//   - Inputs are server-side. The MCP handler enforces that proto_paths
+//     and import_paths are absolute, NUL-free, and that filepath.Clean
+//     preserves the value (no "..", no double-slashes).
+//   - filepath.EvalSymlinks is applied AFTER the basic checks, so a
+//     value that fails validation cannot trigger a stat on an attacker-
+//     controlled location.
+//   - The resolved paths must fall under at least one allowed root
+//     (server CWD or a user-supplied import_paths entry). Without this
+//     check, an MCP caller could enumerate file existence anywhere on
+//     the host (Resolved #28 reality check).
+//   - The protoc subprocess inherits ONLY PATH from the parent
+//     environment; nothing else is propagated (Resolved #12).
+//   - cmd.Dir is the per-call temp dir (Resolved #13).
+//   - The 30-second timeout is hardcoded; the temp dir is removed in a
+//     defer (Resolved #11, #15).
+//   - Combined stdout+stderr is truncated to 4 KiB when included in
+//     errors (Resolved #14).
+package protoschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ProtocTimeout is the maximum wall-clock time a single protoc
+// invocation is allowed to consume before the runner cancels it. 30s
+// covers cold-cache reads of large proto trees on slow CI runners while
+// remaining tight enough that an MCP caller does not block the server
+// indefinitely (Resolved #11).
+const ProtocTimeout = 30 * time.Second
+
+// protocStderrLimit is the byte cap applied to the captured combined
+// stdout+stderr buffer when included in an error string. 4 KiB matches
+// the design-review decision (Resolved #14): enough to surface the
+// "file not found" / "syntax error at line N" message family without
+// letting a misbehaving protoc fill the MCP response with megabytes
+// of noise.
+const protocStderrLimit = 4 * 1024
+
+// ProtocRunOptions is the per-invocation input to RunProtoc. Every
+// field is server-side enumerated by the MCP handler; the runner
+// itself does NOT consult untrusted state.
+type ProtocRunOptions struct {
+	// Binary is the protoc executable to invoke. Either a bare name
+	// resolved via $PATH (e.g. "protoc") or an absolute path. The
+	// caller is expected to have run config.ResolveProtocBinary first.
+	Binary string
+
+	// ProtoPaths is the list of .proto files to compile. All entries
+	// must be absolute, syntactically clean (filepath.Clean preserves
+	// the value) and free of NUL bytes; the runner re-validates these
+	// defensively before exec. The values are exec'd literally as
+	// trailing positional arguments to protoc.
+	ProtoPaths []string
+
+	// ImportPaths is the list of `-I` roots. May be empty — in that
+	// case the runner derives a single import root from the directory
+	// of the first proto path. All entries follow the same validation
+	// rules as ProtoPaths.
+	ImportPaths []string
+
+	// AllowedRoots is the set of directories under which any resolved
+	// (post-EvalSymlinks) proto/import path must fall. The runner
+	// rejects an input that escapes every entry in this set. Typically
+	// the MCP handler supplies {server CWD, all user-supplied import
+	// paths} and falls back to {server CWD, each filepath.Dir of the
+	// proto paths} when import_paths is empty.
+	AllowedRoots []string
+}
+
+// ProtocResult is the structured output of RunProtoc.
+type ProtocResult struct {
+	// DescriptorSet is the raw bytes of the generated
+	// FileDescriptorSet, ready to feed into LoadFileDescriptorSet. The
+	// length is bounded by MaxDescriptorSetBytes (RunProtoc rejects a
+	// larger output rather than passing it on).
+	DescriptorSet []byte
+
+	// DurationMS is the protoc subprocess wall-clock time, useful for
+	// diagnostic logging.
+	DurationMS int64
+}
+
+// errProtocNotFound is the sentinel returned when exec.LookPath fails
+// for the configured Binary. Callers (MCP handler) may unwrap with
+// errors.Is to surface an install hint without string-matching the
+// message text.
+var errProtocNotFound = errors.New("protoc binary not found")
+
+// ErrProtocNotFound returns the sentinel for "protoc binary missing
+// from PATH". Wrap-safe with errors.Is so callers can branch without
+// inspecting the wrapped message.
+func ErrProtocNotFound() error { return errProtocNotFound }
+
+// RunProtoc invokes the configured protoc binary on the given proto
+// paths and returns the resulting FileDescriptorSet bytes.
+//
+// The implementation is the strict design-review prescription (USK-926
+// Resolved #11–#17):
+//
+//  1. exec.LookPath on opts.Binary; missing → wrapped errProtocNotFound.
+//  2. Per-call temp dir via os.MkdirTemp; defer-removed.
+//  3. context.WithTimeout(ProtocTimeout) derived from ctx.
+//  4. cmd.Env = {PATH only}; cmd.Dir = temp dir.
+//  5. argv = [-I<root1> -I<root2> ... --include_imports --descriptor_set_out=<tmp>/out.desc <protos...>].
+//  6. CombinedOutput; on non-zero exit, include the captured output
+//     truncated to 4 KiB in the wrapped error.
+//  7. Read the .desc file. Reject if length > MaxDescriptorSetBytes
+//     before calling LoadFileDescriptorSet (defensive double-check —
+//     LoadFileDescriptorSet also checks).
+//
+// Returns a ProtocResult on success or a wrapped error otherwise. The
+// caller is responsible for passing DescriptorSet to
+// LoadFileDescriptorSet.
+func RunProtoc(ctx context.Context, opts ProtocRunOptions) (*ProtocResult, error) {
+	if err := validateRunOptions(opts); err != nil {
+		return nil, err
+	}
+
+	binPath, err := exec.LookPath(opts.Binary)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %q in PATH: install protoc and ensure it is on PATH, or set GRPCSchema.ProtocBinary in the config file (or YP_PROTOC_BINARY env var)", errProtocNotFound, opts.Binary)
+	}
+
+	resolvedProtos, err := resolveAndCheckPaths(opts.ProtoPaths, opts.AllowedRoots, "proto_paths")
+	if err != nil {
+		return nil, err
+	}
+	importRoots := opts.ImportPaths
+	if len(importRoots) == 0 {
+		importRoots = deriveImportRoots(opts.ProtoPaths)
+	}
+	resolvedImports, err := resolveAndCheckPaths(importRoots, opts.AllowedRoots, "import_paths")
+	if err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "yorishiro-proxy-protoc-*")
+	if err != nil {
+		return nil, fmt.Errorf("create protoc temp dir: %w", err)
+	}
+	defer func() {
+		if rerr := os.RemoveAll(tmpDir); rerr != nil {
+			slog.Warn("failed to remove protoc temp dir", "dir", tmpDir, "err", rerr)
+		}
+	}()
+
+	descPath := filepath.Join(tmpDir, "out.desc")
+	args := buildProtocArgs(resolvedImports, descPath, resolvedProtos)
+
+	runCtx, cancel := context.WithTimeout(ctx, ProtocTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, binPath, args...)
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	cmd.Dir = tmpDir
+
+	slog.DebugContext(ctx, "protoc invocation",
+		"binary", binPath,
+		"proto_count", len(resolvedProtos),
+		"import_root_count", len(resolvedImports),
+		"tmp_dir", tmpDir,
+	)
+
+	start := time.Now()
+	combined, runErr := cmd.CombinedOutput()
+	durMS := time.Since(start).Milliseconds()
+
+	if runErr != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("protoc timed out after %s: %s", ProtocTimeout, truncateForError(combined))
+		}
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			return nil, fmt.Errorf("protoc failed (exit %d): %s", exitErr.ExitCode(), truncateForError(combined))
+		}
+		return nil, fmt.Errorf("protoc failed: %w: %s", runErr, truncateForError(combined))
+	}
+
+	// Stat first so we can reject an oversized output before reading it
+	// into memory. LoadFileDescriptorSet also enforces the cap, but
+	// applying it pre-read bounds the worst-case allocation when a
+	// future protoc bug or misuse produces a multi-GiB descriptor.
+	fi, err := os.Stat(descPath)
+	if err != nil {
+		return nil, fmt.Errorf("read protoc output: %w: %s", err, truncateForError(combined))
+	}
+	if fi.Size() > MaxDescriptorSetBytes {
+		return nil, fmt.Errorf("protoc output size %d exceeds maximum %d bytes", fi.Size(), MaxDescriptorSetBytes)
+	}
+
+	raw, err := os.ReadFile(descPath)
+	if err != nil {
+		return nil, fmt.Errorf("read protoc output %s: %w", descPath, err)
+	}
+
+	slog.DebugContext(ctx, "protoc invocation complete",
+		"duration_ms", durMS,
+		"descriptor_bytes", len(raw),
+	)
+
+	return &ProtocResult{
+		DescriptorSet: raw,
+		DurationMS:    durMS,
+	}, nil
+}
+
+// validateRunOptions runs syntactic checks on the options before any
+// filesystem or exec call. Mirrors the MCP handler validation so the
+// runner is safe to call directly from tests with a fresh struct.
+func validateRunOptions(opts ProtocRunOptions) error {
+	if strings.TrimSpace(opts.Binary) == "" {
+		return errors.New("protoc binary is empty")
+	}
+	if len(opts.ProtoPaths) == 0 {
+		return errors.New("proto_paths is empty")
+	}
+	if err := validatePathList(opts.ProtoPaths, "proto_paths"); err != nil {
+		return err
+	}
+	if err := validatePathList(opts.ImportPaths, "import_paths"); err != nil {
+		return err
+	}
+	if err := validatePathList(opts.AllowedRoots, "allowed_roots"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validatePathList enforces the Resolved #7 basics on every path in
+// the list: absolute, NUL-free, syntactically clean. The check is
+// done BEFORE EvalSymlinks so a malformed path cannot trigger a stat
+// on attacker-controlled territory.
+func validatePathList(paths []string, label string) error {
+	for i, p := range paths {
+		if p == "" {
+			return fmt.Errorf("%s[%d]: empty path", label, i)
+		}
+		if strings.IndexByte(p, 0) >= 0 {
+			return fmt.Errorf("%s[%d]: contains NUL byte", label, i)
+		}
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("%s[%d]: %q is not an absolute path", label, i, p)
+		}
+		if cleaned := filepath.Clean(p); cleaned != p {
+			return fmt.Errorf("%s[%d]: %q is not in canonical form (use %q)", label, i, p, cleaned)
+		}
+	}
+	return nil
+}
+
+// resolveAndCheckPaths applies filepath.EvalSymlinks to each input and
+// confirms the result falls under at least one allowed root
+// (Resolved #8, #9). The resolved paths are returned so the caller
+// can feed them to protoc verbatim — using the symlink-resolved value
+// avoids surprises where protoc itself resolves the link to a path
+// outside the allowed roots.
+func resolveAndCheckPaths(paths []string, allowedRoots []string, label string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	resolvedRoots, err := resolveAllowedRoots(allowedRoots)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(paths))
+	for i, p := range paths {
+		resolved, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			return nil, fmt.Errorf("%s[%d]: resolve %q: %w", label, i, p, err)
+		}
+		if !pathUnderAnyRoot(resolved, resolvedRoots) {
+			return nil, fmt.Errorf("%s[%d]: %q (resolved %q) is not under any allowed root %v", label, i, p, resolved, allowedRoots)
+		}
+		out = append(out, resolved)
+	}
+	return out, nil
+}
+
+// resolveAllowedRoots applies EvalSymlinks to each allowed root once
+// so the per-path comparison can use a string-prefix check on
+// canonicalised paths. Missing roots are skipped (a stale entry in
+// the config should not poison the entire registration).
+func resolveAllowedRoots(roots []string) ([]string, error) {
+	out := make([]string, 0, len(roots))
+	for _, r := range roots {
+		resolved, err := filepath.EvalSymlinks(r)
+		if err != nil {
+			// A missing allowed root is non-fatal — the remaining
+			// roots can still cover the inputs. We do NOT fold the
+			// error in: stale config entries are common (e.g. a CI
+			// runner without the operator's home dir).
+			continue
+		}
+		out = append(out, resolved)
+	}
+	return out, nil
+}
+
+// pathUnderAnyRoot returns true when p is identical to a root or sits
+// beneath it. The comparison uses filepath.Rel to avoid the classic
+// strings.HasPrefix("foo-bar", "foo") bug where a sibling directory
+// shares a prefix with an allowed root.
+func pathUnderAnyRoot(p string, roots []string) bool {
+	for _, r := range roots {
+		rel, err := filepath.Rel(r, p)
+		if err != nil {
+			continue
+		}
+		// A rel that escapes the root starts with ".." (or, on
+		// Windows, is an absolute path back to a different volume).
+		if rel == "." || (!strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveImportRoots returns one -I root per unique filepath.Dir of the
+// proto paths. Used when the MCP caller did not supply explicit
+// import_paths. The returned slice preserves the discovery order so
+// protoc's lookup is deterministic.
+func deriveImportRoots(protoPaths []string) []string {
+	seen := make(map[string]struct{}, len(protoPaths))
+	out := make([]string, 0, len(protoPaths))
+	for _, p := range protoPaths {
+		dir := filepath.Dir(p)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+	return out
+}
+
+// buildProtocArgs assembles the argv list for the protoc subprocess.
+// The order matches protoc's documented expectations:
+//
+//	-I<root>... --include_imports --descriptor_set_out=<file> <protos...>
+//
+// We always pass --include_imports so transitive imports are folded
+// into the output. Without it, a downstream LoadFileDescriptorSet
+// would reject the result for missing dependencies — defeating the
+// purpose of source="file".
+func buildProtocArgs(importRoots []string, descOut string, protoPaths []string) []string {
+	args := make([]string, 0, len(importRoots)+2+len(protoPaths))
+	for _, r := range importRoots {
+		args = append(args, "-I"+r)
+	}
+	args = append(args, "--include_imports")
+	args = append(args, "--descriptor_set_out="+descOut)
+	args = append(args, protoPaths...)
+	return args
+}
+
+// truncateForError clips long stdout+stderr captures so they do not
+// dominate an MCP error message. UTF-8-safe in the sense that a
+// truncated byte sequence is the worst case the caller already sees
+// from protoc itself (which may emit any byte sequence on parse
+// errors).
+func truncateForError(b []byte) string {
+	if len(b) == 0 {
+		return "(no output)"
+	}
+	if len(b) <= protocStderrLimit {
+		return string(b)
+	}
+	return string(b[:protocStderrLimit]) + "... (truncated)"
+}

--- a/internal/encoding/protoschema/protoc_runner_test.go
+++ b/internal/encoding/protoschema/protoc_runner_test.go
@@ -1,0 +1,381 @@
+package protoschema
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidateRunOptions covers the syntactic validation that runs
+// before any filesystem call. These tests do NOT require protoc.
+func TestValidateRunOptions(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	proto := filepath.Join(tmp, "x.proto")
+	if err := os.WriteFile(proto, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		opts    ProtocRunOptions
+		wantErr string
+	}{
+		{
+			name: "empty binary rejected",
+			opts: ProtocRunOptions{
+				Binary:     "",
+				ProtoPaths: []string{proto},
+			},
+			wantErr: "protoc binary is empty",
+		},
+		{
+			name: "whitespace binary rejected",
+			opts: ProtocRunOptions{
+				Binary:     "  ",
+				ProtoPaths: []string{proto},
+			},
+			wantErr: "protoc binary is empty",
+		},
+		{
+			name: "empty proto_paths rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: nil,
+			},
+			wantErr: "proto_paths is empty",
+		},
+		{
+			name: "empty entry rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{""},
+			},
+			wantErr: "empty path",
+		},
+		{
+			name: "NUL byte rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{"/abs/path\x00null"},
+			},
+			wantErr: "contains NUL byte",
+		},
+		{
+			name: "relative path rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{"./relative.proto"},
+			},
+			wantErr: "not an absolute path",
+		},
+		{
+			name: "non-canonical path rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{"/abs/../traversal.proto"},
+			},
+			wantErr: "not in canonical form",
+		},
+		{
+			name: "trailing-slash non-canonical rejected",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{"/abs/dir//x.proto"},
+			},
+			wantErr: "not in canonical form",
+		},
+		{
+			name: "valid options pass syntactic check",
+			opts: ProtocRunOptions{
+				Binary:     "protoc",
+				ProtoPaths: []string{proto},
+			},
+			wantErr: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateRunOptions(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestPathUnderAnyRoot(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path  string
+		roots []string
+		want  bool
+	}{
+		{"/srv/protos/x.proto", []string{"/srv/protos"}, true},
+		{"/srv/protos", []string{"/srv/protos"}, true},
+		{"/srv/protos/nested/y.proto", []string{"/srv/protos"}, true},
+		// Prefix-only false-positive guard: "/srv/protos-other" is NOT
+		// under "/srv/protos" even though strings.HasPrefix would say
+		// so.
+		{"/srv/protos-other/x.proto", []string{"/srv/protos"}, false},
+		{"/etc/passwd", []string{"/srv/protos"}, false},
+		// Multiple roots — second root matches.
+		{"/home/me/protos/x.proto", []string{"/srv/protos", "/home/me"}, true},
+		// No roots = no match.
+		{"/srv/protos/x.proto", nil, false},
+	}
+	for _, tc := range cases {
+		if got := pathUnderAnyRoot(tc.path, tc.roots); got != tc.want {
+			t.Errorf("pathUnderAnyRoot(%q, %v) = %v, want %v", tc.path, tc.roots, got, tc.want)
+		}
+	}
+}
+
+func TestDeriveImportRoots(t *testing.T) {
+	t.Parallel()
+	in := []string{
+		"/srv/a/x.proto",
+		"/srv/a/y.proto", // dedup against /srv/a
+		"/srv/b/z.proto",
+	}
+	got := deriveImportRoots(in)
+	want := []string{"/srv/a", "/srv/b"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildProtocArgs(t *testing.T) {
+	t.Parallel()
+	args := buildProtocArgs(
+		[]string{"/srv/a", "/srv/b"},
+		"/tmp/out.desc",
+		[]string{"/srv/a/x.proto"},
+	)
+	want := []string{
+		"-I/srv/a",
+		"-I/srv/b",
+		"--include_imports",
+		"--descriptor_set_out=/tmp/out.desc",
+		"/srv/a/x.proto",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("got %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestTruncateForError(t *testing.T) {
+	t.Parallel()
+	if got := truncateForError(nil); got != "(no output)" {
+		t.Errorf("empty: got %q, want (no output)", got)
+	}
+	short := []byte("short message")
+	if got := truncateForError(short); got != "short message" {
+		t.Errorf("short: got %q", got)
+	}
+	long := make([]byte, protocStderrLimit*2)
+	for i := range long {
+		long[i] = 'A'
+	}
+	got := truncateForError(long)
+	if !strings.HasSuffix(got, "... (truncated)") {
+		t.Errorf("long must end with truncation marker: %q", got[len(got)-20:])
+	}
+	if len(got) > protocStderrLimit+len("... (truncated)") {
+		t.Errorf("truncated length %d exceeds cap", len(got))
+	}
+}
+
+// TestResolveAndCheckPaths_AllowedRoots verifies that a path resolved
+// via EvalSymlinks is rejected when it escapes the allowed roots.
+// Uses t.TempDir; no protoc required.
+func TestResolveAndCheckPaths_AllowedRoots(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	allowed := filepath.Join(tmp, "allowed")
+	denied := filepath.Join(tmp, "denied")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(denied, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	goodProto := filepath.Join(allowed, "ok.proto")
+	if err := os.WriteFile(goodProto, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	badProto := filepath.Join(denied, "leak.proto")
+	if err := os.WriteFile(badProto, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Happy path — under allowed root.
+	got, err := resolveAndCheckPaths([]string{goodProto}, []string{allowed}, "proto_paths")
+	if err != nil {
+		t.Fatalf("good path rejected: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("resolved = %v", got)
+	}
+
+	// Escape path — under denied root.
+	if _, err := resolveAndCheckPaths([]string{badProto}, []string{allowed}, "proto_paths"); err == nil {
+		t.Fatal("escape path was not rejected")
+	} else if !strings.Contains(err.Error(), "not under any allowed root") {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+// TestResolveAndCheckPaths_Symlinks confirms EvalSymlinks resolution
+// is applied: a symlink that points outside the allowed root is
+// rejected, even if the link itself lives under the root.
+func TestResolveAndCheckPaths_Symlinks(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	allowed := filepath.Join(tmp, "allowed")
+	denied := filepath.Join(tmp, "denied")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(denied, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(denied, "secret.proto")
+	if err := os.WriteFile(target, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(allowed, "ok-looking.proto")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	_, err := resolveAndCheckPaths([]string{link}, []string{allowed}, "proto_paths")
+	if err == nil {
+		t.Fatal("symlink to outside-allowed target was not rejected")
+	}
+	if !strings.Contains(err.Error(), "not under any allowed root") {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+// TestRunProtoc_BinaryMissing exercises the protoc-not-found branch
+// without requiring protoc on the host. The binary name uses a clearly
+// nonsensical value so any future install does not flake this test.
+func TestRunProtoc_BinaryMissing(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	proto := filepath.Join(tmp, "x.proto")
+	if err := os.WriteFile(proto, []byte("syntax = \"proto3\";"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ProtocRunOptions{
+		Binary:       "yorishiro-no-such-protoc-binary-USK-926",
+		ProtoPaths:   []string{proto},
+		AllowedRoots: []string{tmp},
+	}
+	_, err := RunProtoc(context.Background(), opts)
+	if err == nil {
+		t.Fatal("missing binary was not rejected")
+	}
+	if !errors.Is(err, ErrProtocNotFound()) {
+		t.Errorf("err is not ErrProtocNotFound: %v", err)
+	}
+	if !strings.Contains(err.Error(), "YP_PROTOC_BINARY") {
+		t.Errorf("missing env-var hint in error: %q", err)
+	}
+}
+
+// TestRunProtoc_Success exercises the happy path using a real protoc
+// binary. Skipped when protoc is not on PATH (Resolved #20).
+func TestRunProtoc_Success(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	tmp := t.TempDir()
+	proto := filepath.Join(tmp, "hello.proto")
+	const src = `syntax = "proto3";
+package usk.test.runner;
+service Hello {
+  rpc Say (Req) returns (Resp);
+}
+message Req { string name = 1; }
+message Resp { string greeting = 1; }
+`
+	if err := os.WriteFile(proto, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ProtocRunOptions{
+		Binary:       "protoc",
+		ProtoPaths:   []string{proto},
+		AllowedRoots: []string{tmp},
+	}
+	res, err := RunProtoc(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("RunProtoc: %v", err)
+	}
+	if len(res.DescriptorSet) == 0 {
+		t.Fatal("DescriptorSet is empty")
+	}
+	specs, err := LoadFileDescriptorSet(res.DescriptorSet, nil)
+	if err != nil {
+		t.Fatalf("LoadFileDescriptorSet: %v", err)
+	}
+	if len(specs) != 1 || specs[0].Service != "usk.test.runner.Hello" {
+		t.Errorf("specs = %+v", specs)
+	}
+}
+
+// TestRunProtoc_ProtoSyntaxError_NonZeroExit confirms that a malformed
+// .proto surfaces protoc's stderr in the returned error.
+func TestRunProtoc_ProtoSyntaxError_NonZeroExit(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	tmp := t.TempDir()
+	bad := filepath.Join(tmp, "bad.proto")
+	if err := os.WriteFile(bad, []byte("not actually a proto"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ProtocRunOptions{
+		Binary:       "protoc",
+		ProtoPaths:   []string{bad},
+		AllowedRoots: []string{tmp},
+	}
+	_, err := RunProtoc(context.Background(), opts)
+	if err == nil {
+		t.Fatal("malformed proto was accepted")
+	}
+	if !strings.Contains(err.Error(), "protoc failed") {
+		t.Errorf("err is not a protoc-failed wrap: %v", err)
+	}
+}

--- a/internal/mcp/grpc_schema_file_source_integration_test.go
+++ b/internal/mcp/grpc_schema_file_source_integration_test.go
@@ -1,0 +1,209 @@
+//go:build e2e && !e2e_smoke
+
+// Package mcp grpc_schema_file_source_integration_test.go is the
+// USK-926 e2e test for the source="file" path: a temp directory holds
+// a .proto file, the proxy invokes the host protoc binary to compile
+// it, and the resulting schema lands in the Registry via the MCP
+// transport.
+//
+// Lives in the exhaustive e2e tier (`//go:build e2e && !e2e_smoke`)
+// because the host-protoc dependency is unsuitable for the per-PR
+// smoke gate. Skipped when protoc is not on PATH (Resolved #20).
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helloProtoFixture is a minimal proto used by every file-source test
+// here. Single service, single method, two scalar message fields.
+const helloProtoFixture = `syntax = "proto3";
+
+package usk.test.file;
+
+service Hello {
+  rpc Say (Req) returns (Resp);
+}
+
+message Req {
+  string name = 1;
+}
+
+message Resp {
+  string greeting = 1;
+}
+`
+
+// writeHelloProto writes the fixture to a per-test temp dir and
+// returns the absolute path. The dir doubles as the import root.
+func writeHelloProto(t *testing.T) (dir, proto string) {
+	t.Helper()
+	dir = t.TempDir()
+	proto = filepath.Join(dir, "hello.proto")
+	if err := os.WriteFile(proto, []byte(helloProtoFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return dir, proto
+}
+
+func TestGRPCSchema_Register_FileSource_HappyPath(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	dir, proto := writeHelloProto(t)
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":       "file",
+			"proto_paths":  []any{proto},
+			"import_paths": []any{dir},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("register file source: %v", result.Content)
+	}
+	var out grpcSchemaRegisterResult
+	unmarshalExecuteResult(t, result, &out)
+	if len(out.Registered) != 1 {
+		t.Fatalf("Registered len = %d, want 1", len(out.Registered))
+	}
+	if out.Registered[0].Service != "usk.test.file.Hello" {
+		t.Errorf("Service = %q, want usk.test.file.Hello", out.Registered[0].Service)
+	}
+	if len(out.Registered[0].Methods) != 1 || out.Registered[0].Methods[0].Name != "Say" {
+		t.Errorf("Methods = %+v", out.Registered[0].Methods)
+	}
+	// SourceLabel defaults to basename when not supplied (Resolved #19).
+	if out.Registered[0].SourceLabel != "hello.proto" {
+		t.Errorf("SourceLabel = %q, want hello.proto", out.Registered[0].SourceLabel)
+	}
+
+	// list confirms persistence — rehydrate from store is identical to descriptor_set mode.
+	listResult := callGRPCSchema(t, cs, map[string]any{"action": "list"})
+	var listOut grpcSchemaListResult
+	unmarshalExecuteResult(t, listResult, &listOut)
+	if len(listOut.Schemas) != 1 || listOut.Schemas[0].Service != "usk.test.file.Hello" {
+		t.Errorf("list after file register: %+v", listOut.Schemas)
+	}
+}
+
+func TestGRPCSchema_Register_FileSource_DefaultImportPaths(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	_, proto := writeHelloProto(t)
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	// Omit import_paths — the runner should derive filepath.Dir(proto).
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":      "file",
+			"proto_paths": []any{proto},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("register with default import_paths: %v", result.Content)
+	}
+}
+
+func TestGRPCSchema_Register_FileSource_ServiceFilter(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	dir, proto := writeHelloProto(t)
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":         "file",
+			"proto_paths":    []any{proto},
+			"import_paths":   []any{dir},
+			"service_filter": []any{"usk.test.file.Hello"},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("register file source with filter: %v", result.Content)
+	}
+	var out grpcSchemaRegisterResult
+	unmarshalExecuteResult(t, result, &out)
+	if len(out.Registered) != 1 {
+		t.Fatalf("Registered len = %d, want 1", len(out.Registered))
+	}
+}
+
+func TestGRPCSchema_Register_FileSource_NonAbsolutePath_Rejected(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	// No need for protoc: the relative-path check fires before exec.
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":      "file",
+			"proto_paths": []any{"relative/hello.proto"},
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for relative proto path")
+	}
+}
+
+func TestGRPCSchema_Register_FileSource_OutsideAllowedRoot_Rejected(t *testing.T) {
+	// No t.Parallel — this test mutates the package-level osGetwd
+	// indirection (and other parallel tests in this file dispatch
+	// through buildAllowedRoots, which reads it). Keeping the test
+	// serial is simpler than introducing a sync primitive around
+	// osGetwd just for the test surface.
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not on PATH: skipping host-invocation test (USK-926)")
+	}
+	// Two separate temp dirs: proto lives in `protoDir`, the only
+	// allowed import root is `allowedDir`. The runner must reject the
+	// proto path because it escapes the explicit import_paths set.
+	protoDir := t.TempDir()
+	allowedDir := t.TempDir()
+	proto := filepath.Join(protoDir, "leaked.proto")
+	if err := os.WriteFile(proto, []byte(helloProtoFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	// Pin osGetwd somewhere that does NOT contain the proto, so the
+	// proto path can only be reached through explicit import_paths.
+	hermeticCwd := t.TempDir()
+	prev := osGetwd
+	t.Cleanup(func() { osGetwd = prev })
+	osGetwd = func() (string, error) { return hermeticCwd, nil }
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":       "file",
+			"proto_paths":  []any{proto},
+			"import_paths": []any{allowedDir},
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for proto outside allowed roots")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "not under any allowed root") {
+		t.Errorf("error must mention allowed root: %q", msg)
+	}
+}

--- a/internal/mcp/grpc_schema_file_source_unit_test.go
+++ b/internal/mcp/grpc_schema_file_source_unit_test.go
@@ -1,0 +1,192 @@
+// Package mcp grpc_schema_file_source_unit_test.go covers the
+// USK-926 file-source validation table and the deriveFileSourceLabel /
+// buildAllowedRoots helpers. The actual host-protoc invocation is
+// exercised in the e2e tier (grpc_schema_file_source_integration_test.go).
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateGRPCSchemaRegisterInput_FileSourceMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		params  grpcSchemaToolParams
+		wantErr string // substring; "" = no error
+	}{
+		{
+			name:    "empty source + descriptor_set_b64 set (USK-923 back-compat)",
+			params:  grpcSchemaToolParams{DescriptorSetB64: "Cg=="},
+			wantErr: "",
+		},
+		{
+			name:    "empty source + proto_paths rejected",
+			params:  grpcSchemaToolParams{ProtoPaths: []string{"/abs/x.proto"}},
+			wantErr: "source=\"file\" must be set explicitly",
+		},
+		{
+			name:    "empty source + import_paths rejected",
+			params:  grpcSchemaToolParams{ImportPaths: []string{"/abs"}, DescriptorSetB64: "Cg=="},
+			wantErr: "import_paths is only valid with source=\"file\"",
+		},
+		{
+			name:    "descriptor_set + proto_paths rejected",
+			params:  grpcSchemaToolParams{Source: "descriptor_set", DescriptorSetB64: "Cg==", ProtoPaths: []string{"/abs/x.proto"}},
+			wantErr: "proto_paths is only valid",
+		},
+		{
+			name:    "descriptor_set + missing descriptor_set_b64 rejected",
+			params:  grpcSchemaToolParams{Source: "descriptor_set"},
+			wantErr: "descriptor_set_b64 is required",
+		},
+		{
+			name:    "descriptor_set + import_paths rejected",
+			params:  grpcSchemaToolParams{Source: "descriptor_set", DescriptorSetB64: "Cg==", ImportPaths: []string{"/abs"}},
+			wantErr: "import_paths is only valid",
+		},
+		{
+			name:    "file + proto_paths set (happy path)",
+			params:  grpcSchemaToolParams{Source: "file", ProtoPaths: []string{"/abs/x.proto"}},
+			wantErr: "",
+		},
+		{
+			name:    "file + empty proto_paths rejected",
+			params:  grpcSchemaToolParams{Source: "file"},
+			wantErr: "proto_paths is required",
+		},
+		{
+			name:    "file + descriptor_set_b64 rejected",
+			params:  grpcSchemaToolParams{Source: "file", ProtoPaths: []string{"/abs/x.proto"}, DescriptorSetB64: "Cg=="},
+			wantErr: "descriptor_set_b64 is only valid",
+		},
+		{
+			name:    "unknown source rejected",
+			params:  grpcSchemaToolParams{Source: "reflection"},
+			wantErr: "is not supported",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateGRPCSchemaRegisterInput(tc.params)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeriveFileSourceLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"/srv/protos/greeter.proto"}, "greeter.proto"},
+		{"multiple", []string{"/srv/a/x.proto", "/srv/b/y.proto"}, "x.proto,y.proto"},
+	}
+	for _, tc := range cases {
+		if got := deriveFileSourceLabel(tc.in); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestBuildAllowedRoots(t *testing.T) {
+	// No t.Parallel — this test mutates the package-level osGetwd
+	// indirection and would race against other tests that also call
+	// buildAllowedRoots (e.g. the e2e file-source integration tests).
+	tmp := t.TempDir()
+	prev := osGetwd
+	t.Cleanup(func() { osGetwd = prev })
+	osGetwd = func() (string, error) { return tmp, nil }
+
+	t.Run("only proto_paths -> cwd + dirs", func(t *testing.T) {
+		params := grpcSchemaToolParams{
+			Source:     "file",
+			ProtoPaths: []string{"/srv/a/x.proto", "/srv/b/y.proto"},
+		}
+		got, err := buildAllowedRoots(params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{tmp, "/srv/a", "/srv/b"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("[%d] %q want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("explicit import_paths replace derivation", func(t *testing.T) {
+		params := grpcSchemaToolParams{
+			Source:      "file",
+			ProtoPaths:  []string{"/srv/a/x.proto"},
+			ImportPaths: []string{"/srv/imports"},
+		}
+		got, err := buildAllowedRoots(params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{tmp, "/srv/imports"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("duplicate cwd not added twice", func(t *testing.T) {
+		params := grpcSchemaToolParams{
+			Source:      "file",
+			ProtoPaths:  []string{filepath.Join(tmp, "x.proto")},
+			ImportPaths: []string{tmp},
+		}
+		got, err := buildAllowedRoots(params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, r := range got {
+			if r == tmp {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("cwd appears %d times in %v", count, got)
+		}
+	})
+}
+
+func TestBuildAllowedRoots_GetwdFailure(t *testing.T) {
+	// No t.Parallel — see TestBuildAllowedRoots for the rationale.
+	prev := osGetwd
+	t.Cleanup(func() { osGetwd = prev })
+	osGetwd = func() (string, error) { return "", os.ErrPermission }
+
+	params := grpcSchemaToolParams{
+		Source:     "file",
+		ProtoPaths: []string{"/abs/x.proto"},
+	}
+	_, err := buildAllowedRoots(params)
+	if err == nil {
+		t.Fatal("expected error when os.Getwd fails")
+	}
+}

--- a/internal/mcp/grpc_schema_tool.go
+++ b/internal/mcp/grpc_schema_tool.go
@@ -1,5 +1,5 @@
 // Package mcp grpc_schema_tool.go implements the schema-aware gRPC .proto
-// schema management tool (USK-923).
+// schema management tool (USK-923 + USK-926).
 //
 // The tool is a single MCP entry with an `action` discriminator
 // (register / list / unregister / clear), mirroring the macro / manage /
@@ -8,10 +8,20 @@
 // protoschema.Registry on Server.grpcSchemas is rehydrated from the
 // table at first use so registrations survive process restart.
 //
-// register accepts source="descriptor_set" only — a precompiled
-// FileDescriptorSet binary (base64-encoded). source="file" / proto_paths
-// is rejected at the schema boundary with a pointer to protoc
-// --include_imports (D1 deferred to a follow-up Issue).
+// register accepts two source modes:
+//
+//   - source="descriptor_set" (the recommended default, USK-923): a
+//     precompiled FileDescriptorSet binary (base64-encoded). The user
+//     runs `protoc --include_imports --descriptor_set_out=...` on the
+//     operator machine and supplies the result.
+//   - source="file" (USK-926): the proxy invokes a host protoc binary
+//     to compile a list of absolute .proto paths into a
+//     FileDescriptorSet on the operator's behalf. See
+//     internal/encoding/protoschema/protoc_runner.go for the security
+//     posture (allowed-roots validation, 30s timeout, env-minimisation).
+//
+// Both modes feed the same downstream LoadFileDescriptorSet → SaveGRPCSchema
+// → Registry.Register pipeline (Resolved #2, #18).
 package mcp
 
 import (
@@ -19,13 +29,21 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
 	"github.com/usk6666/yorishiro-proxy/internal/encoding/protoschema"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 )
+
+// osGetwd is package-private indirection over os.Getwd so the test
+// harness can pin a known directory without mutating process state.
+// Production callers always hit the real os.Getwd via this var.
+var osGetwd = os.Getwd
 
 // grpcSchemaToolInput is the typed input for the grpc_schema tool.
 type grpcSchemaToolInput struct {
@@ -39,10 +57,10 @@ type grpcSchemaToolInput struct {
 // grpcSchemaToolParams is the union of all grpc_schema action parameters.
 // Only the fields relevant to the specified action are read.
 type grpcSchemaToolParams struct {
-	// Source is the descriptor input shape. USK-923 accepts
-	// "descriptor_set" only; "file" is rejected with a pointer to
-	// protoc --include_imports.
-	Source string `json:"source,omitempty" jsonschema:"input shape; only 'descriptor_set' is currently supported"`
+	// Source is the descriptor input shape. Accepts
+	// "descriptor_set" (USK-923 default; supply DescriptorSetB64) or
+	// "file" (USK-926; supply ProtoPaths and optionally ImportPaths).
+	Source string `json:"source,omitempty" jsonschema:"input shape; one of 'descriptor_set' (default; supply descriptor_set_b64) or 'file' (supply proto_paths)"`
 	// DescriptorSetB64 is the base64-encoded FileDescriptorSet payload.
 	// Required when action=register and source=descriptor_set. Capped at
 	// 16 MiB after base64 decode.
@@ -57,10 +75,16 @@ type grpcSchemaToolParams struct {
 	// Service is the fully-qualified service name. Required for
 	// action=unregister.
 	Service string `json:"service,omitempty" jsonschema:"fully-qualified service name (required for unregister)"`
-	// ProtoPaths is rejected for USK-923; surfaced on the schema so AI
-	// agents see a clear error message instead of a silently ignored
-	// field. Reserved for a follow-up Issue (D1 deferred).
-	ProtoPaths []string `json:"proto_paths,omitempty" jsonschema:"reserved for source='file' (deferred to a follow-up Issue); the field is rejected when populated"`
+	// ProtoPaths is the list of absolute .proto file paths to compile
+	// when source="file". Each path must be absolute, syntactically
+	// clean (no "..", no double-slashes), and fall under the proxy CWD
+	// or one of the supplied ImportPaths (USK-926).
+	ProtoPaths []string `json:"proto_paths,omitempty" jsonschema:"absolute paths to .proto files (required when source='file'); each path must be canonical and fall under proxy CWD or one of import_paths"`
+	// ImportPaths is the list of -I roots passed to protoc. Optional;
+	// when empty, the runner derives a single root per filepath.Dir of
+	// each proto path. Each entry follows the same validation as
+	// ProtoPaths.
+	ImportPaths []string `json:"import_paths,omitempty" jsonschema:"optional absolute -I roots for protoc when source='file'; defaults to the parent directory of each proto path"`
 }
 
 // availableGRPCSchemaActions enumerates valid action names for the
@@ -72,8 +96,10 @@ func (s *Server) registerGRPCSchema() {
 	gomcp.AddTool(s.server, &gomcp.Tool{
 		Name: "grpc_schema",
 		Description: "Manage .proto schemas for schema-aware gRPC decode (query) and encode (resend_grpc). " +
-			"Actions: 'register' (upsert a service from a precompiled FileDescriptorSet base64 payload — " +
-			"generate via `protoc --include_imports --descriptor_set_out=<file> <protos>`, max 16 MiB decoded), " +
+			"Actions: 'register' (upsert a service from either a precompiled FileDescriptorSet via " +
+			"source=\"descriptor_set\" + descriptor_set_b64 — the recommended path, generate via " +
+			"`protoc --include_imports --descriptor_set_out=<file> <protos>`, max 16 MiB decoded — or " +
+			"source=\"file\" + absolute proto_paths which invokes a host protoc binary), " +
 			"'list' (registered services + methods), 'unregister' (remove a service by name), 'clear' (remove all). " +
 			"Once a schema is registered, query messages decodes matching gRPC Data bodies as protojson with real " +
 			"field names (body_decoded_encoding=\"proto-json\") and resend_grpc accepts body_encoding=\"proto-json\". " +
@@ -165,9 +191,11 @@ type grpcSchemaMethodEntry struct {
 	Output string `json:"output"`
 }
 
-// handleGRPCSchemaRegister parses the descriptor_set_b64 payload, filters
-// by service_filter, persists the result via SchemaStore, and updates the
-// in-memory Registry.
+// handleGRPCSchemaRegister parses the requested source mode (base64
+// descriptor_set or host protoc invocation against proto_paths),
+// filters by service_filter, persists the result via SchemaStore, and
+// updates the in-memory Registry. The persist→register tail is
+// identical across modes (Resolved #2, #18).
 func (s *Server) handleGRPCSchemaRegister(ctx context.Context, params grpcSchemaToolParams) (*grpcSchemaRegisterResult, error) {
 	if s.flowStore.store == nil {
 		return nil, fmt.Errorf("flow store is not initialized")
@@ -176,22 +204,9 @@ func (s *Server) handleGRPCSchemaRegister(ctx context.Context, params grpcSchema
 		return nil, err
 	}
 
-	// Pre-decode size cap on the base64 input itself (USK-923 review S-1,
-	// CWE-770). Base64 encodes 3 bytes into 4 chars; cap the encoded
-	// length at the equivalent of MaxDescriptorSetBytes + a small slack
-	// (padding, newlines) so a pathological input cannot allocate
-	// gigabytes during DecodeString before the post-decode cap fires.
-	maxEncodedLen := protoschema.MaxDescriptorSetBytes*4/3 + 64
-	if len(params.DescriptorSetB64) > maxEncodedLen {
-		return nil, fmt.Errorf("descriptor_set_b64 length %d exceeds maximum encoded size %d (decoded cap is %d bytes)", len(params.DescriptorSetB64), maxEncodedLen, protoschema.MaxDescriptorSetBytes)
-	}
-
-	raw, err := base64.StdEncoding.DecodeString(params.DescriptorSetB64)
+	raw, sourceLabel, err := s.loadDescriptorBytes(ctx, params)
 	if err != nil {
-		return nil, fmt.Errorf("decode descriptor_set_b64: %w", err)
-	}
-	if len(raw) > protoschema.MaxDescriptorSetBytes {
-		return nil, fmt.Errorf("descriptor_set size %d exceeds maximum %d bytes after base64 decode", len(raw), protoschema.MaxDescriptorSetBytes)
+		return nil, err
 	}
 
 	specs, err := protoschema.LoadFileDescriptorSet(raw, params.ServiceFilter)
@@ -202,11 +217,11 @@ func (s *Server) handleGRPCSchemaRegister(ctx context.Context, params grpcSchema
 	// Persist before updating the in-memory registry: if the SQLite write
 	// fails partway through, the registry stays consistent with disk.
 	for _, spec := range specs {
-		if perr := s.flowStore.store.SaveGRPCSchema(ctx, spec.Service, raw, params.SourceLabel); perr != nil {
+		if perr := s.flowStore.store.SaveGRPCSchema(ctx, spec.Service, raw, sourceLabel); perr != nil {
 			return nil, fmt.Errorf("save schema for service %q: %w", spec.Service, perr)
 		}
-		if params.SourceLabel != "" {
-			spec.SourceLabel = params.SourceLabel
+		if sourceLabel != "" {
+			spec.SourceLabel = sourceLabel
 		}
 	}
 
@@ -221,23 +236,170 @@ func (s *Server) handleGRPCSchemaRegister(ctx context.Context, params grpcSchema
 	return result, nil
 }
 
-// validateGRPCSchemaRegisterInput enforces the source allowlist and the
-// presence of descriptor_set_b64. The "file" source / proto_paths fields
-// are rejected with a clear pointer to protoc --include_imports.
-func validateGRPCSchemaRegisterInput(params grpcSchemaToolParams) error {
-	if len(params.ProtoPaths) > 0 {
-		return fmt.Errorf("proto_paths is reserved for a deferred follow-up Issue; run `protoc --include_imports --descriptor_set_out=<file> <protos>` and pass the base64-encoded result as descriptor_set_b64 (see help_grpc_schema for details)")
-	}
-	if params.Source != "" && params.Source != "descriptor_set" {
-		if params.Source == "file" {
-			return fmt.Errorf("source=\"file\" is not yet supported; run `protoc --include_imports --descriptor_set_out=<file> <protos>` and pass the base64-encoded result as descriptor_set_b64 (see help_grpc_schema for details)")
+// loadDescriptorBytes is the source-mode adaptor: given a validated
+// params struct, returns the FileDescriptorSet bytes and the effective
+// source label. Per-source-mode branches are kept tight so the
+// persist+Register tail in handleGRPCSchemaRegister stays a single
+// shared block (Resolved #2).
+func (s *Server) loadDescriptorBytes(ctx context.Context, params grpcSchemaToolParams) ([]byte, string, error) {
+	if params.Source == "file" {
+		raw, err := s.loadDescriptorFromFiles(ctx, params)
+		if err != nil {
+			return nil, "", err
 		}
-		return fmt.Errorf("source %q is not supported; use source=\"descriptor_set\"", params.Source)
+		label := params.SourceLabel
+		if label == "" {
+			label = deriveFileSourceLabel(params.ProtoPaths)
+		}
+		return raw, label, nil
 	}
-	if params.DescriptorSetB64 == "" {
-		return fmt.Errorf("descriptor_set_b64 is required for action=register (generate via `protoc --include_imports --descriptor_set_out=<file> <protos>` and base64-encode the result)")
+	raw, err := decodeDescriptorSetB64(params.DescriptorSetB64)
+	if err != nil {
+		return nil, "", err
 	}
-	return nil
+	return raw, params.SourceLabel, nil
+}
+
+// decodeDescriptorSetB64 is the source="descriptor_set" branch of
+// loadDescriptorBytes. Carries the USK-923 pre/post-decode size caps.
+func decodeDescriptorSetB64(b64 string) ([]byte, error) {
+	// Pre-decode size cap on the base64 input itself (USK-923 review S-1,
+	// CWE-770). Base64 encodes 3 bytes into 4 chars; cap the encoded
+	// length at the equivalent of MaxDescriptorSetBytes + a small slack
+	// (padding, newlines) so a pathological input cannot allocate
+	// gigabytes during DecodeString before the post-decode cap fires.
+	maxEncodedLen := protoschema.MaxDescriptorSetBytes*4/3 + 64
+	if len(b64) > maxEncodedLen {
+		return nil, fmt.Errorf("descriptor_set_b64 length %d exceeds maximum encoded size %d (decoded cap is %d bytes)", len(b64), maxEncodedLen, protoschema.MaxDescriptorSetBytes)
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("decode descriptor_set_b64: %w", err)
+	}
+	if len(raw) > protoschema.MaxDescriptorSetBytes {
+		return nil, fmt.Errorf("descriptor_set size %d exceeds maximum %d bytes after base64 decode", len(raw), protoschema.MaxDescriptorSetBytes)
+	}
+	return raw, nil
+}
+
+// loadDescriptorFromFiles is the source="file" branch of
+// loadDescriptorBytes. Resolves the protoc binary from config/env,
+// derives the allowed roots (server CWD + caller-supplied
+// import_paths, falling back to the proto path's parent dirs), and
+// invokes the runner.
+func (s *Server) loadDescriptorFromFiles(ctx context.Context, params grpcSchemaToolParams) ([]byte, error) {
+	binary := config.ResolveProtocBinary(s.connector.proxyDefaults)
+	allowedRoots, err := buildAllowedRoots(params)
+	if err != nil {
+		return nil, err
+	}
+	res, err := protoschema.RunProtoc(ctx, protoschema.ProtocRunOptions{
+		Binary:       binary,
+		ProtoPaths:   params.ProtoPaths,
+		ImportPaths:  params.ImportPaths,
+		AllowedRoots: allowedRoots,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.DescriptorSet, nil
+}
+
+// buildAllowedRoots assembles the allowed-roots set for a source="file"
+// invocation. Always includes the server's CWD plus every supplied
+// import_path; when import_paths is empty, also includes the parent
+// directory of each proto_path so the implicit `-I<dir-of-proto>`
+// derivation lines up with the path-validation check.
+func buildAllowedRoots(params grpcSchemaToolParams) ([]string, error) {
+	cwd, err := osGetwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolve server cwd for allowed_roots: %w", err)
+	}
+	roots := []string{cwd}
+	seen := map[string]struct{}{cwd: {}}
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		roots = append(roots, p)
+	}
+	for _, p := range params.ImportPaths {
+		add(p)
+	}
+	if len(params.ImportPaths) == 0 {
+		for _, p := range params.ProtoPaths {
+			add(filepath.Dir(p))
+		}
+	}
+	return roots, nil
+}
+
+// validateGRPCSchemaRegisterInput enforces the source × proto_paths ×
+// descriptor_set_b64 mutex (Resolved U3). The behaviour matrix:
+//
+//   - empty source + descriptor_set_b64 set → accepted (USK-923 back-compat)
+//   - empty source + proto_paths set        → error (must declare source=file)
+//   - source="descriptor_set" + proto_paths → error (mode mismatch)
+//   - source="file" + proto_paths empty     → error (file mode needs paths)
+//   - source="file" + proto_paths set       → accepted (USK-926 happy path)
+//   - any other source value                → error
+func validateGRPCSchemaRegisterInput(params grpcSchemaToolParams) error {
+	switch params.Source {
+	case "":
+		// USK-923 back-compat: empty source means descriptor_set mode.
+		// Reject proto_paths in this branch — the caller has to be
+		// explicit about file mode (U3).
+		if len(params.ProtoPaths) > 0 {
+			return fmt.Errorf("source=\"file\" must be set explicitly when proto_paths is provided")
+		}
+		if len(params.ImportPaths) > 0 {
+			return fmt.Errorf("import_paths is only valid with source=\"file\"")
+		}
+		if params.DescriptorSetB64 == "" {
+			return fmt.Errorf("descriptor_set_b64 is required for action=register (generate via `protoc --include_imports --descriptor_set_out=<file> <protos>` and base64-encode the result)")
+		}
+		return nil
+	case "descriptor_set":
+		if len(params.ProtoPaths) > 0 {
+			return fmt.Errorf("proto_paths is only valid with source=\"file\"")
+		}
+		if len(params.ImportPaths) > 0 {
+			return fmt.Errorf("import_paths is only valid with source=\"file\"")
+		}
+		if params.DescriptorSetB64 == "" {
+			return fmt.Errorf("descriptor_set_b64 is required for action=register (generate via `protoc --include_imports --descriptor_set_out=<file> <protos>` and base64-encode the result)")
+		}
+		return nil
+	case "file":
+		if len(params.ProtoPaths) == 0 {
+			return fmt.Errorf("proto_paths is required when source=\"file\"")
+		}
+		if params.DescriptorSetB64 != "" {
+			return fmt.Errorf("descriptor_set_b64 is only valid with source=\"descriptor_set\"")
+		}
+		return nil
+	default:
+		return fmt.Errorf("source %q is not supported; use source=\"descriptor_set\" or source=\"file\"", params.Source)
+	}
+}
+
+// deriveFileSourceLabel produces a comma-joined list of proto-file
+// basenames when source_label is omitted in file mode (Resolved #19).
+// Empty paths slice (which the validator already rejects upstream)
+// returns the empty string defensively.
+func deriveFileSourceLabel(protoPaths []string) string {
+	if len(protoPaths) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(protoPaths))
+	for _, p := range protoPaths {
+		names = append(names, filepath.Base(p))
+	}
+	return strings.Join(names, ",")
 }
 
 // handleGRPCSchemaList returns every registered service ordered by service

--- a/internal/mcp/grpc_schema_tool_test.go
+++ b/internal/mcp/grpc_schema_tool_test.go
@@ -91,7 +91,32 @@ func TestGRPCSchema_Register_Happy(t *testing.T) {
 	}
 }
 
-func TestGRPCSchema_Register_RejectsFileSource(t *testing.T) {
+// TestGRPCSchema_Register_FileSource_RequiresExplicitSource — U3:
+// supplying proto_paths without source="file" is rejected; the caller
+// has to be explicit about the mode (no auto-routing).
+func TestGRPCSchema_Register_FileSource_RequiresExplicitSource(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"proto_paths": []any{"/abs/protos/x.proto"},
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for proto_paths without source=file")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "source=\"file\"") {
+		t.Errorf("error must mention source=\"file\" requirement: %q", msg)
+	}
+}
+
+// TestGRPCSchema_Register_FileSource_RequiresProtoPaths — U3:
+// source="file" with no proto_paths is rejected.
+func TestGRPCSchema_Register_FileSource_RequiresProtoPaths(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)
 	cs := setupGRPCSchemaTestSession(t, store)
@@ -103,15 +128,17 @@ func TestGRPCSchema_Register_RejectsFileSource(t *testing.T) {
 		},
 	})
 	if !result.IsError {
-		t.Fatal("expected error for source=file")
+		t.Fatal("expected error for source=file with no proto_paths")
 	}
 	msg := extractTextContent(result)
-	if !strings.Contains(msg, "include_imports") {
-		t.Errorf("error must point at protoc --include_imports: %q", msg)
+	if !strings.Contains(msg, "proto_paths is required") {
+		t.Errorf("error must mention proto_paths required: %q", msg)
 	}
 }
 
-func TestGRPCSchema_Register_RejectsProtoPaths(t *testing.T) {
+// TestGRPCSchema_Register_DescriptorSetSource_RejectsProtoPaths — U3:
+// explicit source="descriptor_set" + proto_paths is a mode mismatch.
+func TestGRPCSchema_Register_DescriptorSetSource_RejectsProtoPaths(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)
 	cs := setupGRPCSchemaTestSession(t, store)
@@ -119,15 +146,59 @@ func TestGRPCSchema_Register_RejectsProtoPaths(t *testing.T) {
 	result := callGRPCSchema(t, cs, map[string]any{
 		"action": "register",
 		"params": map[string]any{
-			"proto_paths": []any{"./protos"},
+			"source":             "descriptor_set",
+			"descriptor_set_b64": "Cg==",
+			"proto_paths":        []any{"/abs/protos/x.proto"},
 		},
 	})
 	if !result.IsError {
-		t.Fatal("expected error for proto_paths")
+		t.Fatal("expected error for source=descriptor_set with proto_paths")
 	}
 	msg := extractTextContent(result)
-	if !strings.Contains(msg, "proto_paths") {
-		t.Errorf("error must mention proto_paths: %q", msg)
+	if !strings.Contains(msg, "proto_paths is only valid with source=\"file\"") {
+		t.Errorf("error must explain mode mismatch: %q", msg)
+	}
+}
+
+// TestGRPCSchema_Register_FileSource_RejectsDescriptorSetB64 — U3:
+// source="file" with descriptor_set_b64 set is a mode mismatch.
+func TestGRPCSchema_Register_FileSource_RejectsDescriptorSetB64(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source":             "file",
+			"proto_paths":        []any{"/abs/protos/x.proto"},
+			"descriptor_set_b64": "Cg==",
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for source=file with descriptor_set_b64")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "descriptor_set_b64 is only valid with source=\"descriptor_set\"") {
+		t.Errorf("error must explain mode mismatch: %q", msg)
+	}
+}
+
+// TestGRPCSchema_Register_UnknownSource — any source value outside the
+// {empty, descriptor_set, file} allowlist must be rejected.
+func TestGRPCSchema_Register_UnknownSource(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "register",
+		"params": map[string]any{
+			"source": "reflection",
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error for unknown source")
 	}
 }
 

--- a/internal/mcp/resources/help_grpc_schema.md
+++ b/internal/mcp/resources/help_grpc_schema.md
@@ -15,7 +15,11 @@ Action-specific parameters.
 ## Actions
 
 ### register
-Upsert a service from a precompiled protobuf `FileDescriptorSet`. Last-write-wins: re-registering a service replaces every method's input/output binding.
+Upsert a service from either a precompiled protobuf `FileDescriptorSet` (recommended) or a list of `.proto` files compiled by a host `protoc` binary. Last-write-wins: re-registering a service replaces every method's input/output binding.
+
+Two source modes are available:
+
+#### Descriptor-set source (`source="descriptor_set"`, recommended)
 
 Generate the descriptor set on the operator machine with:
 
@@ -28,10 +32,26 @@ The `--include_imports` flag is required — without it, transitive imports stay
 Then read `schema.desc` and pass the base64-encoded bytes:
 
 **Parameters:**
-- **source** (string, optional): Input shape. Must be `"descriptor_set"` (default when omitted). `"file"` and `proto_paths` are reserved for a future Issue and rejected here.
+- **source** (string, optional): `"descriptor_set"` or omitted (the default).
 - **descriptor_set_b64** (string, required): Base64-encoded FileDescriptorSet payload. Max 16 MiB after base64 decode.
 - **service_filter** (array of strings, optional): Fully-qualified service names to register. Empty means register every service the descriptor declares. Names not found in the descriptor produce an error.
 - **source_label** (string, optional): Free-form label preserved in `list` output (filename hint, version tag, etc.).
+
+This is the recommended path because it does not require `protoc` on the proxy host.
+
+#### File source (`source="file"`)
+
+The proxy invokes a host `protoc` binary to compile a list of absolute `.proto` paths into a FileDescriptorSet on the operator's behalf.
+
+**Parameters:**
+- **source** (string, required for this mode): `"file"`.
+- **proto_paths** (array of strings, required): Absolute paths to the `.proto` files to compile. Each path must be canonical (no `..`, no double-slashes) and resolve under the proxy's working directory or one of `import_paths`. Symlinks are followed; the resolved target must also fall under the allowed roots.
+- **import_paths** (array of strings, optional): Absolute `-I` roots for protoc. Defaults to the parent directory of each proto path.
+- **service_filter**, **source_label**: Same semantics as the descriptor-set source. When `source_label` is omitted, it defaults to a comma-joined list of proto-file basenames.
+
+`protoc` is invoked with `--include_imports` and a 30-second timeout. The environment is reduced to `PATH` only. By default the binary is resolved against `PATH` as `protoc`; configure an explicit path via `ProxyConfig.GRPCSchema.ProtocBinary` (config file) or the `YP_PROTOC_BINARY` environment variable. If `protoc` is missing, the call returns an install hint.
+
+**Recommended default**: prefer `source="descriptor_set"`. The file path is provided for environments where invoking `protoc` server-side is acceptable; the descriptor-set path keeps the proxy free of an out-of-process compiler dependency.
 
 Returns: `registered[]` — list of `{ service, methods: [{name, input, output}], source_label, registered_at }`.
 
@@ -64,6 +84,19 @@ Returns: `{ cleared }` — number of rows deleted from persistent storage.
     "descriptor_set_b64": "Cg<...base64 bytes...>",
     "service_filter": ["pkg.Greeter"],
     "source_label": "greeter@v1.2.0"
+  }
+}
+```
+
+### Register from .proto files (host protoc)
+```json
+{
+  "action": "register",
+  "params": {
+    "source": "file",
+    "proto_paths": ["/srv/protos/greeter.proto"],
+    "import_paths": ["/srv/protos"],
+    "service_filter": ["pkg.Greeter"]
   }
 }
 ```
@@ -137,7 +170,7 @@ For lossless round-trips, use `body_encoding="proto-schemaless-json"` (synthetic
 
 - **Last-write-wins.** Re-registering a service replaces its previous binding. The `list` output shows the most recent registration for each service.
 - **Persistence.** Registrations survive process restart via the `grpc_schemas` SQLite table.
-- **`source="file"` is not supported.** Run `protoc --include_imports --descriptor_set_out=…` on the operator machine and pass the base64-encoded bytes. Host-side `protoc` invocation is deferred to a follow-up Issue.
+- **`source="file"` requires a host `protoc`.** The recommended path is still `source="descriptor_set"`: run `protoc --include_imports --descriptor_set_out=…` on the operator machine and pass the base64-encoded bytes. Use the file path only when invoking `protoc` server-side is acceptable in your environment. The proxy resolves the binary from `YP_PROTOC_BINARY` → `ProxyConfig.GRPCSchema.ProtocBinary` → `PATH:protoc`.
 - **Reflection-based discovery is not supported.** Server-reflection auto-discovery is deferred to a follow-up Issue.
 - **Case-sensitive lookup.** Protobuf service/method identifiers are case-sensitive per spec. The lookup against `Flow.Metadata["grpc_service"]` / `["grpc_method"]` is exact-match.
 - **Output Filter still applies.** PII patterns (credit cards, etc.) configured in the safety engine mask the protojson output before it leaves the MCP boundary.

--- a/internal/mcp/resources/schema_grpc_schema.json
+++ b/internal/mcp/resources/schema_grpc_schema.json
@@ -16,8 +16,8 @@
       "properties": {
         "source": {
           "type": "string",
-          "description": "Input shape. Only 'descriptor_set' is currently supported; 'file' is rejected with a pointer to protoc --include_imports.",
-          "enum": ["descriptor_set", ""]
+          "description": "Input shape. 'descriptor_set' (default; supply descriptor_set_b64 — the recommended path) or 'file' (supply proto_paths; invokes a host protoc binary).",
+          "enum": ["descriptor_set", "file", ""]
         },
         "descriptor_set_b64": {
           "type": "string",
@@ -38,7 +38,12 @@
         },
         "proto_paths": {
           "type": "array",
-          "description": "Reserved for a future Issue (source='file' deferred); the field is rejected when populated.",
+          "description": "Absolute paths to .proto files (required when source='file'). Each path must be canonical and fall under the proxy CWD or one of import_paths.",
+          "items": { "type": "string" }
+        },
+        "import_paths": {
+          "type": "array",
+          "description": "Optional absolute -I roots for protoc when source='file'. Defaults to the parent directory of each proto path.",
           "items": { "type": "string" }
         }
       },


### PR DESCRIPTION
## Summary

Adds the second source mode (`source="file"`) for the `grpc_schema` MCP tool's `register` action: the proxy invokes a host `protoc` binary on a list of absolute `.proto` paths and feeds the resulting FileDescriptorSet into the same persist + `Registry.Register` pipeline as the existing `source="descriptor_set"` path.

- USK-923's `source="descriptor_set"` stays the **recommended default** in docs and tool description (per user preference). This Issue exists for environments where invoking `protoc` server-side is acceptable.
- New `ProxyConfig.GRPCSchema.ProtocBinary` config knob with `YP_PROTOC_BINARY` env-var override; precedence: env → config → `"protoc"`.
- Security posture: absolute paths required, NUL-byte / non-canonical / `..` rejection, `EvalSymlinks` + allowed-roots check (proxy CWD or supplied `import_paths`), env minimised to `PATH` only, 30s timeout, 4 KiB stderr truncation in errors.
- New MCP param `import_paths` (optional `-I` roots); defaults to `filepath.Dir` of each `proto_paths` entry.
- Explicit, no auto-routing source × params validation per Resolved U3.
- Nightly CI installs `protobuf-compiler` so the host-protoc e2e test actually runs there.

## Resolves

Resolves [USK-926](https://linear.app/usk6666/issue/USK-926).

## Test plan

- [x] `make build` (UI + Go)
- [x] `make lint` (gofmt + go vet + staticcheck + ineffassign + gocyclo)
- [x] `make test` — fast tier passes (all existing tests + new unit tests).
- [x] `go test -race -tags e2e -run TestGRPCSchema_Register_FileSource ./internal/mcp/` — happy path, default import_paths, service filter, relative-path rejection, outside-allowed-root rejection all pass locally with `/usr/bin/protoc` (libprotoc 3.21.12).
- [x] No new go module dependencies.
- [x] Existing `source="descriptor_set"` tests continue to pass (back-compat verified).
- [ ] Code Review / Security Review focus areas: path validation order in `protoc_runner.go` (basics → EvalSymlinks → allowed-roots), `cmd.Env=[]string{"PATH="+os.Getenv("PATH")}` minimisation, nightly-e2e workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)