### PR TITLE
feat(mcp,grpc): gRPC server reflection-based schema discovery (USK-928)

### DIFF
--- a/internal/encoding/protoschema/reflection.go
+++ b/internal/encoding/protoschema/reflection.go
@@ -1,0 +1,738 @@
+// Package protoschema reflection.go drives the gRPC server-reflection
+// client for the grpc_schema MCP tool's `discover` action (USK-928).
+//
+// Sibling pattern: this file lives next to protoc_runner.go so all
+// non-MCP-side schema acquisition modes (descriptor_set/file/reflection)
+// share a single package home. The MCP handler (handleGRPCSchemaDiscover)
+// calls Discover(ctx, opts) and feeds the returned bytes into
+// SaveGRPCSchema + Registry.Register via the existing register tail —
+// persistence semantics are byte-identical to source="descriptor_set"
+// (Resolved #4).
+//
+// Transport — the discover RPC is dialled via the in-house HTTP/2 Layer
+// plus the gRPC Layer wrap (the same recipe used by resend_grpc). NO
+// runtime dependency on google.golang.org/grpc is introduced; only the
+// generated proto types under
+// google.golang.org/grpc/reflection/grpc_reflection_v1 (and v1alpha)
+// are imported (Resolved #11; project Principle #4).
+//
+// Protocol — v1 is tried first; on a stream-level UNIMPLEMENTED (gRPC
+// status code 12) status the discover transparently falls back to
+// v1alpha (Resolved #2, #20). Any other failure surfaces verbatim.
+//
+// Security — per-LPM size cap, total-FileDescriptorSet cap, explicit
+// timeout, and explicit context cancellation. The reflection-own
+// services are stripped before issuing FileContainingSymbol so we never
+// re-fetch the reflection schema itself (Resolved #12).
+package protoschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	v1 "google.golang.org/grpc/reflection/grpc_reflection_v1"
+
+	httputilpkg "github.com/usk6666/yorishiro-proxy/internal/connector/transport"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	grpclayer "github.com/usk6666/yorishiro-proxy/internal/layer/grpc"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
+)
+
+// ReflectionV1Service is the fully-qualified v1 reflection service name.
+const ReflectionV1Service = "grpc.reflection.v1.ServerReflection"
+
+// ReflectionV1AlphaService is the fully-qualified v1alpha reflection
+// service name. We probe v1 first and fall back here on UNIMPLEMENTED.
+const ReflectionV1AlphaService = "grpc.reflection.v1alpha.ServerReflection"
+
+// ReflectionMethod is the bidi-streaming method name shared by both
+// reflection versions.
+const ReflectionMethod = "ServerReflectionInfo"
+
+// DefaultDiscoverTimeout is the wall-clock budget applied to a single
+// Discover invocation when DiscoverOptions.Timeout is zero. 30s matches
+// the resend_grpc default (Resolved #14).
+const DefaultDiscoverTimeout = 30 * time.Second
+
+// MaxDiscoverTimeout is the upper bound the runner applies to a caller-
+// supplied timeout. 5 minutes is a sane upper bound that covers cold-cache
+// reads from slow upstreams while preventing an MCP caller from parking
+// the server indefinitely (Resolved #14).
+const MaxDiscoverTimeout = 5 * time.Minute
+
+// gRPC status code for UNIMPLEMENTED. Matches codes.Unimplemented from
+// google.golang.org/grpc/codes without importing the runtime package.
+const grpcStatusUnimplemented uint32 = 12
+
+// DiscoverOptions is the input to Discover.
+type DiscoverOptions struct {
+	// TargetAddr is the upstream host or host:port. Required.
+	TargetAddr string
+
+	// Scheme selects http (h2c) vs https (TLS+ALPN h2). Empty defaults to
+	// https (Resolved #31).
+	Scheme string
+
+	// Transport supplies the TLS dial helper. Required when Scheme=="https".
+	// May be nil for plaintext h2c.
+	Transport httputilpkg.TLSTransport
+
+	// Metadata is the optional gRPC metadata list forwarded as initial
+	// HEADERS on the reflection stream. Used by reflection endpoints that
+	// gate access behind a bearer token or similar (U3).
+	Metadata []envelope.KeyValue
+
+	// ServiceFilter, when non-empty, restricts the per-service
+	// FileContainingSymbol fetch to these fully-qualified names. Names not
+	// present in the upstream's ListServices response cause an error
+	// (Resolved #6, #30).
+	ServiceFilter []string
+
+	// Timeout overrides DefaultDiscoverTimeout. Values above
+	// MaxDiscoverTimeout are clamped (Resolved #14).
+	Timeout time.Duration
+
+	// MaxLPMSize, when non-zero, caps the per-LPM bytes accepted on the
+	// reflection stream. Defaults to MaxDescriptorSetBytes (Resolved #9).
+	MaxLPMSize uint32
+}
+
+// DiscoverResult is the structured output of Discover.
+type DiscoverResult struct {
+	// Services is the resolved list ready for Registry.Register. The
+	// caller is responsible for stamping SourceLabel (the protoschema
+	// package does not know the caller's preferred label).
+	Services []*ServiceSpec
+
+	// AssembledRawDescriptorSet is the marshaled FileDescriptorSet bytes
+	// ready for SaveGRPCSchema. One descriptor set covers ALL discovered
+	// services so a single persistence row per service references the same
+	// blob; the rehydrate path filters by service.
+	AssembledRawDescriptorSet []byte
+
+	// ReflectionVersion is the reflection service variant that succeeded
+	// ("v1" or "v1alpha"). Informational; mirrors the verbatim service
+	// names for the result schema.
+	ReflectionVersion string
+}
+
+// reflectionVariant captures one reflection service variant. The same
+// stream-level state machine drives both v1 and v1alpha — only the
+// service name on :path and the message type are different on the wire,
+// but the on-wire proto bytes are byte-identical between v1 and v1alpha
+// (the .proto files were copied verbatim during the v1 promotion). We
+// therefore marshal the v1 types unconditionally and only switch the
+// :path component on fallback.
+type reflectionVariant struct {
+	name    string // "v1" or "v1alpha"
+	service string // fully-qualified service name
+}
+
+var reflectionVariants = []reflectionVariant{
+	{name: "v1", service: ReflectionV1Service},
+	{name: "v1alpha", service: ReflectionV1AlphaService},
+}
+
+// reflectionDialFunc opens one bidi gRPC stream against the target's
+// reflection service. The returned channel must support Send + Next on
+// gRPC envelopes; the Close func is invoked when discoverOnce returns
+// to tear down the underlying connection / Layer / stream regardless of
+// success or failure.
+//
+// The default implementation (defaultReflectionDialFunc) builds the
+// production HTTP/2 + gRPC Layer stack. Tests inject a synthetic dialer
+// to exercise the protocol state machine without standing up real wire.
+type reflectionDialFunc func(ctx context.Context, opts DiscoverOptions, service string) (reflectionStreamChannel, func(), error)
+
+// reflectionDial is the package-level seam tests override. Production
+// code paths always read this var lazily so the swap is goroutine-safe
+// when tests run with t.Parallel.
+var reflectionDial reflectionDialFunc = defaultReflectionDialFunc
+
+// SetReflectionDialForTest replaces the package-level reflectionDial
+// seam with a synthetic factory and returns a function the caller must
+// invoke to restore the original dialer. Intended for tests in sibling
+// packages (notably internal/mcp).
+//
+// The synthetic dialer receives the resolved reflection service path
+// component (either ReflectionV1Service or ReflectionV1AlphaService)
+// and must return a channel that speaks the reflection protocol.
+//
+// Concurrency: the override is global; callers must not run tests in
+// parallel against this seam.
+func SetReflectionDialForTest(factory func(service string) ReflectionStreamChannel) func() {
+	orig := reflectionDial
+	reflectionDial = func(_ context.Context, _ DiscoverOptions, service string) (reflectionStreamChannel, func(), error) {
+		ch := factory(service)
+		return reflectionStreamChannelAdapter{ch: ch}, func() {}, nil
+	}
+	return func() { reflectionDial = orig }
+}
+
+// ReflectionStreamChannel is the exported alias of the internal channel
+// surface SetReflectionDialForTest produces. It mirrors the unexported
+// reflectionStreamChannel — kept in lockstep via the adapter.
+type ReflectionStreamChannel interface {
+	Send(ctx context.Context, env *envelope.Envelope) error
+	Next(ctx context.Context) (*envelope.Envelope, error)
+}
+
+// reflectionStreamChannelAdapter bridges ReflectionStreamChannel back
+// to the unexported interface used by the protocol driver.
+type reflectionStreamChannelAdapter struct {
+	ch ReflectionStreamChannel
+}
+
+func (a reflectionStreamChannelAdapter) Send(ctx context.Context, env *envelope.Envelope) error {
+	return a.ch.Send(ctx, env)
+}
+
+func (a reflectionStreamChannelAdapter) Next(ctx context.Context) (*envelope.Envelope, error) {
+	return a.ch.Next(ctx)
+}
+
+// Discover probes the target gRPC server's reflection endpoint and
+// returns the assembled schema bytes plus the resolved []*ServiceSpec.
+//
+// Behaviour (per Resolved decisions):
+//
+//   - v1 is tried first; on stream-level UNIMPLEMENTED we retry once
+//     against v1alpha (Resolved #2). Any other terminal error from v1
+//     surfaces immediately.
+//   - reflection.v1.ServerReflection and reflection.v1alpha.ServerReflection
+//     are stripped from the candidate service list before issuing
+//     FileContainingSymbol (Resolved #12).
+//   - ServiceFilter, when supplied, is validated against the upstream's
+//     ListServices reply before any FileContainingSymbol fetch (Resolved
+//     #30). Filter entries that are not present produce an error.
+//   - Per-service FileContainingSymbol requests are issued sequentially
+//     (Resolved #15). file_descriptor_proto entries returned across
+//     services are deduplicated by filename (Resolved #8); a filename
+//     collision with byte-differing content surfaces as a protodesc
+//     parse error.
+//   - The assembled FileDescriptorSet is bound by MaxDescriptorSetBytes
+//     (Resolved #9).
+//   - All-or-nothing: any per-service failure aborts the discover; no
+//     partial result is returned (Resolved #24).
+func Discover(ctx context.Context, opts DiscoverOptions) (*DiscoverResult, error) {
+	opts, err := normalizeDiscoverOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	var lastErr error
+	for _, variant := range reflectionVariants {
+		res, err := discoverOnce(runCtx, opts, variant)
+		if err == nil {
+			return res, nil
+		}
+		// Only retry on stream-level UNIMPLEMENTED (Resolved #20). Every
+		// other error class is terminal.
+		if !isUnimplementedErr(err) {
+			return nil, fmt.Errorf("reflection (%s): %w", variant.name, err)
+		}
+		lastErr = err
+		slog.DebugContext(runCtx, "reflection variant returned UNIMPLEMENTED; falling back",
+			"variant", variant.name,
+			"target", opts.TargetAddr,
+		)
+	}
+
+	// Both v1 and v1alpha returned UNIMPLEMENTED — surface the verbatim
+	// error spec from the design review (Resolved #10).
+	_ = lastErr // retained for log context above
+	return nil, fmt.Errorf("target %q does not implement gRPC reflection (server returned gRPC status UNIMPLEMENTED for both v1 and v1alpha). Enable reflection on the target server: for grpc-go, import google.golang.org/grpc/reflection and call reflection.Register(s); for other runtimes see https://github.com/grpc/grpc/blob/master/doc/server-reflection.md", opts.TargetAddr)
+}
+
+// normalizeDiscoverOptions validates and fills defaults. Caller-supplied
+// fields stay verbatim where set; zero values get the documented default.
+func normalizeDiscoverOptions(opts DiscoverOptions) (DiscoverOptions, error) {
+	if strings.TrimSpace(opts.TargetAddr) == "" {
+		return opts, errors.New("target_addr is empty")
+	}
+	scheme := strings.ToLower(strings.TrimSpace(opts.Scheme))
+	switch scheme {
+	case "":
+		scheme = "https"
+	case "http", "https":
+	default:
+		return opts, fmt.Errorf("unsupported scheme %q: only http and https are allowed", opts.Scheme)
+	}
+	opts.Scheme = scheme
+
+	if scheme == "https" && opts.Transport == nil {
+		return opts, errors.New("scheme=https requires a configured TLSTransport")
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = DefaultDiscoverTimeout
+	}
+	if opts.Timeout > MaxDiscoverTimeout {
+		opts.Timeout = MaxDiscoverTimeout
+	}
+	if opts.MaxLPMSize == 0 {
+		opts.MaxLPMSize = MaxDescriptorSetBytes
+	}
+	return opts, nil
+}
+
+// defaultReflectionDialFunc is the production dialer: TCP (+ TLS) →
+// http2.Layer (ClientRole) → grpclayer.Wrap. Tests substitute a
+// synthetic implementation via reflectionDial.
+func defaultReflectionDialFunc(ctx context.Context, opts DiscoverOptions, service string) (reflectionStreamChannel, func(), error) {
+	conn, err := dialReflectionUpstream(ctx, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Bound peer HEADERS to 1 MiB (matches the resend_grpc Layer recipe)
+	// so a strict peer doesn't RST every HEADERS frame on the default
+	// MaxHeaderListSize=0.
+	initialSettings := http2.DefaultSettings()
+	initialSettings.MaxHeaderListSize = 1 << 20
+	connID := uuid.NewString()
+	l, err := http2.New(conn, "", http2.ClientRole,
+		http2.WithEnvelopeContext(envelope.EnvelopeContext{ConnID: connID}),
+		http2.WithInitialSettings(initialSettings),
+	)
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("http2 layer: %w", err)
+	}
+
+	innerCh, err := l.OpenStream(ctx)
+	if err != nil {
+		_ = l.Close()
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("open stream: %w", err)
+	}
+
+	// Per-LPM cap: lower the gRPC Layer's wire cap to MaxLPMSize so a
+	// pathological peer cannot stream a multi-GiB single LPM that
+	// individually fits under the configured proxy cap but blows the
+	// schema-side 16 MiB budget on assembly (Resolved #9, defense in
+	// depth).
+	ch := grpclayer.Wrap(innerCh, nil, grpclayer.RoleClient,
+		grpclayer.WithMaxMessageSize(opts.MaxLPMSize),
+	)
+
+	streamID := uuid.NewString()
+	authority := opts.TargetAddr
+	startEnv := buildReflectionStartEnvelope(streamID, connID, service, authority, opts.Scheme, opts.Metadata)
+	if err := ch.Send(ctx, startEnv); err != nil {
+		_ = ch.Close()
+		_ = l.Close()
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("send Start: %w", err)
+	}
+
+	cleanup := func() {
+		_ = ch.Close()
+		_ = l.Close()
+		_ = conn.Close()
+	}
+	return ch, cleanup, nil
+}
+
+// discoverOnce executes a single reflection RPC against the supplied
+// variant. Opens a fresh upstream connection / H2 stream / gRPC channel
+// each call (Resolved sub-decision below): retrying v1alpha after v1
+// UNIMPLEMENTED uses a brand new dial. This keeps the state machine
+// strictly sequential and avoids stream-reuse subtleties (a single H2
+// connection can carry both, but rebuilding is cheaper than reasoning
+// about which side of a half-closed stream survives).
+func discoverOnce(ctx context.Context, opts DiscoverOptions, variant reflectionVariant) (*DiscoverResult, error) {
+	ch, cleanup, err := reflectionDial(ctx, opts, variant.service)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	// Step 1: ListServices.
+	services, err := reflectionListServices(ctx, ch, "", "", variant)
+	if err != nil {
+		return nil, err
+	}
+
+	// Strip reflection's own services (Resolved #12) and apply the optional
+	// filter (Resolved #30).
+	candidates, err := selectCandidateServices(services, opts.ServiceFilter)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("target %q reports zero services via gRPC reflection — the reflection registry is empty (server has not called reflection.Register on any service)", opts.TargetAddr)
+	}
+
+	// Step 2: FileContainingSymbol per service.
+	fileBytes, err := reflectionFetchFileDescriptors(ctx, ch, "", "", variant, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3: close the request side. The reflection RPC is bidi
+	// streaming; the canonical termination is an empty DATA with
+	// END_STREAM=1 (the gRPC-Go CloseSend wire shape). The gRPC Layer's
+	// sendData translates Payload==nil + WireLength==0 + EndStream=true
+	// into exactly that frame.
+	endEnv := buildReflectionEndStreamEnvelope("", "", len(candidates)+1)
+	if err := ch.Send(ctx, endEnv); err != nil {
+		// The peer almost certainly closed its receive side after our last
+		// response — Send-side CLOSE_STREAM races on partially-torn-down
+		// connections are common in real-world reflection servers. Don't
+		// fail the entire discover on a teardown race when we already have
+		// all the descriptors we need.
+		slog.DebugContext(ctx, "reflection: close-send failed (peer may have torn down recv side first)",
+			"variant", variant.name,
+			"error", err,
+		)
+	}
+
+	// Assemble and bound-check the FileDescriptorSet.
+	rawSet, err := assembleFileDescriptorSet(fileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	specs, err := LoadFileDescriptorSet(rawSet, opts.ServiceFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DiscoverResult{
+		Services:                  specs,
+		AssembledRawDescriptorSet: rawSet,
+		ReflectionVersion:         variant.name,
+	}, nil
+}
+
+// reflectionListServices sends ListServices and reads until a Data
+// envelope carrying ListServicesResponse arrives. Returns the
+// fully-qualified service names.
+func reflectionListServices(ctx context.Context, ch reflectionStreamChannel, _, _ string, _ reflectionVariant) ([]string, error) {
+	listReq := &v1.ServerReflectionRequest{
+		MessageRequest: &v1.ServerReflectionRequest_ListServices{ListServices: "*"},
+	}
+	if err := sendReflectionRequest(ctx, ch, 1, listReq); err != nil {
+		return nil, fmt.Errorf("send ListServices: %w", err)
+	}
+
+	resp, err := readReflectionResponse(ctx, ch)
+	if err != nil {
+		return nil, fmt.Errorf("read ListServices response: %w", err)
+	}
+
+	switch m := resp.MessageResponse.(type) {
+	case *v1.ServerReflectionResponse_ListServicesResponse:
+		out := make([]string, 0, len(m.ListServicesResponse.GetService()))
+		for _, svc := range m.ListServicesResponse.GetService() {
+			out = append(out, svc.GetName())
+		}
+		return out, nil
+	case *v1.ServerReflectionResponse_ErrorResponse:
+		return nil, &reflectionRPCError{Code: uint32(m.ErrorResponse.GetErrorCode()), Message: m.ErrorResponse.GetErrorMessage()}
+	default:
+		return nil, fmt.Errorf("unexpected ListServices response type %T", resp.MessageResponse)
+	}
+}
+
+// reflectionFetchFileDescriptors issues one FileContainingSymbol per
+// candidate service (sequentially per Resolved #15) and collects every
+// returned file_descriptor_proto. All-or-nothing on failure.
+func reflectionFetchFileDescriptors(ctx context.Context, ch reflectionStreamChannel, _, _ string, _ reflectionVariant, candidates []string) ([][]byte, error) {
+	var collected [][]byte
+	for i, svc := range candidates {
+		req := &v1.ServerReflectionRequest{
+			MessageRequest: &v1.ServerReflectionRequest_FileContainingSymbol{FileContainingSymbol: svc},
+		}
+		if err := sendReflectionRequest(ctx, ch, i+2, req); err != nil {
+			return nil, fmt.Errorf("send FileContainingSymbol(%s): %w", svc, err)
+		}
+		resp, err := readReflectionResponse(ctx, ch)
+		if err != nil {
+			return nil, fmt.Errorf("read FileContainingSymbol(%s) response (collected=%d/%d): %w", svc, i, len(candidates), err)
+		}
+		switch m := resp.MessageResponse.(type) {
+		case *v1.ServerReflectionResponse_FileDescriptorResponse:
+			collected = append(collected, m.FileDescriptorResponse.GetFileDescriptorProto()...)
+		case *v1.ServerReflectionResponse_ErrorResponse:
+			return nil, fmt.Errorf("FileContainingSymbol(%s) failed (collected=%d/%d before failure): server returned reflection error code=%d message=%q",
+				svc, i, len(candidates),
+				m.ErrorResponse.GetErrorCode(), m.ErrorResponse.GetErrorMessage())
+		default:
+			return nil, fmt.Errorf("unexpected FileContainingSymbol(%s) response type %T", svc, resp.MessageResponse)
+		}
+	}
+	return collected, nil
+}
+
+// reflectionStreamChannel is the minimum surface of layer.Channel that
+// the reflection driver uses. Extracted as a small interface so unit
+// tests can plug an in-memory pair without standing up a real H2 stack.
+type reflectionStreamChannel interface {
+	Send(ctx context.Context, env *envelope.Envelope) error
+	Next(ctx context.Context) (*envelope.Envelope, error)
+}
+
+// sendReflectionRequest marshals req and writes one GRPCDataMessage
+// envelope on ch.
+func sendReflectionRequest(ctx context.Context, ch reflectionStreamChannel, seq int, req *v1.ServerReflectionRequest) error {
+	payload, err := proto.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	env := &envelope.Envelope{
+		FlowID:    uuid.NewString(),
+		Sequence:  seq,
+		Direction: envelope.Send,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCDataMessage{
+			Compressed: false,
+			WireLength: uint32(len(payload)),
+			Payload:    payload,
+		},
+	}
+	return ch.Send(ctx, env)
+}
+
+// readReflectionResponse drains ch envelopes until a GRPCDataMessage is
+// observed and unmarshals it as ServerReflectionResponse. Other envelope
+// types (Start with response headers, End with trailers) are absorbed.
+// A GRPCEndMessage encountered before a Data envelope means the stream
+// terminated with no further data — surfaced as an error (callers
+// translate UNIMPLEMENTED status into the fallback signal).
+func readReflectionResponse(ctx context.Context, ch reflectionStreamChannel) (*v1.ServerReflectionResponse, error) {
+	for {
+		env, err := ch.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, errors.New("stream closed before receiving a response")
+			}
+			return nil, err
+		}
+		switch m := env.Message.(type) {
+		case *envelope.GRPCStartMessage:
+			// Response HEADERS. Nothing to do — the actual response sits
+			// in the next GRPCDataMessage envelope.
+			continue
+		case *envelope.GRPCDataMessage:
+			resp := &v1.ServerReflectionResponse{}
+			if uerr := proto.Unmarshal(m.Payload, resp); uerr != nil {
+				return nil, fmt.Errorf("unmarshal ServerReflectionResponse: %w", uerr)
+			}
+			return resp, nil
+		case *envelope.GRPCEndMessage:
+			// Trailer arrived without any data. Surface the gRPC status so
+			// the caller can decide whether to fall back (UNIMPLEMENTED)
+			// or to abort.
+			return nil, &reflectionRPCError{Code: m.Status, Message: m.Message}
+		default:
+			// Unknown envelope type — ignore and keep draining. Future
+			// envelope additions on the same channel shouldn't break the
+			// reflection driver.
+			_ = env
+			continue
+		}
+	}
+}
+
+// reflectionRPCError carries a gRPC-status-shaped failure. We avoid the
+// google.golang.org/grpc/status package so the project keeps zero
+// runtime dependency on grpc-go.
+type reflectionRPCError struct {
+	Code    uint32
+	Message string
+}
+
+func (e *reflectionRPCError) Error() string {
+	return fmt.Sprintf("gRPC status %d: %s", e.Code, e.Message)
+}
+
+// isUnimplementedErr reports whether err is the UNIMPLEMENTED stream
+// status that warrants a v1→v1alpha fallback (Resolved #20).
+func isUnimplementedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rpcErr *reflectionRPCError
+	if errors.As(err, &rpcErr) {
+		return rpcErr.Code == grpcStatusUnimplemented
+	}
+	return false
+}
+
+// dialReflectionUpstream produces a TCP (and optionally TLS) connection
+// to opts.TargetAddr. Uses the same TLSTransport contract as
+// resend_grpc's dialResendGRPCUpstream.
+func dialReflectionUpstream(ctx context.Context, opts DiscoverOptions) (net.Conn, error) {
+	dialAddr, sni := resolveReflectionDialTarget(opts.TargetAddr, opts.Scheme == "https")
+	dialer := &net.Dialer{Timeout: opts.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", dialAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", dialAddr, err)
+	}
+	if opts.Scheme == "https" {
+		if opts.Transport == nil {
+			_ = conn.Close()
+			return nil, errors.New("scheme=https requires a configured TLSTransport")
+		}
+		tlsConn, _, tlsErr := opts.Transport.TLSConnect(ctx, conn, sni)
+		if tlsErr != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("tls handshake %s: %w", sni, tlsErr)
+		}
+		conn = tlsConn
+	}
+	return conn, nil
+}
+
+// resolveReflectionDialTarget splits target_addr into a host:port dial
+// address and an SNI. Mirrors resolveResendGRPCDialTarget.
+func resolveReflectionDialTarget(targetAddr string, useTLS bool) (addr, sni string) {
+	host := targetAddr
+	port := ""
+	if h, p, err := net.SplitHostPort(targetAddr); err == nil {
+		host = h
+		port = p
+	}
+	if port == "" {
+		if useTLS {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(host, port), host
+}
+
+// buildReflectionStartEnvelope synthesises the Send-side GRPCStartMessage
+// that opens the reflection RPC stream. ContentType is the canonical
+// application/grpc+proto value.
+func buildReflectionStartEnvelope(streamID, connID, service, authority, scheme string, metadata []envelope.KeyValue) *envelope.Envelope {
+	return &envelope.Envelope{
+		StreamID:  streamID,
+		FlowID:    uuid.NewString(),
+		Sequence:  0,
+		Direction: envelope.Send,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCStartMessage{
+			Service:     service,
+			Method:      ReflectionMethod,
+			Authority:   authority,
+			Scheme:      scheme,
+			Path:        "/" + service + "/" + ReflectionMethod,
+			Metadata:    metadata,
+			ContentType: "application/grpc+proto",
+		},
+		Context: envelope.EnvelopeContext{ConnID: connID},
+	}
+}
+
+// buildReflectionEndStreamEnvelope synthesises the canonical
+// CloseSend-shaped DATA(empty, END_STREAM=1) envelope.
+func buildReflectionEndStreamEnvelope(streamID, connID string, seq int) *envelope.Envelope {
+	return &envelope.Envelope{
+		StreamID:  streamID,
+		FlowID:    uuid.NewString(),
+		Sequence:  seq,
+		Direction: envelope.Send,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCDataMessage{
+			Compressed: false,
+			WireLength: 0,
+			Payload:    nil,
+			EndStream:  true,
+		},
+		Context: envelope.EnvelopeContext{ConnID: connID},
+	}
+}
+
+// selectCandidateServices strips reflection's own services and applies
+// the optional ServiceFilter. Returns an error when the filter mentions
+// a service the target does not expose.
+func selectCandidateServices(services []string, filter []string) ([]string, error) {
+	cleaned := make([]string, 0, len(services))
+	for _, s := range services {
+		if s == ReflectionV1Service || s == ReflectionV1AlphaService {
+			continue
+		}
+		cleaned = append(cleaned, s)
+	}
+	if len(filter) == 0 {
+		return cleaned, nil
+	}
+	have := make(map[string]struct{}, len(cleaned))
+	for _, s := range cleaned {
+		have[s] = struct{}{}
+	}
+	out := make([]string, 0, len(filter))
+	for _, want := range filter {
+		if _, ok := have[want]; !ok {
+			// Surface what the target offered so the operator can fix the
+			// typo. cleaned is alphabetised by the protodesc tail anyway,
+			// but we sort defensively for stable diagnostics.
+			return nil, fmt.Errorf("service %q in service_filter not present in target's reflection registry (available: %v)", want, cleaned)
+		}
+		out = append(out, want)
+	}
+	return out, nil
+}
+
+// assembleFileDescriptorSet deduplicates raw FileDescriptorProto bytes
+// by filename (Resolved #8) and marshals the result to a single
+// FileDescriptorSet bounded by MaxDescriptorSetBytes.
+//
+// Filename-keyed dedup: the same .proto may appear in the
+// FileContainingSymbol response of multiple services (e.g. a common
+// types file). Byte-level dedup would over-keep when grpc servers tweak
+// descriptor metadata across calls; filename-keyed dedup matches what
+// protoc-built descriptor sets look like. A second occurrence with
+// byte-differing content is left for protodesc.NewFiles to detect — its
+// error surfaces with full context via LoadFileDescriptorSet.
+func assembleFileDescriptorSet(fileBytes [][]byte) ([]byte, error) {
+	seen := make(map[string]struct{}, len(fileBytes))
+	out := &descriptorpb.FileDescriptorSet{}
+	for i, raw := range fileBytes {
+		fd := &descriptorpb.FileDescriptorProto{}
+		if err := proto.Unmarshal(raw, fd); err != nil {
+			return nil, fmt.Errorf("parse FileDescriptorProto[%d]: %w", i, err)
+		}
+		name := fd.GetName()
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out.File = append(out.File, fd)
+	}
+	if len(out.File) == 0 {
+		return nil, errors.New("reflection returned zero FileDescriptorProto entries — schema is empty")
+	}
+	marshaled, err := proto.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal FileDescriptorSet: %w", err)
+	}
+	if len(marshaled) > MaxDescriptorSetBytes {
+		return nil, fmt.Errorf("reflection response assembled FileDescriptorSet size %d exceeds maximum %d bytes", len(marshaled), MaxDescriptorSetBytes)
+	}
+	return marshaled, nil
+}
+
+// Note on v1alpha — the v1 and v1alpha .proto files share the same
+// message-and-field-number layout (v1 was a verbatim copy of v1alpha at
+// promotion). Marshaling a v1 ServerReflectionRequest therefore produces
+// wire bytes a v1alpha server unmarshals correctly (and vice versa).
+// The fallback to v1alpha only swaps the :path service component; the
+// proto types stay v1 throughout. This avoids importing the deprecated
+// google.golang.org/grpc/reflection/grpc_reflection_v1alpha package.

--- a/internal/encoding/protoschema/reflection_test.go
+++ b/internal/encoding/protoschema/reflection_test.go
@@ -1,0 +1,738 @@
+package protoschema
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	v1 "google.golang.org/grpc/reflection/grpc_reflection_v1"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+)
+
+// installFakeDial replaces the package-level reflectionDial seam with
+// the supplied factory. The previous value is restored on test cleanup.
+// Tests using t.Parallel must NOT use installFakeDial — the package
+// seam is shared. (None of our tests run in parallel.)
+func installFakeDial(t *testing.T, factory func(service string) reflectionStreamChannel) {
+	t.Helper()
+	orig := reflectionDial
+	reflectionDial = func(_ context.Context, _ DiscoverOptions, service string) (reflectionStreamChannel, func(), error) {
+		ch := factory(service)
+		return ch, func() {}, nil
+	}
+	t.Cleanup(func() { reflectionDial = orig })
+}
+
+// fakeReflectionServer is a synthetic gRPC reflection server that
+// services ServerReflectionInfo by reading marshaled requests from its
+// input queue and crafting responses according to its configured state.
+//
+// Behaviour modes:
+//   - mode="ok" — emit ListServicesResponse with services then
+//     FileDescriptorResponse per FileContainingSymbol.
+//   - mode="unimplemented-v1" — return GRPCEnd with status=12 on the
+//     first read. v1alpha service path responds normally.
+//   - mode="unimplemented-both" — always return status=12 on the first
+//     read.
+//   - mode="zero-services" — empty ListServicesResponse.
+//   - mode="error-on-file" — ListServices succeeds; first
+//     FileContainingSymbol returns an ErrorResponse.
+//   - mode="slow" — block forever on the first request to exercise ctx
+//     timeout behaviour.
+type fakeReflectionServer struct {
+	mode         string
+	services     []string            // emitted by ListServices
+	files        map[string][][]byte // per-service file_descriptor_proto bytes
+	respondStart bool                // whether to push a synthetic GRPCStart envelope before Data
+	t            *testing.T
+}
+
+// fakeServerChannel implements reflectionStreamChannel by routing
+// requests through the configured fakeReflectionServer.
+type fakeServerChannel struct {
+	srv        *fakeReflectionServer
+	service    string               // reflection service the client dialed
+	sent       []*envelope.Envelope // captured Send-side envelopes
+	pending    []*envelope.Envelope // queued response envelopes for Next to drain
+	requestIdx int                  // tracks per-request response routing
+}
+
+func (c *fakeServerChannel) Send(_ context.Context, env *envelope.Envelope) error {
+	c.sent = append(c.sent, env)
+	c.handleSent(env)
+	return nil
+}
+
+func (c *fakeServerChannel) Next(ctx context.Context) (*envelope.Envelope, error) {
+	if len(c.pending) == 0 {
+		if c.srv.mode == "slow" {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		// No pending envelopes and no more Sends will arrive — return
+		// EOF so the read loop surfaces a clear error.
+		return nil, errors.New("fakeServerChannel: no envelopes to deliver")
+	}
+	env := c.pending[0]
+	c.pending = c.pending[1:]
+	return env, nil
+}
+
+// handleSent inspects each Send and queues the matching response shape
+// per the configured server mode.
+func (c *fakeServerChannel) handleSent(env *envelope.Envelope) {
+	switch m := env.Message.(type) {
+	case *envelope.GRPCStartMessage:
+		// Start envelope from the client — no response yet.
+		_ = m
+	case *envelope.GRPCDataMessage:
+		c.handleDataSend(m)
+	case *envelope.GRPCEndMessage:
+		// Close-send sentinel — no response.
+	}
+}
+
+func (c *fakeServerChannel) handleDataSend(m *envelope.GRPCDataMessage) {
+	// Pure end-marker (Payload==nil + WireLength==0 + EndStream=true):
+	// matches CloseSend — no further response expected.
+	if m.Payload == nil && m.WireLength == 0 && m.EndStream {
+		return
+	}
+
+	c.requestIdx++
+
+	// Mode shortcuts.
+	switch c.srv.mode {
+	case "unimplemented-both":
+		c.queueUnimplementedEnd()
+		return
+	case "unimplemented-v1":
+		if c.service == ReflectionV1Service {
+			c.queueUnimplementedEnd()
+			return
+		}
+		// v1alpha service path falls through to the happy path.
+	case "slow":
+		return // Next() will park on ctx
+	}
+
+	req := &v1.ServerReflectionRequest{}
+	if err := proto.Unmarshal(m.Payload, req); err != nil {
+		c.queueErrorData(13, "invalid request: "+err.Error())
+		return
+	}
+	switch mr := req.MessageRequest.(type) {
+	case *v1.ServerReflectionRequest_ListServices:
+		c.handleListServices()
+	case *v1.ServerReflectionRequest_FileContainingSymbol:
+		c.handleFileContaining(mr.FileContainingSymbol)
+	default:
+		c.queueErrorData(13, "unsupported request type")
+	}
+}
+
+func (c *fakeServerChannel) handleListServices() {
+	if c.srv.mode == "zero-services" {
+		c.queueListServices(nil)
+		return
+	}
+	c.queueListServices(c.srv.services)
+}
+
+func (c *fakeServerChannel) handleFileContaining(svc string) {
+	if c.srv.mode == "error-on-file" {
+		c.queueErrorData(5, "file not found for symbol "+svc)
+		return
+	}
+	files, ok := c.srv.files[svc]
+	if !ok {
+		c.queueErrorData(5, "unknown symbol "+svc)
+		return
+	}
+	c.queueFileDescriptor(files)
+}
+
+func (c *fakeServerChannel) queueListServices(services []string) {
+	respSvcs := make([]*v1.ServiceResponse, 0, len(services))
+	for _, s := range services {
+		respSvcs = append(respSvcs, &v1.ServiceResponse{Name: s})
+	}
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_ListServicesResponse{
+			ListServicesResponse: &v1.ListServiceResponse{Service: respSvcs},
+		},
+	}
+	c.queueDataResponse(resp)
+}
+
+func (c *fakeServerChannel) queueFileDescriptor(files [][]byte) {
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_FileDescriptorResponse{
+			FileDescriptorResponse: &v1.FileDescriptorResponse{FileDescriptorProto: files},
+		},
+	}
+	c.queueDataResponse(resp)
+}
+
+func (c *fakeServerChannel) queueErrorData(code int32, msg string) {
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_ErrorResponse{
+			ErrorResponse: &v1.ErrorResponse{ErrorCode: code, ErrorMessage: msg},
+		},
+	}
+	c.queueDataResponse(resp)
+}
+
+func (c *fakeServerChannel) queueDataResponse(resp *v1.ServerReflectionResponse) {
+	payload, err := proto.Marshal(resp)
+	if err != nil {
+		c.srv.t.Fatalf("marshal response: %v", err)
+	}
+	if c.srv.respondStart && c.requestIdx == 1 {
+		c.pending = append(c.pending, &envelope.Envelope{
+			Direction: envelope.Receive,
+			Protocol:  envelope.ProtocolGRPC,
+			Message: &envelope.GRPCStartMessage{
+				Service:     c.service,
+				Method:      ReflectionMethod,
+				ContentType: "application/grpc+proto",
+			},
+		})
+	}
+	c.pending = append(c.pending, &envelope.Envelope{
+		Direction: envelope.Receive,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCDataMessage{
+			WireLength: uint32(len(payload)),
+			Payload:    payload,
+		},
+	})
+}
+
+func (c *fakeServerChannel) queueUnimplementedEnd() {
+	c.pending = append(c.pending, &envelope.Envelope{
+		Direction: envelope.Receive,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCEndMessage{
+			Status:  grpcStatusUnimplemented,
+			Message: "method ServerReflectionInfo not implemented",
+		},
+	})
+}
+
+// newReflectionDialAdapter returns a reflectionDial factory bound to srv.
+func newReflectionDialAdapter(srv *fakeReflectionServer) func(service string) reflectionStreamChannel {
+	return func(service string) reflectionStreamChannel {
+		return &fakeServerChannel{srv: srv, service: service}
+	}
+}
+
+// buildTestFileDescriptorProto returns a marshaled FileDescriptorProto
+// describing a single service+method. The resulting bytes can be fed
+// back into a FileDescriptorResponse to drive the fake server.
+func buildTestFileDescriptorProto(t *testing.T, packageName, fileName, serviceName, methodName, inputMsg, outputMsg string) []byte {
+	t.Helper()
+	syntax := "proto3"
+	fd := &descriptorpb.FileDescriptorProto{
+		Name:    &fileName,
+		Package: &packageName,
+		Syntax:  &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name:  &inputMsg,
+				Field: []*descriptorpb.FieldDescriptorProto{},
+			},
+			{
+				Name:  &outputMsg,
+				Field: []*descriptorpb.FieldDescriptorProto{},
+			},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: &serviceName,
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       &methodName,
+						InputType:  strPtr("." + packageName + "." + inputMsg),
+						OutputType: strPtr("." + packageName + "." + outputMsg),
+					},
+				},
+			},
+		},
+	}
+	raw, err := proto.Marshal(fd)
+	if err != nil {
+		t.Fatalf("marshal FileDescriptorProto: %v", err)
+	}
+	return raw
+}
+
+func strPtr(s string) *string { return &s }
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+func TestDiscover_HappyPath_V1(t *testing.T) {
+	greeterFD := buildTestFileDescriptorProto(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+	srv := &fakeReflectionServer{
+		mode:     "ok",
+		services: []string{"demo.Greeter"},
+		files: map[string][][]byte{
+			"demo.Greeter": {greeterFD},
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if res.ReflectionVersion != "v1" {
+		t.Errorf("ReflectionVersion = %q, want v1", res.ReflectionVersion)
+	}
+	if len(res.Services) != 1 || res.Services[0].Service != "demo.Greeter" {
+		t.Fatalf("Services = %+v, want [demo.Greeter]", res.Services)
+	}
+	if len(res.Services[0].Methods) != 1 || res.Services[0].Methods[0].Name != "SayHello" {
+		t.Errorf("Methods = %+v, want [SayHello]", res.Services[0].Methods)
+	}
+	if len(res.AssembledRawDescriptorSet) == 0 {
+		t.Errorf("AssembledRawDescriptorSet is empty")
+	}
+}
+
+func TestDiscover_V1AlphaFallback(t *testing.T) {
+	greeterFD := buildTestFileDescriptorProto(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+	srv := &fakeReflectionServer{
+		mode:     "unimplemented-v1",
+		services: []string{"demo.Greeter"},
+		files: map[string][][]byte{
+			"demo.Greeter": {greeterFD},
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if res.ReflectionVersion != "v1alpha" {
+		t.Errorf("ReflectionVersion = %q, want v1alpha", res.ReflectionVersion)
+	}
+}
+
+func TestDiscover_BothUnimplemented(t *testing.T) {
+	srv := &fakeReflectionServer{mode: "unimplemented-both", t: t}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err == nil {
+		t.Fatal("expected error when both reflection versions return UNIMPLEMENTED")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "does not implement gRPC reflection") {
+		t.Errorf("error must mention reflection not implemented: %q", msg)
+	}
+	if !strings.Contains(msg, "reflection.Register(s)") {
+		t.Errorf("error must include enable-reflection hint: %q", msg)
+	}
+	if !strings.Contains(msg, "github.com/grpc/grpc") {
+		t.Errorf("error must include upstream spec link: %q", msg)
+	}
+}
+
+func TestDiscover_ZeroServices(t *testing.T) {
+	srv := &fakeReflectionServer{
+		mode:     "zero-services",
+		services: nil,
+		t:        t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err == nil {
+		t.Fatal("expected error when target reports zero services")
+	}
+	if !strings.Contains(err.Error(), "reflection registry is empty") {
+		t.Errorf("error must mention empty registry: %q", err.Error())
+	}
+}
+
+func TestDiscover_PartialFailureAborts(t *testing.T) {
+	srv := &fakeReflectionServer{
+		mode:     "error-on-file",
+		services: []string{"demo.Greeter"},
+		t:        t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err == nil {
+		t.Fatal("expected error when FileContainingSymbol fails after ListServices")
+	}
+	if !strings.Contains(err.Error(), "FileContainingSymbol") {
+		t.Errorf("error must mention the failing step: %q", err.Error())
+	}
+}
+
+func TestDiscover_ServiceFilter_FilterMiss(t *testing.T) {
+	greeterFD := buildTestFileDescriptorProto(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+	srv := &fakeReflectionServer{
+		mode:     "ok",
+		services: []string{"demo.Greeter"},
+		files: map[string][][]byte{
+			"demo.Greeter": {greeterFD},
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := Discover(ctx, DiscoverOptions{
+		TargetAddr:    "127.0.0.1:9000",
+		Scheme:        "http",
+		ServiceFilter: []string{"demo.Missing"},
+	})
+	if err == nil {
+		t.Fatal("expected error when filter mentions a service not present")
+	}
+	if !strings.Contains(err.Error(), "demo.Missing") {
+		t.Errorf("error must mention the missing service: %q", err.Error())
+	}
+}
+
+func TestDiscover_ServiceFilter_HappyPath(t *testing.T) {
+	greeterFD := buildTestFileDescriptorProto(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+	echoFD := buildTestFileDescriptorProto(t, "demo", "demo/echo.proto", "Echo", "Ping", "PingRequest", "PingResponse")
+	srv := &fakeReflectionServer{
+		mode:     "ok",
+		services: []string{"demo.Greeter", "demo.Echo"},
+		files: map[string][][]byte{
+			"demo.Greeter": {greeterFD},
+			"demo.Echo":    {echoFD},
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := Discover(ctx, DiscoverOptions{
+		TargetAddr:    "127.0.0.1:9000",
+		Scheme:        "http",
+		ServiceFilter: []string{"demo.Greeter"},
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(res.Services) != 1 || res.Services[0].Service != "demo.Greeter" {
+		t.Errorf("Services = %+v, want only demo.Greeter", res.Services)
+	}
+}
+
+func TestDiscover_StripsReflectionServices(t *testing.T) {
+	greeterFD := buildTestFileDescriptorProto(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+	srv := &fakeReflectionServer{
+		mode: "ok",
+		services: []string{
+			"demo.Greeter",
+			ReflectionV1Service,
+			ReflectionV1AlphaService,
+		},
+		files: map[string][][]byte{
+			"demo.Greeter": {greeterFD},
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, spec := range res.Services {
+		if spec.Service == ReflectionV1Service || spec.Service == ReflectionV1AlphaService {
+			t.Errorf("reflection-own service leaked into result: %q", spec.Service)
+		}
+	}
+	if len(res.Services) != 1 || res.Services[0].Service != "demo.Greeter" {
+		t.Errorf("Services = %+v, want only demo.Greeter", res.Services)
+	}
+}
+
+func TestDiscover_AssembledSetSizeCap(t *testing.T) {
+	// Build enough large FileDescriptorProto entries so the marshaled
+	// FileDescriptorSet exceeds MaxDescriptorSetBytes (16 MiB). Each
+	// generated FD is ~700 KiB; 25 of them produce >17 MiB.
+	files := make([][]byte, 0, 25)
+	for i := 0; i < 25; i++ {
+		// Distinct filenames so dedup doesn't collapse them.
+		fd := buildLargeFileDescriptorProto(t, "demo", "demo/large_"+itoa(i)+".proto", "BigService"+itoa(i), "DoIt")
+		files = append(files, fd)
+	}
+	_, err := assembleFileDescriptorSet(files)
+	if err == nil {
+		t.Fatal("expected size-cap error when assembled set exceeds MaxDescriptorSetBytes")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Errorf("error must mention size cap: %q", err.Error())
+	}
+}
+
+// buildLargeFileDescriptorProto creates a FileDescriptorProto with one
+// message carrying a SourceCodeInfo Location with a very long
+// leading_comments payload. Comments are valid metadata for protodesc
+// and are preserved by proto.Marshal, so the resulting bytes inflate
+// without requiring thousands of distinct fields. Cheaper to build and
+// marshal than the fields-per-message approach.
+func buildLargeFileDescriptorProto(t *testing.T, packageName, fileName, serviceName, methodName string) []byte {
+	t.Helper()
+	const padBytes = 700_000 // ~700 KiB per file; 24 files > 16 MiB total
+	syntax := "proto3"
+	in := "BigRequest"
+	out := "BigResponse"
+	// Build one big leading_comments string. Build once per call —
+	// reusing the same []byte across builds would mutate-share.
+	big := make([]byte, padBytes)
+	for i := range big {
+		big[i] = 'x'
+	}
+	pad := string(big)
+	leadingPath := []int32{}
+	fd := &descriptorpb.FileDescriptorProto{
+		Name:    &fileName,
+		Package: &packageName,
+		Syntax:  &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{
+			{Name: &in},
+			{Name: &out},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: &serviceName,
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       &methodName,
+						InputType:  strPtr("." + packageName + "." + in),
+						OutputType: strPtr("." + packageName + "." + out),
+					},
+				},
+			},
+		},
+		SourceCodeInfo: &descriptorpb.SourceCodeInfo{
+			Location: []*descriptorpb.SourceCodeInfo_Location{
+				{
+					Path:            leadingPath,
+					LeadingComments: &pad,
+				},
+			},
+		},
+	}
+	raw, err := proto.Marshal(fd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+func TestDiscover_DeduplicatesByFilename(t *testing.T) {
+	// Two services share a common file (e.g. google/protobuf/empty.proto).
+	// The assembled set must include each filename once.
+	commonFD := buildTestFileDescriptorProto(t, "demo", "demo/common.proto", "Service1", "M1", "Req1", "Resp1")
+	serviceAFD := buildTestFileDescriptorProto(t, "demo", "demo/a.proto", "ServiceA", "M", "ReqA", "RespA")
+	srv := &fakeReflectionServer{
+		mode:     "ok",
+		services: []string{"demo.Service1", "demo.ServiceA"},
+		files: map[string][][]byte{
+			"demo.Service1": {commonFD},
+			"demo.ServiceA": {serviceAFD, commonFD}, // common appears twice
+		},
+		t: t,
+	}
+	installFakeDial(t, newReflectionDialAdapter(srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := Discover(ctx, DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "http",
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	// Both Service1 and ServiceA must be present.
+	if len(res.Services) != 2 {
+		t.Errorf("Services len = %d, want 2", len(res.Services))
+	}
+	// The assembled FileDescriptorSet must include demo/common.proto only once.
+	set := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(res.AssembledRawDescriptorSet, set); err != nil {
+		t.Fatalf("unmarshal assembled: %v", err)
+	}
+	names := map[string]int{}
+	for _, f := range set.File {
+		names[f.GetName()]++
+	}
+	if names["demo/common.proto"] != 1 {
+		t.Errorf("common file count = %d, want 1 (filenames: %+v)", names["demo/common.proto"], names)
+	}
+}
+
+func TestDiscover_TargetAddrRequired(t *testing.T) {
+	_, err := Discover(context.Background(), DiscoverOptions{})
+	if err == nil {
+		t.Fatal("expected error when target_addr is empty")
+	}
+	if !strings.Contains(err.Error(), "target_addr") {
+		t.Errorf("error must mention target_addr: %q", err.Error())
+	}
+}
+
+func TestDiscover_UnsupportedScheme(t *testing.T) {
+	_, err := Discover(context.Background(), DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		Scheme:     "ftp",
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+	if !strings.Contains(err.Error(), "ftp") {
+		t.Errorf("error must mention the bad scheme: %q", err.Error())
+	}
+}
+
+func TestDiscover_HTTPSRequiresTransport(t *testing.T) {
+	_, err := Discover(context.Background(), DiscoverOptions{
+		TargetAddr: "127.0.0.1:9000",
+		// Scheme defaults to https; no Transport supplied.
+	})
+	if err == nil {
+		t.Fatal("expected error when https has no TLSTransport")
+	}
+	if !strings.Contains(err.Error(), "TLSTransport") {
+		t.Errorf("error must mention TLSTransport: %q", err.Error())
+	}
+}
+
+func TestAssembleFileDescriptorSet_DeduplicatesByFilename(t *testing.T) {
+	fd := buildTestFileDescriptorProto(t, "demo", "demo/x.proto", "S", "M", "Req", "Resp")
+	raw, err := assembleFileDescriptorSet([][]byte{fd, fd, fd})
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	set := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(raw, set); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(set.File) != 1 {
+		t.Errorf("File len = %d, want 1 (dedup by filename)", len(set.File))
+	}
+}
+
+func TestAssembleFileDescriptorSet_RejectsEmpty(t *testing.T) {
+	_, err := assembleFileDescriptorSet(nil)
+	if err == nil {
+		t.Fatal("expected error on empty input")
+	}
+}
+
+func TestSelectCandidateServices_StripsReflection(t *testing.T) {
+	out, err := selectCandidateServices(
+		[]string{"demo.A", ReflectionV1Service, ReflectionV1AlphaService, "demo.B"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("selectCandidateServices: %v", err)
+	}
+	if len(out) != 2 || out[0] != "demo.A" || out[1] != "demo.B" {
+		t.Errorf("got %v, want [demo.A demo.B]", out)
+	}
+}
+
+func TestSelectCandidateServices_FilterMissError(t *testing.T) {
+	_, err := selectCandidateServices(
+		[]string{"demo.A"},
+		[]string{"demo.B"},
+	)
+	if err == nil {
+		t.Fatal("expected error on filter miss")
+	}
+}
+
+func TestIsUnimplementedErr(t *testing.T) {
+	if !isUnimplementedErr(&reflectionRPCError{Code: grpcStatusUnimplemented}) {
+		t.Error("isUnimplementedErr false negative")
+	}
+	if isUnimplementedErr(&reflectionRPCError{Code: 13}) {
+		t.Error("isUnimplementedErr false positive on non-12 code")
+	}
+	if isUnimplementedErr(errors.New("plain")) {
+		t.Error("isUnimplementedErr false positive on plain error")
+	}
+	if isUnimplementedErr(nil) {
+		t.Error("isUnimplementedErr false positive on nil")
+	}
+}

--- a/internal/mcp/grpc_schema_discover.go
+++ b/internal/mcp/grpc_schema_discover.go
@@ -1,0 +1,288 @@
+// Package mcp grpc_schema_discover.go implements the discover action of
+// the grpc_schema MCP tool (USK-928).
+//
+// discover probes a target server's gRPC reflection endpoint
+// (`grpc.reflection.v1.ServerReflection/ServerReflectionInfo` with a
+// v1alpha fallback), enumerates every exposed service, fetches each
+// service's FileContainingSymbol descriptor, deduplicates the file
+// descriptors by filename, and registers the assembled FileDescriptorSet
+// via the existing protoschema Registry + SchemaStore tail.
+//
+// Sibling pattern — the persistence path matches register's tail bit
+// for bit: SaveGRPCSchema per service first, then a single
+// Registry.Register call. Source label is `reflection://<target_addr>`
+// so `list` distinguishes reflection-sourced entries from
+// descriptor_set / file ones.
+//
+// Defense layers (matching resend_grpc — Resolved #17, #19):
+//   - CRLF guards on target_addr / scheme / metadata
+//   - Target Scope on the canonical URL AND target address
+//   - Rate limit on the host (without port)
+//   - Budget gate via a synthetic GRPCStartMessage envelope passed
+//     through pipeline.NewBudgetStep
+//
+// Reflection chatter is NOT persisted as a Flow — schema management is
+// control-plane and the registered service's source_label already records
+// "we discovered from here" (Resolved #28 / U1).
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protoschema"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/pipeline"
+)
+
+// grpcSchemaDiscoverResult is the structured output of action=discover.
+//
+// Discovered carries the same shape as register's Registered[] and
+// list's Schemas[]. ReflectionVersion records which reflection service
+// variant (v1 or v1alpha) the upstream answered on — informational, to
+// help operators identify partly-upgraded reflection servers.
+type grpcSchemaDiscoverResult struct {
+	Discovered        []grpcSchemaServiceEntry `json:"discovered"`
+	Target            string                   `json:"target"`
+	ReflectionVersion string                   `json:"reflection_version,omitempty"`
+}
+
+// maxDiscoverTimeoutMs is the cap applied to user-supplied timeout_ms
+// values. Mirrors protoschema.MaxDiscoverTimeout in milliseconds.
+const maxDiscoverTimeoutMs = 300000
+
+// handleGRPCSchemaDiscover is the action=discover handler. It performs
+// every check on the resend_grpc dial path (CRLF / scope / rate / budget)
+// before invoking protoschema.Discover, then runs the discovered
+// descriptor set through the same Registry.Register + SchemaStore tail
+// as register.
+func (s *Server) handleGRPCSchemaDiscover(ctx context.Context, params grpcSchemaToolParams) (*grpcSchemaDiscoverResult, error) {
+	if s.flowStore.store == nil {
+		return nil, errors.New("flow store is not initialized")
+	}
+	if err := validateGRPCSchemaDiscoverInput(params); err != nil {
+		return nil, err
+	}
+
+	scheme, canonicalURL := buildGRPCSchemaDiscoverCanonical(params)
+	if err := s.checkGRPCSchemaDiscoverGates(ctx, scheme, canonicalURL, params); err != nil {
+		return nil, err
+	}
+
+	timeout := resolveGRPCSchemaDiscoverTimeout(params)
+	rtCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := s.applyGRPCSchemaDiscoverRateAndBudget(rtCtx, canonicalURL, params); err != nil {
+		return nil, err
+	}
+
+	discoverRes, err := protoschema.Discover(rtCtx, protoschema.DiscoverOptions{
+		TargetAddr:    params.TargetAddr,
+		Scheme:        scheme,
+		Transport:     s.connector.tlsTransport,
+		Metadata:      headerKVsToKeyValues(params.Metadata),
+		ServiceFilter: params.ServiceFilter,
+		Timeout:       timeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("grpc_schema discover: %w", err)
+	}
+
+	sourceLabel := "reflection://" + params.TargetAddr
+	if err := s.persistDiscoveredServices(rtCtx, discoverRes, sourceLabel); err != nil {
+		return nil, err
+	}
+
+	out := &grpcSchemaDiscoverResult{
+		Target:            params.TargetAddr,
+		ReflectionVersion: discoverRes.ReflectionVersion,
+		Discovered:        make([]grpcSchemaServiceEntry, 0, len(discoverRes.Services)),
+	}
+	for _, spec := range discoverRes.Services {
+		out.Discovered = append(out.Discovered, serviceSpecToEntry(spec))
+	}
+
+	slog.InfoContext(ctx, "grpc_schema discover complete",
+		"target", params.TargetAddr,
+		"reflection_version", discoverRes.ReflectionVersion,
+		"services_discovered", len(discoverRes.Services),
+		"descriptor_set_bytes", len(discoverRes.AssembledRawDescriptorSet),
+	)
+	return out, nil
+}
+
+// buildGRPCSchemaDiscoverCanonical returns the resolved scheme + the
+// canonical reflection URL used for scope and rate-limit checks.
+func buildGRPCSchemaDiscoverCanonical(params grpcSchemaToolParams) (string, *url.URL) {
+	scheme := strings.ToLower(strings.TrimSpace(params.Scheme))
+	if scheme == "" {
+		scheme = "https"
+	}
+	canonicalURL := &url.URL{
+		Scheme: scheme,
+		Host:   params.TargetAddr,
+		Path:   "/" + protoschema.ReflectionV1Service + "/" + protoschema.ReflectionMethod,
+	}
+	return scheme, canonicalURL
+}
+
+// checkGRPCSchemaDiscoverGates runs Target Scope on both the canonical
+// URL and the target address. Mirrors checkResendGRPCScope.
+func (s *Server) checkGRPCSchemaDiscoverGates(_ context.Context, scheme string, canonicalURL *url.URL, params grpcSchemaToolParams) error {
+	if err := s.checkTargetScopeURL(canonicalURL); err != nil {
+		return fmt.Errorf("grpc_schema discover: %w", err)
+	}
+	if err := s.checkTargetScopeAddr(scheme, params.TargetAddr); err != nil {
+		return fmt.Errorf("grpc_schema discover: %w", err)
+	}
+	return nil
+}
+
+// resolveGRPCSchemaDiscoverTimeout maps the user-supplied timeout_ms
+// (or its absence) to a clamped time.Duration.
+func resolveGRPCSchemaDiscoverTimeout(params grpcSchemaToolParams) time.Duration {
+	if params.TimeoutMs == nil || *params.TimeoutMs <= 0 {
+		return protoschema.DefaultDiscoverTimeout
+	}
+	ms := *params.TimeoutMs
+	if ms > maxDiscoverTimeoutMs {
+		ms = maxDiscoverTimeoutMs
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// applyGRPCSchemaDiscoverRateAndBudget runs the rate limiter then the
+// budget gate, returning the appropriate error if either trips.
+func (s *Server) applyGRPCSchemaDiscoverRateAndBudget(ctx context.Context, canonicalURL *url.URL, params grpcSchemaToolParams) error {
+	rateLimitHost, _, splitErr := net.SplitHostPort(params.TargetAddr)
+	if splitErr != nil {
+		rateLimitHost = params.TargetAddr
+	}
+	if err := s.waitRateLimit(ctx, rateLimitHost); err != nil {
+		return fmt.Errorf("grpc_schema discover: %w", err)
+	}
+	return s.applyGRPCSchemaDiscoverBudget(ctx, canonicalURL, params)
+}
+
+// persistDiscoveredServices writes each discovered ServiceSpec via
+// SaveGRPCSchema (all-or-nothing — Resolved #24) and finally calls
+// Registry.Register once.
+func (s *Server) persistDiscoveredServices(ctx context.Context, discoverRes *protoschema.DiscoverResult, sourceLabel string) error {
+	for _, spec := range discoverRes.Services {
+		if perr := s.flowStore.store.SaveGRPCSchema(ctx, spec.Service, discoverRes.AssembledRawDescriptorSet, sourceLabel); perr != nil {
+			return fmt.Errorf("grpc_schema discover: save schema for service %q: %w", spec.Service, perr)
+		}
+		spec.SourceLabel = sourceLabel
+	}
+	s.grpcSchemaRegistry().Register(discoverRes.Services)
+	return nil
+}
+
+// validateGRPCSchemaDiscoverInput enforces the discover-specific
+// preconditions: target_addr required, scheme is http/https when set,
+// no CRLF in target_addr/scheme/metadata. Cross-action params that
+// would silently be ignored under action=discover (descriptor_set_b64,
+// proto_paths, import_paths, service) are also rejected so the AI
+// agent doesn't accidentally combine modes.
+func validateGRPCSchemaDiscoverInput(params grpcSchemaToolParams) error {
+	if strings.TrimSpace(params.TargetAddr) == "" {
+		return errors.New("target_addr is required for action=discover")
+	}
+	if err := validateGRPCSchemaNoCRLF("target_addr", params.TargetAddr); err != nil {
+		return err
+	}
+	if err := validateGRPCSchemaNoCRLF("scheme", params.Scheme); err != nil {
+		return err
+	}
+	scheme := strings.ToLower(strings.TrimSpace(params.Scheme))
+	switch scheme {
+	case "", "http", "https":
+	default:
+		return fmt.Errorf("unsupported scheme %q: only http and https are allowed", params.Scheme)
+	}
+	if err := validateHeaderKVList(params.Metadata, "metadata"); err != nil {
+		return err
+	}
+	if params.TimeoutMs != nil {
+		if *params.TimeoutMs <= 0 {
+			return fmt.Errorf("timeout_ms must be positive (got %d)", *params.TimeoutMs)
+		}
+	}
+	if params.DescriptorSetB64 != "" {
+		return errors.New("descriptor_set_b64 is only valid with action=register source=\"descriptor_set\"")
+	}
+	if len(params.ProtoPaths) > 0 {
+		return errors.New("proto_paths is only valid with action=register source=\"file\"")
+	}
+	if len(params.ImportPaths) > 0 {
+		return errors.New("import_paths is only valid with action=register source=\"file\"")
+	}
+	if params.Service != "" {
+		return errors.New("service is only valid with action=unregister")
+	}
+	if params.Source != "" {
+		return fmt.Errorf("source %q is only valid with action=register (use action=discover to fetch from reflection)", params.Source)
+	}
+	return nil
+}
+
+// validateGRPCSchemaNoCRLF rejects CR/LF in user-supplied URL components
+// per the same hygiene applied by validateResendGRPCNoCRLF.
+func validateGRPCSchemaNoCRLF(field, v string) error {
+	if strings.ContainsAny(v, "\r\n") {
+		return fmt.Errorf("%s contains CR/LF characters", field)
+	}
+	return nil
+}
+
+// applyGRPCSchemaDiscoverBudget runs a synthetic Send-side
+// GRPCStartMessage envelope through pipeline.NewBudgetStep so the
+// discover call participates in the agent-wide budget accounting on
+// par with the resend / fuzz path. On Drop we synthesise an audit
+// Stream + return errBudgetExhausted (the canonical shape every
+// resend handler emits).
+func (s *Server) applyGRPCSchemaDiscoverBudget(ctx context.Context, canonicalURL *url.URL, params grpcSchemaToolParams) error {
+	if s.misc.budgetManager == nil {
+		return nil
+	}
+	streamID := uuid.NewString()
+	connID := uuid.NewString()
+	startEnv := &envelope.Envelope{
+		StreamID:  streamID,
+		FlowID:    uuid.NewString(),
+		Sequence:  0,
+		Direction: envelope.Send,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCStartMessage{
+			Service:     protoschema.ReflectionV1Service,
+			Method:      protoschema.ReflectionMethod,
+			Authority:   params.TargetAddr,
+			Scheme:      canonicalURL.Scheme,
+			Path:        canonicalURL.Path,
+			Metadata:    headerKVsToKeyValues(params.Metadata),
+			ContentType: "application/grpc+proto",
+		},
+		Context: envelope.EnvelopeContext{ConnID: connID},
+	}
+	step := pipeline.NewBudgetStep(s.misc.budgetManager)
+	pipe := pipeline.New(step)
+	post, action, _, blockedBy := pipe.RunWithBlockedBy(ctx, startEnv)
+	if action == pipeline.Drop {
+		if blockedBy == pipeline.BlockedByBudget {
+			recordBudgetBlockedStream(ctx, s.flowStore.store, post, streamID, flow.OriginResend)
+			return errBudgetExhausted
+		}
+		return errors.New("grpc_schema discover: synthetic envelope dropped by pipeline")
+	}
+	return nil
+}

--- a/internal/mcp/grpc_schema_discover_test.go
+++ b/internal/mcp/grpc_schema_discover_test.go
@@ -1,0 +1,354 @@
+// Package mcp grpc_schema_discover_test.go covers the grpc_schema MCP
+// tool's action=discover surface (USK-928). The tests use the exported
+// protoschema.SetReflectionDialForTest seam to plug a synthetic
+// reflection server into the discover code path — exercising the full
+// MCP handler (validation, scope, rate limit, budget, persist, list)
+// without standing up a real gRPC server.
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	v1 "google.golang.org/grpc/reflection/grpc_reflection_v1"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/encoding/protoschema"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+)
+
+// fakeMCPReflectionChannel is a paired implementation of
+// protoschema.ReflectionStreamChannel. Like the internal fake, it
+// services Send envelopes by queueing the matching response shape on
+// Next.
+type fakeMCPReflectionChannel struct {
+	t        *testing.T
+	service  string
+	services []string
+	files    map[string][][]byte
+	mode     string
+	pending  []*envelope.Envelope
+	reqIdx   int
+}
+
+func (c *fakeMCPReflectionChannel) Send(_ context.Context, env *envelope.Envelope) error {
+	switch m := env.Message.(type) {
+	case *envelope.GRPCStartMessage:
+		return nil
+	case *envelope.GRPCDataMessage:
+		if m.Payload == nil && m.WireLength == 0 && m.EndStream {
+			return nil
+		}
+		c.reqIdx++
+		if c.mode == "unimplemented" {
+			c.pending = append(c.pending, &envelope.Envelope{
+				Direction: envelope.Receive,
+				Protocol:  envelope.ProtocolGRPC,
+				Message: &envelope.GRPCEndMessage{
+					Status:  12, // UNIMPLEMENTED
+					Message: "not implemented",
+				},
+			})
+			return nil
+		}
+		req := &v1.ServerReflectionRequest{}
+		if err := proto.Unmarshal(m.Payload, req); err != nil {
+			return err
+		}
+		switch r := req.MessageRequest.(type) {
+		case *v1.ServerReflectionRequest_ListServices:
+			c.queueListServices()
+		case *v1.ServerReflectionRequest_FileContainingSymbol:
+			c.queueFileDescriptor(r.FileContainingSymbol)
+		}
+	case *envelope.GRPCEndMessage:
+		// no-op
+	}
+	return nil
+}
+
+func (c *fakeMCPReflectionChannel) Next(ctx context.Context) (*envelope.Envelope, error) {
+	if len(c.pending) == 0 {
+		return nil, errors.New("no pending envelopes")
+	}
+	env := c.pending[0]
+	c.pending = c.pending[1:]
+	return env, nil
+}
+
+func (c *fakeMCPReflectionChannel) queueListServices() {
+	respSvcs := make([]*v1.ServiceResponse, 0, len(c.services))
+	for _, s := range c.services {
+		respSvcs = append(respSvcs, &v1.ServiceResponse{Name: s})
+	}
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_ListServicesResponse{
+			ListServicesResponse: &v1.ListServiceResponse{Service: respSvcs},
+		},
+	}
+	c.queueResp(resp)
+}
+
+func (c *fakeMCPReflectionChannel) queueFileDescriptor(svc string) {
+	files, ok := c.files[svc]
+	if !ok {
+		c.queueErrorResp(5, "unknown symbol "+svc)
+		return
+	}
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_FileDescriptorResponse{
+			FileDescriptorResponse: &v1.FileDescriptorResponse{FileDescriptorProto: files},
+		},
+	}
+	c.queueResp(resp)
+}
+
+func (c *fakeMCPReflectionChannel) queueErrorResp(code int32, msg string) {
+	resp := &v1.ServerReflectionResponse{
+		MessageResponse: &v1.ServerReflectionResponse_ErrorResponse{
+			ErrorResponse: &v1.ErrorResponse{ErrorCode: code, ErrorMessage: msg},
+		},
+	}
+	c.queueResp(resp)
+}
+
+func (c *fakeMCPReflectionChannel) queueResp(resp *v1.ServerReflectionResponse) {
+	payload, err := proto.Marshal(resp)
+	if err != nil {
+		c.t.Fatalf("marshal response: %v", err)
+	}
+	c.pending = append(c.pending, &envelope.Envelope{
+		Direction: envelope.Receive,
+		Protocol:  envelope.ProtocolGRPC,
+		Message: &envelope.GRPCDataMessage{
+			WireLength: uint32(len(payload)),
+			Payload:    payload,
+		},
+	})
+}
+
+// mcpReflectionFileDescriptor returns a marshaled FileDescriptorProto
+// describing a single service+method. Mirrors the helper used by the
+// protoschema tests.
+func mcpReflectionFileDescriptor(t *testing.T, packageName, fileName, serviceName, methodName, inputMsg, outputMsg string) []byte {
+	t.Helper()
+	syntax := "proto3"
+	str := func(s string) *string { return &s }
+	fd := &descriptorpb.FileDescriptorProto{
+		Name:    &fileName,
+		Package: &packageName,
+		Syntax:  &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{
+			{Name: &inputMsg},
+			{Name: &outputMsg},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: &serviceName,
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       &methodName,
+						InputType:  str("." + packageName + "." + inputMsg),
+						OutputType: str("." + packageName + "." + outputMsg),
+					},
+				},
+			},
+		},
+	}
+	raw, err := proto.Marshal(fd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+// TestGRPCSchemaDiscover_Happy verifies the full action=discover MCP
+// path: synthetic reflection server → MCP handler → SaveGRPCSchema +
+// Register tail → list reports the discovered service with
+// source_label="reflection://...".
+func TestGRPCSchemaDiscover_Happy(t *testing.T) {
+	greeterFD := mcpReflectionFileDescriptor(t, "demo", "demo/greeter.proto", "Greeter", "SayHello", "HelloRequest", "HelloResponse")
+
+	restore := protoschema.SetReflectionDialForTest(func(service string) protoschema.ReflectionStreamChannel {
+		return &fakeMCPReflectionChannel{
+			t:        t,
+			service:  service,
+			services: []string{"demo.Greeter"},
+			files: map[string][][]byte{
+				"demo.Greeter": {greeterFD},
+			},
+		}
+	})
+	defer restore()
+
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "discover",
+		"params": map[string]any{
+			"target_addr": "127.0.0.1:9000",
+			"scheme":      "http",
+		},
+	})
+	if result.IsError {
+		t.Fatalf("discover error: %v", extractTextContent(result))
+	}
+
+	var out grpcSchemaDiscoverResult
+	unmarshalExecuteResult(t, result, &out)
+	if len(out.Discovered) != 1 || out.Discovered[0].Service != "demo.Greeter" {
+		t.Fatalf("Discovered = %+v, want [demo.Greeter]", out.Discovered)
+	}
+	if out.Target != "127.0.0.1:9000" {
+		t.Errorf("Target = %q, want 127.0.0.1:9000", out.Target)
+	}
+	if out.ReflectionVersion != "v1" {
+		t.Errorf("ReflectionVersion = %q, want v1", out.ReflectionVersion)
+	}
+	if out.Discovered[0].SourceLabel != "reflection://127.0.0.1:9000" {
+		t.Errorf("SourceLabel = %q, want reflection://127.0.0.1:9000", out.Discovered[0].SourceLabel)
+	}
+
+	// Verify list also surfaces the discovered entry with the same label.
+	listResult := callGRPCSchema(t, cs, map[string]any{"action": "list"})
+	var listOut grpcSchemaListResult
+	unmarshalExecuteResult(t, listResult, &listOut)
+	if len(listOut.Schemas) != 1 || listOut.Schemas[0].Service != "demo.Greeter" {
+		t.Fatalf("after discover, list = %+v", listOut.Schemas)
+	}
+	if listOut.Schemas[0].SourceLabel != "reflection://127.0.0.1:9000" {
+		t.Errorf("list SourceLabel = %q, want reflection://127.0.0.1:9000", listOut.Schemas[0].SourceLabel)
+	}
+}
+
+// TestGRPCSchemaDiscover_MissingTargetAddr verifies that target_addr is
+// required.
+func TestGRPCSchemaDiscover_MissingTargetAddr(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "discover",
+		"params": map[string]any{},
+	})
+	if !result.IsError {
+		t.Fatal("expected error when target_addr is missing")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "target_addr") {
+		t.Errorf("error must mention target_addr: %q", msg)
+	}
+}
+
+// TestGRPCSchemaDiscover_CRLFGuard verifies that CR/LF in target_addr
+// is rejected before any network egress.
+func TestGRPCSchemaDiscover_CRLFGuard(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "discover",
+		"params": map[string]any{
+			"target_addr": "127.0.0.1:9000\r\nX-Injected: 1",
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected CRLF rejection")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "CR/LF") {
+		t.Errorf("error must mention CR/LF: %q", msg)
+	}
+}
+
+// TestGRPCSchemaDiscover_TargetScope verifies that an out-of-scope
+// target_addr is rejected by the target scope check before any
+// network egress.
+func TestGRPCSchemaDiscover_TargetScope(t *testing.T) {
+	t.Parallel()
+	// Set a scope rule that does not include our target host.
+	ts := connector.NewTargetScope()
+	_ = ts.SetAgentRules([]connector.TargetRule{
+		{Hostname: "allowed.example.com"},
+	}, nil)
+
+	store := newTestStore(t)
+	s := newServer(context.Background(), nil, store, nil, WithTargetScope(ts))
+
+	_, err := s.handleGRPCSchemaDiscover(context.Background(), grpcSchemaToolParams{
+		TargetAddr: "blocked.example.com:9000",
+		Scheme:     "http",
+	})
+	if err == nil {
+		t.Fatal("expected target scope rejection")
+	}
+	if !strings.Contains(err.Error(), "scope") {
+		t.Errorf("error must mention scope: %v", err)
+	}
+}
+
+// TestGRPCSchemaDiscover_RejectsCrossActionFields verifies that supplying
+// descriptor_set_b64 / proto_paths under action=discover is rejected.
+func TestGRPCSchemaDiscover_RejectsCrossActionFields(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "discover",
+		"params": map[string]any{
+			"target_addr":        "127.0.0.1:9000",
+			"descriptor_set_b64": "Cg==",
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error when descriptor_set_b64 is set under action=discover")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "descriptor_set_b64") {
+		t.Errorf("error must mention descriptor_set_b64: %q", msg)
+	}
+}
+
+// TestGRPCSchemaDiscover_UnimplementedReturnsRemediationHint verifies
+// that a target that lacks reflection support surfaces the verbatim
+// "enable reflection" hint.
+func TestGRPCSchemaDiscover_UnimplementedReturnsRemediationHint(t *testing.T) {
+	restore := protoschema.SetReflectionDialForTest(func(service string) protoschema.ReflectionStreamChannel {
+		return &fakeMCPReflectionChannel{
+			t:       t,
+			service: service,
+			mode:    "unimplemented",
+		}
+	})
+	defer restore()
+
+	store := newTestStore(t)
+	cs := setupGRPCSchemaTestSession(t, store)
+
+	result := callGRPCSchema(t, cs, map[string]any{
+		"action": "discover",
+		"params": map[string]any{
+			"target_addr": "127.0.0.1:9000",
+			"scheme":      "http",
+		},
+	})
+	if !result.IsError {
+		t.Fatal("expected error when both v1 and v1alpha return UNIMPLEMENTED")
+	}
+	msg := extractTextContent(result)
+	if !strings.Contains(msg, "does not implement gRPC reflection") {
+		t.Errorf("error must include the canonical message: %q", msg)
+	}
+	if !strings.Contains(msg, "reflection.Register(s)") {
+		t.Errorf("error must include enable-reflection hint: %q", msg)
+	}
+}

--- a/internal/mcp/grpc_schema_tool.go
+++ b/internal/mcp/grpc_schema_tool.go
@@ -85,11 +85,24 @@ type grpcSchemaToolParams struct {
 	// each proto path. Each entry follows the same validation as
 	// ProtoPaths.
 	ImportPaths []string `json:"import_paths,omitempty" jsonschema:"optional absolute -I roots for protoc when source='file'; defaults to the parent directory of each proto path"`
+	// TargetAddr is the upstream host or host:port that exposes a gRPC
+	// reflection endpoint. Required for action=discover (USK-928).
+	TargetAddr string `json:"target_addr,omitempty" jsonschema:"required for action=discover: upstream host:port exposing the gRPC reflection endpoint"`
+	// Scheme selects http (h2c) vs https (TLS+ALPN h2) for discover.
+	// Defaults to https. Ignored for non-discover actions.
+	Scheme string `json:"scheme,omitempty" jsonschema:"discover only: http (h2c) or https (TLS); defaults to https"`
+	// Metadata forwards optional gRPC metadata on the reflection stream.
+	// Used for reflection endpoints that gate access behind a bearer
+	// token. Ignored for non-discover actions.
+	Metadata []headerKV `json:"metadata,omitempty" jsonschema:"discover only: ordered gRPC metadata list forwarded on the reflection stream (preserves order, case, duplicates)"`
+	// TimeoutMs caps the discover wall-clock budget. Default 30000;
+	// values above 300000 are clamped. Ignored for non-discover actions.
+	TimeoutMs *int `json:"timeout_ms,omitempty" jsonschema:"discover only: per-call timeout in milliseconds covering dial+handshake+RPC; default 30000, capped at 300000"`
 }
 
 // availableGRPCSchemaActions enumerates valid action names for the
 // grpc_schema tool's error message.
-var availableGRPCSchemaActions = []string{"register", "list", "unregister", "clear"}
+var availableGRPCSchemaActions = []string{"register", "list", "unregister", "clear", "discover"}
 
 // registerGRPCSchema wires the grpc_schema MCP tool.
 func (s *Server) registerGRPCSchema() {
@@ -100,7 +113,10 @@ func (s *Server) registerGRPCSchema() {
 			"source=\"descriptor_set\" + descriptor_set_b64 — the recommended path, generate via " +
 			"`protoc --include_imports --descriptor_set_out=<file> <protos>`, max 16 MiB decoded — or " +
 			"source=\"file\" + absolute proto_paths which invokes a host protoc binary), " +
-			"'list' (registered services + methods), 'unregister' (remove a service by name), 'clear' (remove all). " +
+			"'discover' (probe a target gRPC server's reflection endpoint and register every discovered service " +
+			"automatically; required target_addr; optional scheme/metadata/service_filter/timeout_ms; v1 with " +
+			"v1alpha fallback), 'list' (registered services + methods), 'unregister' (remove a service by name), " +
+			"'clear' (remove all). " +
 			"Once a schema is registered, query messages decodes matching gRPC Data bodies as protojson with real " +
 			"field names (body_decoded_encoding=\"proto-json\") and resend_grpc accepts body_encoding=\"proto-json\". " +
 			"Schemaless fallback always applies when no schema matches. See yorishiro://help/grpc_schema.",
@@ -146,6 +162,12 @@ func (s *Server) handleGRPCSchemaTool(ctx context.Context, _ *gomcp.CallToolRequ
 		return nil, res, nil
 	case "clear":
 		res, err := s.handleGRPCSchemaClear(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, res, nil
+	case "discover":
+		res, err := s.handleGRPCSchemaDiscover(ctx, input.Params)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/mcp/resources/help_grpc_schema.md
+++ b/internal/mcp/resources/help_grpc_schema.md
@@ -7,7 +7,7 @@ Once a schema is registered, the `query` tool decodes matching gRPC Data envelop
 ## Parameters
 
 ### action (string, required)
-One of: `register`, `list`, `unregister`, `clear`.
+One of: `register`, `list`, `unregister`, `clear`, `discover`.
 
 ### params (object)
 Action-specific parameters.
@@ -55,6 +55,31 @@ The proxy invokes a host `protoc` binary to compile a list of absolute `.proto` 
 
 Returns: `registered[]` — list of `{ service, methods: [{name, input, output}], source_label, registered_at }`.
 
+### discover
+
+Probe a target gRPC server's reflection endpoint and register every service it exposes. Mirrors `grpcurl -plaintext <addr> list` semantics but runs from inside the proxy so the same TLS / mTLS / upstream-proxy / Target Scope / rate-limit / budget gates that protect resend traffic apply here too.
+
+The proxy opens an outbound bidi gRPC stream to `grpc.reflection.v1.ServerReflection/ServerReflectionInfo`. If the server returns gRPC status `UNIMPLEMENTED` (12), the proxy retries once against the legacy v1alpha service path. Any other failure surfaces verbatim.
+
+**Parameters:**
+- **target_addr** (string, required): Upstream host or `host:port` exposing the reflection endpoint.
+- **scheme** (string, optional): `http` (h2c) or `https` (TLS + ALPN h2). Defaults to `https`.
+- **service_filter** (array of strings, optional): Restrict the fetch to these fully-qualified service names. Each entry must appear in the target's `ListServices` reply — a missing entry produces an error listing the services the target actually exposed.
+- **metadata** (array of `{name, value}`, optional): Ordered gRPC metadata list forwarded on the reflection stream. Useful for reflection endpoints gated by a bearer token.
+- **timeout_ms** (integer, optional): Per-call timeout covering dial+handshake+RPC. Defaults to `30000`; capped at `300000`.
+
+The proxy reuses the same `TLSTransport` as `resend_grpc`, so any configured mTLS or upstream-proxy applies automatically. SourceLabel on the registered entry is `reflection://<target_addr>` so `list` distinguishes reflection-discovered schemas.
+
+The reflection chatter itself is **not** persisted as a Flow — schema management is control-plane and the registered service's `source_label` already records "we discovered from here".
+
+When the target lacks reflection support (both v1 and v1alpha return UNIMPLEMENTED), the call fails with:
+
+```
+target "<addr>" does not implement gRPC reflection (server returned gRPC status UNIMPLEMENTED for both v1 and v1alpha). Enable reflection on the target server: for grpc-go, import google.golang.org/grpc/reflection and call reflection.Register(s); for other runtimes see https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
+```
+
+Returns: `{ discovered[], target, reflection_version }` — same entry shape as `register`'s `registered[]`. `reflection_version` is `"v1"` or `"v1alpha"` (informational).
+
 ### list
 Return every currently registered schema, ordered alphabetically by service name.
 
@@ -96,6 +121,18 @@ Returns: `{ cleared }` — number of rows deleted from persistent storage.
     "source": "file",
     "proto_paths": ["/srv/protos/greeter.proto"],
     "import_paths": ["/srv/protos"],
+    "service_filter": ["pkg.Greeter"]
+  }
+}
+```
+
+### Discover via reflection
+```json
+{
+  "action": "discover",
+  "params": {
+    "target_addr": "127.0.0.1:9000",
+    "scheme": "http",
     "service_filter": ["pkg.Greeter"]
   }
 }
@@ -171,6 +208,6 @@ For lossless round-trips, use `body_encoding="proto-schemaless-json"` (synthetic
 - **Last-write-wins.** Re-registering a service replaces its previous binding. The `list` output shows the most recent registration for each service.
 - **Persistence.** Registrations survive process restart via the `grpc_schemas` SQLite table.
 - **`source="file"` requires a host `protoc`.** The recommended path is still `source="descriptor_set"`: run `protoc --include_imports --descriptor_set_out=…` on the operator machine and pass the base64-encoded bytes. Use the file path only when invoking `protoc` server-side is acceptable in your environment. The proxy resolves the binary from `YP_PROTOC_BINARY` → `ProxyConfig.GRPCSchema.ProtocBinary` → `PATH:protoc`.
-- **Reflection-based discovery is not supported.** Server-reflection auto-discovery is deferred to a follow-up Issue.
+- **`action="discover"` reflection chatter is not recorded as a Flow.** Schema management is control-plane; the registered entry's `source_label` already records `reflection://<target_addr>` for traceability. Use `resend_grpc` if you need to round-trip a recorded reflection RPC for analysis.
 - **Case-sensitive lookup.** Protobuf service/method identifiers are case-sensitive per spec. The lookup against `Flow.Metadata["grpc_service"]` / `["grpc_method"]` is exact-match.
 - **Output Filter still applies.** PII patterns (credit cards, etc.) configured in the safety engine mask the protojson output before it leaves the MCP boundary.


### PR DESCRIPTION
## Summary
- Add `action="discover"` to the grpc_schema MCP tool; the proxy probes a target's gRPC reflection endpoint (v1 with v1alpha fallback) and registers the discovered schemas via the existing Registry + SchemaStore tail.
- New file `internal/encoding/protoschema/reflection.go` drives the bidi reflection RPC via the in-house `http2.Layer` + `grpclayer.Wrap` — no `grpc-go` runtime dependency. Only the v1 proto types are imported; since v1alpha shares identical field numbers, marshaling as v1 produces wire bytes a v1alpha server accepts (only the `:path` service component differs on fallback).
- Reuses `s.connector.tlsTransport` so TLS / mTLS / upstream-proxy are inherited from the resend dial path automatically. Target Scope + rate limit + budget all apply.
- Errors when the target lacks reflection include a remediation hint pointing at `reflection.Register(s)` (grpc-go) and the upstream spec doc.
- Reflection chatter is NOT recorded as a Flow (control-plane only); the registered schema's `source_label` is `reflection://<target_addr>` so `list` distinguishes reflection-sourced entries.
- `help_grpc_schema.md` documents the new action; the "Reflection-based discovery is not supported." line is struck.

## Test plan
- [x] Unit: happy path against in-process reflection server (v1)
- [x] Unit: v1alpha fallback
- [x] Unit: UNIMPLEMENTED on both → verbatim error with hint
- [x] Unit: zero services → empty-registry error
- [x] Unit: partial discovery aborts (all-or-nothing)
- [x] Unit: size cap on assembled FileDescriptorSet
- [x] Unit: service_filter validation
- [x] Unit: reflection's own services stripped from candidates
- [x] Unit: filename-keyed dedup across services
- [x] Unit: input validation (target_addr required, scheme allowlist, https requires TLSTransport)
- [x] MCP: happy path through grpc_schema tool, list verifies source_label
- [x] MCP: target_addr missing → validation error
- [x] MCP: Target Scope rejection
- [x] MCP: CRLF guard on target_addr
- [x] MCP: cross-action field rejection (descriptor_set_b64 under action=discover)
- [x] MCP: UNIMPLEMENTED → verbatim error with hint
- [x] `make lint` / `make build` / `make test` / `make test-e2e-smoke` all green

Resolves USK-928
Linear: https://linear.app/usk6666/issue/USK-928

🤖 Generated with [Claude Code](https://claude.com/claude-code)