### PR TITLE
feat(webui,mcp): grpc_schema management panel (USK-927)

### DIFF
--- a/web/src/lib/mcp/client.ts
+++ b/web/src/lib/mcp/client.ts
@@ -17,6 +17,11 @@ import type {
   ConnectionStatus,
   ExecuteParams,
   FuzzToolParams,
+  GrpcSchemaClearResult,
+  GrpcSchemaListResult,
+  GrpcSchemaParams,
+  GrpcSchemaRegisterResult,
+  GrpcSchemaUnregisterResult,
   InterceptActionParams,
   MacroToolParams,
   ManageParams,
@@ -38,6 +43,18 @@ import type {
   ResendWSResult,
   SecurityParams,
 } from "./types.js";
+
+/**
+ * Union of grpc_schema action results, keyed by the same `action` value
+ * passed in `GrpcSchemaParams`. Callers narrow with `as`-casts or
+ * `switch (params.action)` since the wire response shape depends on the
+ * action discriminator only.
+ */
+export type GrpcSchemaResult =
+  | GrpcSchemaRegisterResult
+  | GrpcSchemaListResult
+  | GrpcSchemaUnregisterResult
+  | GrpcSchemaClearResult;
 
 /** Configuration for the MCP client. */
 export interface McpClientConfig {
@@ -317,6 +334,24 @@ export class McpClient {
   async resendRaw(params: ResendRawParams): Promise<ResendRawTypedResult> {
     return this.callTool<ResendRawTypedResult>(
       "resend_raw",
+      params as unknown as Record<string, unknown>,
+    );
+  }
+
+  /**
+   * Manage gRPC .proto schemas (USK-923 / USK-926).
+   *
+   * Single MCP entry with an `action` discriminator. Returns the
+   * action-specific result shape — callers narrow on `params.action`
+   * (`GrpcSchemaResult` is the typed union). Used by the
+   * `useGrpcSchema` / `useGrpcSchemaList` hooks driving the Settings
+   * `gRPC Schemas` panel.
+   */
+  async grpcSchema<R extends GrpcSchemaResult = GrpcSchemaResult>(
+    params: GrpcSchemaParams,
+  ): Promise<R> {
+    return this.callTool<R>(
+      "grpc_schema",
       params as unknown as Record<string, unknown>,
     );
   }

--- a/web/src/lib/mcp/hooks.ts
+++ b/web/src/lib/mcp/hooks.ts
@@ -10,12 +10,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMcpContext } from "./context.js";
 import type { McpClient } from "./client.js";
+import type { GrpcSchemaResult } from "./client.js";
 import type {
   ConfigureParams,
   ConfigureResult,
   ConnectionStatus,
   ExecuteParams,
   FuzzToolParams,
+  GrpcSchemaListResult,
+  GrpcSchemaParams,
   InterceptActionParams,
   MacroToolParams,
   ManageParams,
@@ -689,6 +692,101 @@ export function usePluginIntrospect(): UsePluginIntrospectResult {
     setError(null);
     try {
       const result = await client.pluginIntrospect();
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [client, status]);
+
+  useEffect(() => {
+    if (status !== "connected") return;
+    refetch();
+  }, [status, refetch]);
+
+  return { data, loading, error, refetch };
+}
+
+// ---------------------------------------------------------------------------
+// useGrpcSchema — grpc_schema tool (register / unregister / clear actions)
+// ---------------------------------------------------------------------------
+
+/** Return type for useGrpcSchema. */
+export interface UseGrpcSchemaResult {
+  /** Execute a grpc_schema action. Returns the action-specific result. */
+  grpcSchema: <R extends GrpcSchemaResult = GrpcSchemaResult>(
+    params: GrpcSchemaParams,
+  ) => Promise<R>;
+  /** Whether a grpc_schema operation is in progress. */
+  loading: boolean;
+  /** Last grpc_schema error, if any. */
+  error: Error | null;
+}
+
+/**
+ * Hook to call the MCP grpc_schema tool (register / unregister / clear).
+ *
+ * For the `list` action prefer {@link useGrpcSchemaList}, which auto-fetches
+ * on connect and exposes `refetch`. This hook covers the mutating actions
+ * (register, unregister, clear) and matches the action-hook shape used
+ * elsewhere in this module.
+ *
+ * @example
+ * ```tsx
+ * const { grpcSchema, loading } = useGrpcSchema();
+ * await grpcSchema({ action: "unregister", params: { service: "pkg.Svc" } });
+ * ```
+ */
+export function useGrpcSchema(): UseGrpcSchemaResult {
+  const { execute, loading, error } = useMcpAction(
+    (client: McpClient, params: GrpcSchemaParams) => client.grpcSchema(params),
+  );
+  return {
+    grpcSchema: execute as <R extends GrpcSchemaResult = GrpcSchemaResult>(
+      params: GrpcSchemaParams,
+    ) => Promise<R>,
+    loading,
+    error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useGrpcSchemaList — grpc_schema action="list" auto-fetch hook
+// ---------------------------------------------------------------------------
+
+/** Return type for useGrpcSchemaList. */
+export interface UseGrpcSchemaListResult {
+  /** Latest list snapshot. Null while the first fetch is in flight. */
+  data: GrpcSchemaListResult | null;
+  /** Whether a fetch is currently in progress. */
+  loading: boolean;
+  /** Last fetch error, if any. */
+  error: Error | null;
+  /** Manually re-fetch the schema list. */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook that auto-fetches the grpc_schema list when the MCP client connects.
+ * Modelled on {@link usePluginIntrospect}: parameterless query-style hook
+ * with `data` / `loading` / `error` / `refetch`. Callers should `refetch()`
+ * after a mutating action (register / unregister / clear).
+ */
+export function useGrpcSchemaList(): UseGrpcSchemaListResult {
+  const { client, status } = useMcpContext();
+  const [data, setData] = useState<GrpcSchemaListResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!client || status !== "connected") return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await client.grpcSchema<GrpcSchemaListResult>({
+        action: "list",
+      });
       setData(result);
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));

--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -1573,6 +1573,80 @@ export interface ResendRawTypedResult {
 }
 
 // ---------------------------------------------------------------------------
+// grpc_schema tool — schema-aware gRPC .proto management (USK-923 / USK-926)
+// ---------------------------------------------------------------------------
+
+/** Available grpc_schema actions. */
+export type GrpcSchemaAction =
+  | "register"
+  | "list"
+  | "unregister"
+  | "clear";
+
+/** Descriptor input shape for action=register. */
+export type GrpcSchemaSource = "descriptor_set" | "file";
+
+/** Action-specific parameters for the grpc_schema tool. */
+export interface GrpcSchemaToolParams {
+  /** Source mode (register only). */
+  source?: GrpcSchemaSource;
+  /** Base64-encoded FileDescriptorSet payload (register, source=descriptor_set). Max 16 MiB decoded. */
+  descriptor_set_b64?: string;
+  /** Optional service-name allowlist applied during register. */
+  service_filter?: string[];
+  /** Free-form diagnostic label preserved in list output. */
+  source_label?: string;
+  /** Fully-qualified service name (unregister only). */
+  service?: string;
+  /** Absolute .proto paths (register, source=file). */
+  proto_paths?: string[];
+  /** Optional -I roots for protoc (register, source=file). */
+  import_paths?: string[];
+}
+
+/** Parameters for the grpc_schema MCP tool. */
+export interface GrpcSchemaParams {
+  action: GrpcSchemaAction;
+  params?: GrpcSchemaToolParams;
+}
+
+/** One method entry inside a registered gRPC service. */
+export interface GrpcSchemaMethodEntry {
+  name: string;
+  input: string;
+  output: string;
+}
+
+/** One service entry returned by register / list. */
+export interface GrpcSchemaServiceEntry {
+  service: string;
+  methods: GrpcSchemaMethodEntry[];
+  source_label?: string;
+  registered_at?: string;
+}
+
+/** Result of grpc_schema action=register. */
+export interface GrpcSchemaRegisterResult {
+  registered: GrpcSchemaServiceEntry[];
+}
+
+/** Result of grpc_schema action=list. */
+export interface GrpcSchemaListResult {
+  schemas: GrpcSchemaServiceEntry[];
+}
+
+/** Result of grpc_schema action=unregister. */
+export interface GrpcSchemaUnregisterResult {
+  service: string;
+  unregistered: boolean;
+}
+
+/** Result of grpc_schema action=clear. */
+export interface GrpcSchemaClearResult {
+  cleared: number;
+}
+
+// ---------------------------------------------------------------------------
 // MCP client connection state
 // ---------------------------------------------------------------------------
 

--- a/web/src/pages/Settings/GrpcSchemas.tsx
+++ b/web/src/pages/Settings/GrpcSchemas.tsx
@@ -1,0 +1,646 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  Badge,
+  Button,
+  Input,
+  Spinner,
+  useDialog,
+  useToast,
+} from "../../components/ui/index.js";
+import {
+  useGrpcSchema,
+  useGrpcSchemaList,
+} from "../../lib/mcp/hooks.js";
+import type {
+  GrpcSchemaClearResult,
+  GrpcSchemaRegisterResult,
+  GrpcSchemaServiceEntry,
+  GrpcSchemaUnregisterResult,
+} from "../../lib/mcp/types.js";
+
+/**
+ * Maximum decoded descriptor_set size accepted by the proxy server,
+ * mirrored client-side as a preflight check (USK-927 design review #5).
+ * Server-side cap lives at
+ * `internal/encoding/protoschema/registry.go:MaxDescriptorSetBytes`.
+ */
+const MAX_DESCRIPTOR_BYTES = 16 * 1024 * 1024;
+
+/** Chunk size used during base64 encoding to avoid stack overflow. */
+const BASE64_CHUNK_SIZE = 0x8000; // 32 KiB
+
+/**
+ * Convert a Uint8Array to a base64 string in chunks. Large
+ * `String.fromCharCode.apply()` calls overflow the JS argument-stack limit
+ * around a few hundred KiB; chunking keeps each apply() call below the
+ * 32 KiB threshold so files up to the 16 MiB cap encode safely.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += BASE64_CHUNK_SIZE) {
+    const chunk = bytes.subarray(i, i + BASE64_CHUNK_SIZE);
+    binary += String.fromCharCode.apply(
+      null,
+      chunk as unknown as number[],
+    );
+  }
+  return btoa(binary);
+}
+
+/**
+ * Split a textarea's value into a trimmed, non-empty string list (one
+ * entry per line). Used for service_filter, proto_paths, import_paths.
+ */
+function splitLines(value: string): string[] {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Render the methods column for a single service row. */
+function MethodsList({ methods }: { methods: GrpcSchemaServiceEntry["methods"] }) {
+  if (!methods || methods.length === 0) {
+    return <span className="settings-rule-detail">No methods</span>;
+  }
+  const renderText = methods
+    .map((m) => `${m.name}(${m.input}) → ${m.output}`)
+    .join(", ");
+  // Collapse beyond 5 methods to keep the row scan-friendly.
+  if (methods.length > 5) {
+    return (
+      <details>
+        <summary
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--font-size-xs)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          {methods.length} methods (expand)
+        </summary>
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--font-size-xs)",
+            color: "var(--text-secondary)",
+            wordBreak: "break-all",
+          }}
+        >
+          {renderText}
+        </span>
+      </details>
+    );
+  }
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--font-size-xs)",
+        color: "var(--text-secondary)",
+        wordBreak: "break-all",
+      }}
+    >
+      {renderText}
+    </span>
+  );
+}
+
+/**
+ * GrpcSchemas — operator-facing management panel for the `grpc_schema`
+ * MCP tool (USK-923 / USK-926 / USK-927).
+ *
+ * Surfaces:
+ *   - List of registered services with method signatures, source label,
+ *     and registered timestamp.
+ *   - Per-row Unregister button (confirm dialog).
+ *   - Clear-all action (confirm dialog).
+ *   - Descriptor_set upload form (.desc → base64, 16 MiB preflight).
+ *   - Collapsed disclosure for source="file" (proto_paths + import_paths).
+ *
+ * Discovery (USK-928 reflection) is intentionally out of scope; tracked
+ * by a follow-up Issue per USK-927 design review D1.
+ */
+export function GrpcSchemas() {
+  const { addToast } = useToast();
+  const { showDialog } = useDialog();
+  const { data, loading: listLoading, error: listError, refetch } =
+    useGrpcSchemaList();
+  const { grpcSchema, loading: actionLoading } = useGrpcSchema();
+
+  // Upload (descriptor_set) form state.
+  const [showUploadForm, setShowUploadForm] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [serviceFilterText, setServiceFilterText] = useState("");
+  const [sourceLabel, setSourceLabel] = useState("");
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // File-mode (source="file") form state.
+  const [protoPathsText, setProtoPathsText] = useState("");
+  const [importPathsText, setImportPathsText] = useState("");
+  const [fileModeServiceFilter, setFileModeServiceFilter] = useState("");
+  const [fileModeSourceLabel, setFileModeSourceLabel] = useState("");
+
+  const schemas = data?.schemas ?? [];
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0] ?? null;
+      if (file && file.size > MAX_DESCRIPTOR_BYTES) {
+        addToast({
+          type: "error",
+          message: `File exceeds 16 MiB limit (${(file.size / 1024 / 1024).toFixed(2)} MiB)`,
+        });
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+        setSelectedFile(null);
+        return;
+      }
+      setSelectedFile(file);
+      // Default the source label to the file name so the operator can
+      // see/edit before submit (design review #7).
+      if (file && !sourceLabel.trim()) {
+        setSourceLabel(file.name);
+      }
+    },
+    [addToast, sourceLabel],
+  );
+
+  const resetUploadForm = useCallback(() => {
+    setSelectedFile(null);
+    setServiceFilterText("");
+    setSourceLabel("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) {
+      addToast({ type: "warning", message: "Select a .desc file to upload" });
+      return;
+    }
+    if (selectedFile.size > MAX_DESCRIPTOR_BYTES) {
+      addToast({
+        type: "error",
+        message: `File exceeds 16 MiB limit (${(selectedFile.size / 1024 / 1024).toFixed(2)} MiB)`,
+      });
+      return;
+    }
+    try {
+      const buf = await selectedFile.arrayBuffer();
+      const bytes = new Uint8Array(buf);
+      const b64 = bytesToBase64(bytes);
+      const serviceFilter = splitLines(serviceFilterText);
+      const result = await grpcSchema<GrpcSchemaRegisterResult>({
+        action: "register",
+        params: {
+          source: "descriptor_set",
+          descriptor_set_b64: b64,
+          ...(serviceFilter.length > 0 ? { service_filter: serviceFilter } : {}),
+          ...(sourceLabel.trim() ? { source_label: sourceLabel.trim() } : {}),
+        },
+      });
+      const count = result.registered?.length ?? 0;
+      addToast({
+        type: "success",
+        message: `Registered ${count} service${count === 1 ? "" : "s"} from "${selectedFile.name}"`,
+      });
+      resetUploadForm();
+      setShowUploadForm(false);
+      await refetch();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Upload failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }, [
+    selectedFile,
+    serviceFilterText,
+    sourceLabel,
+    grpcSchema,
+    addToast,
+    refetch,
+    resetUploadForm,
+  ]);
+
+  const handleFileModeRegister = useCallback(async () => {
+    const protoPaths = splitLines(protoPathsText);
+    if (protoPaths.length === 0) {
+      addToast({
+        type: "warning",
+        message: "Add at least one absolute .proto file path",
+      });
+      return;
+    }
+    const importPaths = splitLines(importPathsText);
+    const serviceFilter = splitLines(fileModeServiceFilter);
+    try {
+      const result = await grpcSchema<GrpcSchemaRegisterResult>({
+        action: "register",
+        params: {
+          source: "file",
+          proto_paths: protoPaths,
+          ...(importPaths.length > 0 ? { import_paths: importPaths } : {}),
+          ...(serviceFilter.length > 0 ? { service_filter: serviceFilter } : {}),
+          ...(fileModeSourceLabel.trim()
+            ? { source_label: fileModeSourceLabel.trim() }
+            : {}),
+        },
+      });
+      const count = result.registered?.length ?? 0;
+      addToast({
+        type: "success",
+        message: `Registered ${count} service${count === 1 ? "" : "s"} via protoc`,
+      });
+      setProtoPathsText("");
+      setImportPathsText("");
+      setFileModeServiceFilter("");
+      setFileModeSourceLabel("");
+      await refetch();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `protoc register failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }, [
+    protoPathsText,
+    importPathsText,
+    fileModeServiceFilter,
+    fileModeSourceLabel,
+    grpcSchema,
+    addToast,
+    refetch,
+  ]);
+
+  const handleUnregister = useCallback(
+    async (service: string) => {
+      const confirmed = await showDialog({
+        title: "Unregister schema",
+        message: `Unregister service ${service}?`,
+        variant: "confirm",
+        confirmLabel: "Unregister",
+        confirmVariant: "danger",
+      });
+      if (!confirmed) return;
+      try {
+        const result = await grpcSchema<GrpcSchemaUnregisterResult>({
+          action: "unregister",
+          params: { service },
+        });
+        if (result.unregistered) {
+          addToast({ type: "success", message: `Unregistered ${service}` });
+        } else {
+          addToast({
+            type: "warning",
+            message: `Service ${service} was not registered`,
+          });
+        }
+        await refetch();
+      } catch (err) {
+        addToast({
+          type: "error",
+          message: `Unregister failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    },
+    [grpcSchema, addToast, refetch, showDialog],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    const count = schemas.length;
+    if (count === 0) return;
+    const confirmed = await showDialog({
+      title: "Clear all gRPC schemas",
+      message: `All ${count} registered schema${count === 1 ? "" : "s"} will be removed. Continue?`,
+      variant: "confirm",
+      confirmLabel: "Clear all",
+      confirmVariant: "danger",
+    });
+    if (!confirmed) return;
+    try {
+      const result = await grpcSchema<GrpcSchemaClearResult>({
+        action: "clear",
+      });
+      addToast({
+        type: "success",
+        message: `Cleared ${result.cleared} schema${result.cleared === 1 ? "" : "s"}`,
+      });
+      await refetch();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Clear failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }, [schemas.length, grpcSchema, addToast, refetch, showDialog]);
+
+  return (
+    <div className="settings-section">
+      {/* Schema list section */}
+      <div className="settings-card">
+        <div className="settings-card-header">
+          <span className="settings-card-title">
+            Registered gRPC Schemas ({schemas.length})
+          </span>
+          <div className="settings-card-actions">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setShowUploadForm(!showUploadForm)}
+            >
+              {showUploadForm ? "Cancel" : "Upload .desc"}
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={handleClearAll}
+              disabled={schemas.length === 0 || actionLoading}
+            >
+              Clear all
+            </Button>
+          </div>
+        </div>
+        <div className="settings-card-body">
+          <p className="settings-section-desc">
+            Registered .proto schemas drive schema-aware decode in <code>query messages</code>
+            {" "}(<code>body_decoded_encoding=&quot;proto-json&quot;</code>) and accept{" "}
+            <code>body_encoding=&quot;proto-json&quot;</code> on <code>resend_grpc</code>.
+            Schemaless fallback applies when no schema matches a flow.
+          </p>
+
+          {/* Upload form (descriptor_set source) */}
+          {showUploadForm && (
+            <div
+              className="settings-add-form"
+              style={{ marginBottom: "var(--space-md)" }}
+            >
+              <div className="settings-add-form-title">
+                Upload FileDescriptorSet (.desc)
+              </div>
+              <p className="settings-section-desc">
+                Generate the descriptor with{" "}
+                <code>protoc --include_imports --descriptor_set_out=out.desc *.proto</code>
+                {" "}on your operator machine, then upload the resulting{" "}
+                <code>.desc</code> file here (max 16 MiB).
+              </p>
+              <div className="settings-form-row">
+                <div className="input-wrapper">
+                  <label
+                    className="input-label"
+                    htmlFor="grpc-schema-file-input"
+                  >
+                    Descriptor file
+                  </label>
+                  <input
+                    ref={fileInputRef}
+                    id="grpc-schema-file-input"
+                    type="file"
+                    accept=".desc,.pb,.bin,application/octet-stream"
+                    onChange={handleFileChange}
+                    aria-describedby="grpc-schema-file-hint"
+                  />
+                  <span
+                    id="grpc-schema-file-hint"
+                    className="settings-rule-detail"
+                  >
+                    .desc / .pb / .bin (FileDescriptorSet); max 16 MiB
+                  </span>
+                </div>
+              </div>
+              <div className="settings-form-row">
+                <Input
+                  label="Source label (optional)"
+                  value={sourceLabel}
+                  onChange={(e) => setSourceLabel(e.target.value)}
+                  placeholder="Defaults to the file name"
+                />
+              </div>
+              <div className="settings-form-row">
+                <div className="input-wrapper" style={{ flex: 1 }}>
+                  <label
+                    className="input-label"
+                    htmlFor="grpc-schema-service-filter"
+                  >
+                    Service filter (optional, one per line)
+                  </label>
+                  <textarea
+                    id="grpc-schema-service-filter"
+                    className="input"
+                    value={serviceFilterText}
+                    onChange={(e) => setServiceFilterText(e.target.value)}
+                    placeholder={"pkg.Service1\npkg.Service2"}
+                    rows={3}
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      resize: "vertical",
+                      minHeight: "60px",
+                    }}
+                  />
+                  <span className="settings-rule-detail">
+                    Fully-qualified service names. Leave blank to register every service in the descriptor.
+                  </span>
+                </div>
+              </div>
+              <div className="settings-add-form-actions">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    resetUploadForm();
+                    setShowUploadForm(false);
+                  }}
+                  disabled={actionLoading}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleUpload}
+                  disabled={!selectedFile || actionLoading}
+                >
+                  {actionLoading ? "Uploading..." : "Register"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Schema list */}
+          {listLoading && !data ? (
+            <div className="settings-loading">
+              <Spinner size="md" />
+            </div>
+          ) : listError ? (
+            <div className="settings-error">
+              Error loading schemas: {listError.message}
+            </div>
+          ) : schemas.length === 0 ? (
+            <div className="settings-empty">
+              No gRPC schemas registered
+            </div>
+          ) : (
+            <div className="settings-item-list">
+              {schemas.map((schema) => (
+                <div key={schema.service} className="settings-rule">
+                  <div className="settings-rule-info">
+                    <span className="settings-rule-id">{schema.service}</span>
+                    <MethodsList methods={schema.methods} />
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: "var(--space-xs)",
+                        marginTop: "var(--space-xs)",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      {schema.source_label && (
+                        <Badge variant="info">{schema.source_label}</Badge>
+                      )}
+                      {schema.registered_at && (
+                        <span className="settings-rule-detail">
+                          Registered: {schema.registered_at}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="settings-rule-actions">
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => handleUnregister(schema.service)}
+                      disabled={actionLoading}
+                    >
+                      Unregister
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* File-mode (source="file") disclosure */}
+      <div className="settings-card">
+        <div className="settings-card-header">
+          <span className="settings-card-title">Advanced</span>
+        </div>
+        <div className="settings-card-body">
+          <details>
+            <summary
+              style={{
+                cursor: "pointer",
+                color: "var(--text-secondary)",
+                fontSize: "var(--font-size-sm)",
+                marginBottom: "var(--space-sm)",
+              }}
+            >
+              Compile from .proto files (advanced)
+            </summary>
+            <p className="settings-section-desc">
+              The proxy invokes its host <code>protoc</code> binary against
+              the listed absolute paths. Paths must be canonical and fall
+              under the proxy CWD or one of the import paths. Operation has
+              a 30 s timeout (server-enforced).
+            </p>
+            <div className="settings-form-row">
+              <div className="input-wrapper" style={{ flex: 1 }}>
+                <label
+                  className="input-label"
+                  htmlFor="grpc-schema-proto-paths"
+                >
+                  Proto paths (one absolute path per line)
+                </label>
+                <textarea
+                  id="grpc-schema-proto-paths"
+                  className="input"
+                  value={protoPathsText}
+                  onChange={(e) => setProtoPathsText(e.target.value)}
+                  placeholder={"/absolute/path/to/foo.proto\n/absolute/path/to/bar.proto"}
+                  rows={3}
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    resize: "vertical",
+                    minHeight: "60px",
+                  }}
+                />
+              </div>
+            </div>
+            <div className="settings-form-row">
+              <div className="input-wrapper" style={{ flex: 1 }}>
+                <label
+                  className="input-label"
+                  htmlFor="grpc-schema-import-paths"
+                >
+                  Import paths (optional, one per line)
+                </label>
+                <textarea
+                  id="grpc-schema-import-paths"
+                  className="input"
+                  value={importPathsText}
+                  onChange={(e) => setImportPathsText(e.target.value)}
+                  placeholder={"/absolute/path/to/protoroot1\n/absolute/path/to/protoroot2"}
+                  rows={2}
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    resize: "vertical",
+                    minHeight: "40px",
+                  }}
+                />
+                <span className="settings-rule-detail">
+                  Passed to <code>protoc -I&lt;root&gt;</code>. Defaults to each proto path&apos;s parent directory.
+                </span>
+              </div>
+            </div>
+            <div className="settings-form-row">
+              <Input
+                label="Source label (optional)"
+                value={fileModeSourceLabel}
+                onChange={(e) => setFileModeSourceLabel(e.target.value)}
+                placeholder="Defaults to comma-joined basenames"
+              />
+            </div>
+            <div className="settings-form-row">
+              <div className="input-wrapper" style={{ flex: 1 }}>
+                <label
+                  className="input-label"
+                  htmlFor="grpc-schema-file-service-filter"
+                >
+                  Service filter (optional, one per line)
+                </label>
+                <textarea
+                  id="grpc-schema-file-service-filter"
+                  className="input"
+                  value={fileModeServiceFilter}
+                  onChange={(e) => setFileModeServiceFilter(e.target.value)}
+                  placeholder={"pkg.Service1\npkg.Service2"}
+                  rows={2}
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    resize: "vertical",
+                    minHeight: "40px",
+                  }}
+                />
+              </div>
+            </div>
+            <div className="settings-add-form-actions">
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleFileModeRegister}
+                disabled={actionLoading || protoPathsText.trim().length === 0}
+              >
+                {actionLoading ? "Compiling..." : "Compile and register"}
+              </Button>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Settings/SettingsPage.tsx
+++ b/web/src/pages/Settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { CACertPanel } from "./CACertPanel.js";
 import { CaptureScope } from "./CaptureScope.js";
 import { ClientCertificate } from "./ClientCertificate.js";
 import { ConnectionSettings } from "./ConnectionSettings.js";
+import { GrpcSchemas } from "./GrpcSchemas.js";
 import { InterceptRules } from "./InterceptRules.js";
 import { ProxyControl } from "./ProxyControl.js";
 import "./SettingsPage.css";
@@ -19,6 +20,7 @@ const TABS = [
   { id: "capture", label: "Capture Scope" },
   { id: "tls", label: "TLS Passthrough" },
   { id: "tcp-forwards", label: "TCP Forwards" },
+  { id: "grpc-schemas", label: "gRPC Schemas" },
   { id: "intercept", label: "Intercept Rules" },
   { id: "transform", label: "Auto-Transform" },
   { id: "socks5-auth", label: "SOCKS5 Auth" },
@@ -137,6 +139,9 @@ export function SettingsPage() {
             {(c) => <TcpForwards config={c} onRefresh={handleRefresh} />}
           </TabContent>
         );
+
+      case "grpc-schemas":
+        return <GrpcSchemas />;
 
       case "intercept":
         return (


### PR DESCRIPTION
## Summary
- Add `gRPC Schemas` tab to the Settings page for operator-facing schema management
- Add `McpClient.grpcSchema()` + `useGrpcSchema()` (mutating actions) + `useGrpcSchemaList()` (auto-fetch query-style hook)
- Support `descriptor_set` (base64 .desc upload with 16 MiB client preflight + chunked encoding) and `source="file"` (USK-926 follow-up, collapsed disclosure) registration shapes
- Per-row Unregister with confirm dialog; section-level Clear all with confirm dialog
- Tab placement: after `tcp-forwards`, before `intercept`
- Out of scope: USK-928 reflection-based `discover` action (deferred to a follow-up Issue per design review D1)

## Implementation notes
- **MCP wrapper**: `client.ts` exposes `grpcSchema<R>(params)` with `R extends GrpcSchemaResult` so callers can narrow on the `action` discriminator (`GrpcSchemaRegisterResult` / `GrpcSchemaListResult` / `GrpcSchemaUnregisterResult` / `GrpcSchemaClearResult`).
- **Hook shape**: `useGrpcSchema` follows the `useFuzz` / `useResend` action-hook pattern; `useGrpcSchemaList` mirrors `usePluginIntrospect` (auto-fetch on connect + `refetch`).
- **16 MiB cap**: enforced client-side as a preflight on `File.size`; server-side cap in `internal/encoding/protoschema/registry.go` continues to apply (defence in depth).
- **Chunked base64**: `String.fromCharCode.apply` is batched at 32 KiB chunks to avoid stack overflow on files up to the 16 MiB cap.
- **CSS**: reuses existing `settings-*` classes (`settings-card`, `settings-add-form`, `settings-form-row`, `settings-item-list`, `settings-rule`, `settings-empty`); no new CSS introduced.
- **A11y**: every textarea / file input has a `<label htmlFor>`; the file input has an `aria-describedby` hint that documents the 16 MiB cap. Dialog focus trap is reused from the shared `useDialog` provider.

## Test plan
- [x] `make build` succeeds (WebUI compiles via tsc + vite; Go embeds `dist/`)
- [x] `make lint` passes (Go side)
- [x] `make test` passes (Go fast tier)
- [x] `pnpm vitest run` passes (10 files / 197 tests; no new eslint errors from this PR)
- [ ] Manual: upload a valid `.desc` file → schema appears in list with correct service / methods / source_label / registered_at
- [ ] Manual: pick a >16 MiB file → client preflight rejects with an error toast before reading
- [ ] Manual: per-row Unregister → confirm dialog → list refreshes
- [ ] Manual: Clear all → confirm dialog → list empties
- [ ] Manual: file-mode disclosure expands → submit with absolute proto_paths → register succeeds (assumes host `protoc` configured)

Resolves USK-927
Linear: https://linear.app/usk6666/issue/USK-927

🤖 Generated with [Claude Code](https://claude.com/claude-code)