### PR TITLE
feat(connector,proxybuild): H1 grpc-web auto-classify (USK-934)

### DIFF
--- a/docs/rfc/envelope.md
+++ b/docs/rfc/envelope.md
@@ -690,6 +690,8 @@ Implementation: `internal/proxybuild/tcp_forward.go`. Configuration: `internal/c
 
 All forwarded streams reuse the same `Pipeline` and `RecordStep`, so Flow / Stream recording (`flow.Stream.Scheme` reflects the client-side wire; per-Flow `Envelope.Raw` preserves wire bytes), plugin hooks, intercept / transform rules, and Safety Input Filter apply identically to forward traffic.
 
+**gRPC-Web auto-classify (USK-934).** The `http` arm (and `auto` arm when it dispatches to HTTP/1.1) inspects the first request's `Content-Type` header per-exchange. When it matches `application/grpc-web[-text][+proto|…]`, the per-exchange client Channel is wrapped with `grpcweb.Wrap` (downstream) and the upstream Channel is wrapped via `connector.WrapH1UpstreamForDispatch` (upstream symmetry) — Stream `Protocol` is then re-tagged to `grpc-web` by `record_step.maybeRetagProtocol`. This mirrors the H2 sibling pattern (`connector.DispatchH2Stream`) so HTTP/1.1 keep-alive that mixes grpc-web POST and JSON POST on the same connection routes correctly per-exchange. See `internal/connector/h1_dispatch.go`.
+
 ### 3.5 Pipeline Step Categorization
 
 Pipeline interface is unchanged:

--- a/internal/connector/h1_dispatch.go
+++ b/internal/connector/h1_dispatch.go
@@ -1,0 +1,195 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/grpcweb"
+)
+
+// DispatchH1Channel peeks the first envelope on an HTTP/1.x per-exchange
+// Channel, inspects the request's content-type for protocol detection, and
+// wraps the channel with the gRPC-Web Layer when the content-type matches:
+//
+//   - application/grpc-web[-text][+proto|...] → grpcweb.Wrap (returned
+//     Channel emits GRPCStart/Data*/End envelopes stamped
+//     Protocol=ProtocolGRPCWeb instead of *envelope.HTTPMessage).
+//   - any other content-type → returned Channel re-yields the peeked
+//     envelope verbatim on the first Next call; no protocol upgrade.
+//
+// This is the HTTP/1.x sibling of [DispatchH2Stream]. It exists because
+// HTTP/1.1 keep-alive can mix grpc-web POST requests and JSON POST
+// requests on the same connection, so the protocol decision must be made
+// per-exchange — not at stack-build time.
+//
+// role selects the gRPC-Web Layer's direction convention:
+//   - [grpcweb.RoleServer] for the downstream (client → proxy) wrap; the
+//     proxy behaves as the gRPC-Web server reading the request.
+//   - [grpcweb.RoleClient] for the upstream (proxy → upstream) wrap; the
+//     proxy behaves as the gRPC-Web client assembling the request back to
+//     the wire via inner.Send.
+//
+// grpcwebOpts are passed to [grpcweb.Wrap] on the gRPC-Web branch (e.g.,
+// the per-stream [grpcweb.WithEncodedFormRecordCallback] installed by
+// session.GRPCWebBase64RecordOption). Ignored on the default branch.
+//
+// The returned [layer.Channel] is what the caller should run RunSession
+// or other consumers against. The peeked envelope is replayed via an
+// internal replay-channel so no data is lost.
+//
+// Errors from the initial peek (clientCh.Next) are returned as-is so the
+// caller can distinguish "peer hung up before request" from "stream
+// error".
+//
+// USK-934: before this dispatcher existed, HTTP/1.x grpc-web traffic was
+// recorded with Stream.Protocol="http", invisible to
+// `query filter.protocol=grpc-web` / `manage delete_flows protocol=grpc-web`.
+// Wire bytes were preserved (the http1 Layer captured them in Raw) but
+// the protocol classification was wrong. This helper closes the gap by
+// applying the H2 sibling's content-type-based wrap to H1 as well.
+func DispatchH1Channel(
+	ctx context.Context,
+	clientCh layer.Channel,
+	role grpcweb.Role,
+	grpcwebOpts []grpcweb.Option,
+	logger *slog.Logger,
+) (layer.Channel, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	firstEnv, err := clientCh.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// The first envelope on an HTTP/1.x per-exchange Channel is always an
+	// *envelope.HTTPMessage (the parsed request). Anything else means the
+	// caller wired us against the wrong Channel type.
+	msg, ok := firstEnv.Message.(*envelope.HTTPMessage)
+	if !ok {
+		return nil, fmt.Errorf("connector: DispatchH1Channel: first envelope is %T, expected *HTTPMessage", firstEnv.Message)
+	}
+
+	ct := extractHTTPContentType(msg)
+	replay := &http1ReplayChannel{
+		underlying: clientCh,
+		queued:     []*envelope.Envelope{firstEnv},
+	}
+
+	if grpcweb.IsGRPCWebContentType(ct) {
+		logger.Debug("connector: DispatchH1Channel: gRPC-Web content-type detected; wrapping with grpcweb",
+			"stream_id", firstEnv.StreamID,
+			"method", msg.Method,
+			"path", msg.Path,
+			"content_type", ct,
+		)
+		return grpcweb.Wrap(replay, role, grpcwebOpts...), nil
+	}
+
+	return replay, nil
+}
+
+// WrapH1UpstreamForDispatch wraps a freshly opened upstream HTTP/1.x
+// Channel with the same per-protocol layer the client-side dispatcher
+// chose for the request. The session loop calls Send on this Channel
+// with envelopes drawn from the client side, so the upstream Channel's
+// Send method MUST accept the same Message types.
+//
+// Concretely:
+//
+//   - reqProto == [envelope.ProtocolGRPCWeb] → wrap with [grpcweb.Wrap]
+//     in [grpcweb.RoleClient] so the gRPC-Web Send path (which accepts
+//     GRPCStart / GRPCData / GRPCEnd envelopes and assembles them back
+//     into an outbound HTTPMessage via inner.Send) reaches the upstream
+//     wire correctly.
+//   - any other Protocol (or empty) → return upCh unchanged.
+//
+// This is the HTTP/1.x sibling of [WrapH2UpstreamForDispatch]. Without
+// this symmetry the upstream http1 Channel would see a
+// GRPCStartMessage on the first Send and reject it (the http1 Channel
+// only accepts *envelope.HTTPMessage), aborting the exchange before any
+// envelope reached the Pipeline — exactly the failure pattern USK-771
+// fixed for HTTP/2.
+//
+// grpcwebOpts are passed to [grpcweb.Wrap] on the gRPC-Web branch
+// (matching the dispatcher's downstream wrap), ignored otherwise.
+func WrapH1UpstreamForDispatch(
+	upCh layer.Channel,
+	reqProto envelope.Protocol,
+	grpcwebOpts []grpcweb.Option,
+) layer.Channel {
+	if reqProto == envelope.ProtocolGRPCWeb {
+		return grpcweb.Wrap(upCh, grpcweb.RoleClient, grpcwebOpts...)
+	}
+	return upCh
+}
+
+// extractHTTPContentType returns the value of the first content-type
+// header found on msg (case-insensitive name match), or "" if none is
+// present. Multiple content-type headers are not merged; the first wins
+// (matching extractContentType's H2 semantics).
+func extractHTTPContentType(msg *envelope.HTTPMessage) string {
+	if msg == nil {
+		return ""
+	}
+	for _, kv := range msg.Headers {
+		if strings.EqualFold(kv.Name, "content-type") {
+			return kv.Value
+		}
+	}
+	return ""
+}
+
+// http1ReplayChannel wraps a [layer.Channel] so the first Next call
+// returns a previously-peeked envelope before delegating to the
+// underlying Channel. All other operations (Send, Close, Closed, Err,
+// StreamID) pass through.
+//
+// Used by [DispatchH1Channel] to peek the first request envelope for
+// content-type classification without disturbing the session loop's
+// view of the Channel. The proxybuild package has an identical type for
+// the tcp_forward L7 filter — both call sites accept light duplication
+// per CLAUDE.md (prefer light duplication over premature abstraction
+// when the shared interface is not yet stable across all four
+// implementations).
+//
+// USK-934 (sibling of the proxybuild.http1ReplayChannel introduced in
+// USK-913 for the websocket/sse filter): a common shared helper across
+// connector and proxybuild is deferred — the connector copy is
+// internal-internal so the import direction (proxybuild → connector) is
+// preserved.
+type http1ReplayChannel struct {
+	underlying layer.Channel
+	mu         sync.Mutex
+	queued     []*envelope.Envelope
+}
+
+func (c *http1ReplayChannel) StreamID() string { return c.underlying.StreamID() }
+
+func (c *http1ReplayChannel) Next(ctx context.Context) (*envelope.Envelope, error) {
+	c.mu.Lock()
+	if len(c.queued) > 0 {
+		env := c.queued[0]
+		c.queued = c.queued[1:]
+		c.mu.Unlock()
+		return env, nil
+	}
+	c.mu.Unlock()
+	return c.underlying.Next(ctx)
+}
+
+func (c *http1ReplayChannel) Send(ctx context.Context, env *envelope.Envelope) error {
+	return c.underlying.Send(ctx, env)
+}
+
+func (c *http1ReplayChannel) Close() error { return c.underlying.Close() }
+
+func (c *http1ReplayChannel) Closed() <-chan struct{} { return c.underlying.Closed() }
+
+func (c *http1ReplayChannel) Err() error { return c.underlying.Err() }

--- a/internal/connector/h1_dispatch_test.go
+++ b/internal/connector/h1_dispatch_test.go
@@ -1,0 +1,359 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/grpcweb"
+)
+
+// TestExtractHTTPContentType verifies extractHTTPContentType returns the
+// first content-type header value (case-insensitive name match), preserves
+// the wire-observed value casing, and returns "" when no content-type
+// header is present. Mirrors TestExtractContentType for HTTP/2.
+func TestExtractHTTPContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *envelope.HTTPMessage
+		want string
+	}{
+		{
+			name: "nil message",
+			msg:  nil,
+			want: "",
+		},
+		{
+			name: "no content-type header",
+			msg:  &envelope.HTTPMessage{Headers: []envelope.KeyValue{{Name: "x-other", Value: "ignore"}}},
+			want: "",
+		},
+		{
+			name: "lowercase content-type",
+			msg:  &envelope.HTTPMessage{Headers: []envelope.KeyValue{{Name: "content-type", Value: "application/grpc-web+proto"}}},
+			want: "application/grpc-web+proto",
+		},
+		{
+			name: "mixed-case header name",
+			msg:  &envelope.HTTPMessage{Headers: []envelope.KeyValue{{Name: "Content-Type", Value: "application/grpc-web-text"}}},
+			want: "application/grpc-web-text",
+		},
+		{
+			name: "first content-type wins",
+			msg: &envelope.HTTPMessage{Headers: []envelope.KeyValue{
+				{Name: "content-type", Value: "application/grpc-web+proto"},
+				{Name: "content-type", Value: "application/json"},
+			}},
+			want: "application/grpc-web+proto",
+		},
+		{
+			name: "value case preserved",
+			msg: &envelope.HTTPMessage{Headers: []envelope.KeyValue{
+				{Name: "Content-Type", Value: "Application/GRPC-WEB; CHARSET=UTF-8"},
+			}},
+			want: "Application/GRPC-WEB; CHARSET=UTF-8",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractHTTPContentType(tt.msg); got != tt.want {
+				t.Errorf("extractHTTPContentType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDispatchH1Channel_GRPCWebClassification verifies the dispatcher
+// wraps the channel with grpcweb.Wrap iff the request's content-type is
+// a gRPC-Web media type. The wrap is detected via the upstream
+// symmetry: a grpcweb-wrapped channel accepts *envelope.GRPCStartMessage
+// on Send (the default http1-style channel does not).
+//
+// Negative cases (json / empty / non-grpc-web grpc) confirm the
+// dispatcher returns the replay channel unwrapped so the underlying
+// HTTPMessage flows through unchanged.
+func TestDispatchH1Channel_GRPCWebClassification(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		// wantWrapped is true when the dispatcher is expected to wrap the
+		// channel with grpcweb.Wrap. Verified by replaying the first
+		// envelope and asserting it carries Protocol=ProtocolGRPCWeb when
+		// the wrap fired.
+		wantWrapped bool
+	}{
+		{"grpc-web binary +proto", "application/grpc-web+proto", true},
+		{"grpc-web binary", "application/grpc-web", true},
+		{"grpc-web text", "application/grpc-web-text", true},
+		{"grpc-web text +proto", "application/grpc-web-text+proto", true},
+		{"grpc-web with charset", "application/grpc-web+proto; charset=utf-8", true},
+		{"native grpc (NOT grpc-web)", "application/grpc", false},
+		{"native grpc +proto (NOT grpc-web)", "application/grpc+proto", false},
+		{"json", "application/json", false},
+		{"empty", "", false},
+		{"text/plain", "text/plain", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build a request HTTPMessage with the test content-type.
+			req := &envelope.HTTPMessage{
+				Method: "POST",
+				Path:   "/hello.HelloService/SayHello",
+				Headers: []envelope.KeyValue{
+					{Name: "host", Value: "127.0.0.1"},
+					{Name: "content-type", Value: tt.contentType},
+				},
+				// Empty body avoids the layer attempting LPM parse on
+				// the unit-test path. The classification decision is
+				// based on the content-type only.
+				Body: nil,
+			}
+			env := &envelope.Envelope{
+				StreamID:  "h1-test",
+				Direction: envelope.Send,
+				Protocol:  envelope.ProtocolHTTP,
+				Message:   req,
+			}
+
+			fake := newFakeH1Channel([]*envelope.Envelope{env})
+			dispatched, err := DispatchH1Channel(context.Background(), fake, grpcweb.RoleServer, nil, nil)
+			if err != nil {
+				t.Fatalf("DispatchH1Channel returned error: %v", err)
+			}
+			if dispatched == nil {
+				t.Fatalf("DispatchH1Channel returned nil channel")
+			}
+
+			// Replay the first envelope. For the wrapped case, grpcweb
+			// emits a GRPCStartMessage with Protocol=ProtocolGRPCWeb.
+			// For the unwrapped case, the replay channel re-yields the
+			// original HTTPMessage envelope with Protocol=ProtocolHTTP.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			first, err := dispatched.Next(ctx)
+			if err != nil {
+				t.Fatalf("dispatched.Next returned error: %v", err)
+			}
+			if tt.wantWrapped {
+				if first.Protocol != envelope.ProtocolGRPCWeb {
+					t.Errorf("wanted Protocol=ProtocolGRPCWeb (wrapped), got %q for ct=%q",
+						first.Protocol, tt.contentType)
+				}
+				if _, ok := first.Message.(*envelope.GRPCStartMessage); !ok {
+					t.Errorf("wanted *GRPCStartMessage (wrapped), got %T for ct=%q",
+						first.Message, tt.contentType)
+				}
+			} else {
+				if first.Protocol != envelope.ProtocolHTTP {
+					t.Errorf("wanted Protocol=ProtocolHTTP (unwrapped), got %q for ct=%q",
+						first.Protocol, tt.contentType)
+				}
+				if _, ok := first.Message.(*envelope.HTTPMessage); !ok {
+					t.Errorf("wanted *HTTPMessage (unwrapped), got %T for ct=%q",
+						first.Message, tt.contentType)
+				}
+			}
+		})
+	}
+}
+
+// TestDispatchH1Channel_PeekError verifies that an error from clientCh.Next
+// (e.g., peer hung up before sending a request) is returned to the caller
+// verbatim so the caller can distinguish from "wrong Channel type".
+func TestDispatchH1Channel_PeekError(t *testing.T) {
+	wantErr := io.EOF
+	fake := newFakeH1ChannelErr(wantErr)
+	_, err := DispatchH1Channel(context.Background(), fake, grpcweb.RoleServer, nil, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("wanted err=%v, got %v", wantErr, err)
+	}
+}
+
+// TestDispatchH1Channel_WrongMessageType verifies the dispatcher returns
+// a descriptive error if the first envelope is not an *HTTPMessage. This
+// is defensive — the H1 Layer always emits HTTPMessage envelopes, so the
+// branch only fires on a programmer wiring error.
+func TestDispatchH1Channel_WrongMessageType(t *testing.T) {
+	// A WSMessage envelope masquerading on an "h1" channel — wiring bug.
+	env := &envelope.Envelope{
+		StreamID:  "h1-test",
+		Direction: envelope.Send,
+		Protocol:  envelope.ProtocolHTTP,
+		Message:   &envelope.WSMessage{Opcode: envelope.WSText, Payload: []byte("oops")},
+	}
+	fake := newFakeH1Channel([]*envelope.Envelope{env})
+	_, err := DispatchH1Channel(context.Background(), fake, grpcweb.RoleServer, nil, nil)
+	if err == nil {
+		t.Fatalf("wanted error on wrong message type, got nil")
+	}
+}
+
+// TestWrapH1UpstreamForDispatch verifies per-Protocol dispatch of the
+// upstream wrapper:
+//
+//   - ProtocolGRPCWeb returns a grpcweb-wrapped Channel that accepts a
+//     *envelope.GRPCStartMessage on Send (the symmetric pattern to
+//     USK-771's H2 fix — without this, the upstream bare http1 Channel
+//     would only accept *envelope.HTTPMessage and reject the gRPC
+//     envelopes the session forwards from the client side).
+//   - any other Protocol returns the inner Channel unchanged (verified by
+//     pointer identity).
+//
+// The grpc-web Send acceptance is a structural test: the fake upstream
+// silently absorbs any Send, so the wrapper's Send-side accept/reject
+// decision is observable as nil/non-nil at the Send return.
+func TestWrapH1UpstreamForDispatch(t *testing.T) {
+	t.Run("grpc-web wraps and accepts GRPCStartMessage", func(t *testing.T) {
+		fake := newFakeUpstreamChannel()
+		ch := WrapH1UpstreamForDispatch(fake, envelope.ProtocolGRPCWeb, nil)
+		if ch == nil {
+			t.Fatalf("WrapH1UpstreamForDispatch returned nil for grpc-web")
+		}
+		defer ch.Close()
+		// Identity guard: the grpc-web branch must wrap (returning a
+		// new Channel), not return the inner unchanged.
+		if any(ch) == any(fake) {
+			t.Errorf("grpc-web path returned inner unchanged; expected wrap")
+		}
+		env := &envelope.Envelope{
+			StreamID:  "test",
+			Direction: envelope.Send,
+			Protocol:  envelope.ProtocolGRPCWeb,
+			Message:   &envelope.GRPCStartMessage{Service: "x.Y", Method: "Z", ContentType: "application/grpc-web+proto"},
+		}
+		if err := ch.Send(context.Background(), env); err != nil {
+			t.Fatalf("grpc-web wrapper rejected GRPCStartMessage: %v", err)
+		}
+	})
+
+	t.Run("default (http) returns inner unchanged", func(t *testing.T) {
+		fake := newFakeUpstreamChannel()
+		ch := WrapH1UpstreamForDispatch(fake, envelope.ProtocolHTTP, nil)
+		if ch == nil {
+			t.Fatalf("WrapH1UpstreamForDispatch returned nil for http")
+		}
+		// Pointer identity: the default branch returns the inner Channel.
+		if any(ch) != any(fake) {
+			t.Errorf("default path wrapped the inner channel; expected unchanged")
+		}
+	})
+
+	t.Run("empty Protocol returns inner unchanged", func(t *testing.T) {
+		fake := newFakeUpstreamChannel()
+		ch := WrapH1UpstreamForDispatch(fake, "", nil)
+		if any(ch) != any(fake) {
+			t.Errorf("empty Protocol path wrapped the inner channel; expected unchanged")
+		}
+	})
+}
+
+// TestHTTP1ReplayChannel_NextReplaysQueuedFirst verifies the replay
+// wrapper returns queued envelopes before delegating to the underlying
+// Channel. Confirms the dispatcher's peek-then-replay invariant: no
+// envelope is lost when the dispatcher decides not to wrap.
+func TestHTTP1ReplayChannel_NextReplaysQueuedFirst(t *testing.T) {
+	queued := &envelope.Envelope{StreamID: "x", Sequence: 0, Message: &envelope.HTTPMessage{Method: "GET"}}
+	follow := &envelope.Envelope{StreamID: "x", Sequence: 1, Message: &envelope.HTTPMessage{Method: "POST"}}
+	fake := newFakeH1Channel([]*envelope.Envelope{follow})
+
+	c := &http1ReplayChannel{
+		underlying: fake,
+		queued:     []*envelope.Envelope{queued},
+	}
+	got1, err := c.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next #1 err: %v", err)
+	}
+	if got1 != queued {
+		t.Errorf("Next #1 = %v, want queued envelope", got1)
+	}
+
+	got2, err := c.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next #2 err: %v", err)
+	}
+	if got2 != follow {
+		t.Errorf("Next #2 = %v, want underlying follow envelope", got2)
+	}
+}
+
+// TestHTTP1ReplayChannel_PassThrough verifies StreamID / Send / Close /
+// Closed / Err delegate to the underlying Channel.
+func TestHTTP1ReplayChannel_PassThrough(t *testing.T) {
+	fake := newFakeH1Channel(nil)
+	c := &http1ReplayChannel{underlying: fake}
+
+	if got := c.StreamID(); got != fake.StreamID() {
+		t.Errorf("StreamID = %q, want %q", got, fake.StreamID())
+	}
+	if err := c.Send(context.Background(), &envelope.Envelope{}); err != nil {
+		t.Errorf("Send err = %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("Close err = %v", err)
+	}
+	if c.Closed() != fake.Closed() {
+		t.Errorf("Closed() did not pass through")
+	}
+	if err := c.Err(); err != nil {
+		t.Errorf("Err = %v", err)
+	}
+}
+
+// fakeH1Channel is a layer.Channel test double that yields a fixed
+// queue of envelopes on Next and silently absorbs Send.
+type fakeH1Channel struct {
+	mu       sync.Mutex
+	envs     []*envelope.Envelope
+	closed   chan struct{}
+	closedOn sync.Once
+	nextErr  error
+}
+
+func newFakeH1Channel(envs []*envelope.Envelope) *fakeH1Channel {
+	return &fakeH1Channel{
+		envs:   envs,
+		closed: make(chan struct{}),
+	}
+}
+
+func newFakeH1ChannelErr(err error) *fakeH1Channel {
+	return &fakeH1Channel{
+		closed:  make(chan struct{}),
+		nextErr: err,
+	}
+}
+
+func (f *fakeH1Channel) StreamID() string { return "fake-h1" }
+
+func (f *fakeH1Channel) Next(_ context.Context) (*envelope.Envelope, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
+	if len(f.envs) == 0 {
+		return nil, io.EOF
+	}
+	env := f.envs[0]
+	f.envs = f.envs[1:]
+	return env, nil
+}
+
+func (f *fakeH1Channel) Send(_ context.Context, _ *envelope.Envelope) error { return nil }
+
+func (f *fakeH1Channel) Close() error {
+	f.closedOn.Do(func() { close(f.closed) })
+	return nil
+}
+
+func (f *fakeH1Channel) Closed() <-chan struct{} { return f.closed }
+
+func (f *fakeH1Channel) Err() error { return nil }
+
+// compile-time assertion: fakeH1Channel implements layer.Channel.
+var _ layer.Channel = (*fakeH1Channel)(nil)

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -756,7 +756,7 @@ func runHTTP1ExchangeLoop(
 			wg.Add(1)
 			go func(ch layer.Channel) {
 				defer wg.Done()
-				runHTTP1Exchange(ctx, stack, ch, upstreamH1, p, deps, sessOpts, target, grpcwebOpts, logger)
+				runHTTP1Exchange(ctx, stack, ch, upstreamH1, p, sessOpts, target, grpcwebOpts, logger)
 			}(clientCh)
 		}
 	}
@@ -782,7 +782,6 @@ func runHTTP1Exchange(
 	clientCh layer.Channel,
 	upstreamH1 *http1.Layer,
 	p *pipeline.Pipeline,
-	_ Deps,
 	sessOpts session.SessionOptions,
 	target string,
 	baseGRPCWebOpts []grpcweb.Option,

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -694,7 +694,7 @@ func buildOnStack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) connecto
 					"upstream_type", fmt.Sprintf("%T", stack.UpstreamTopmost()))
 				return
 			}
-			runHTTP1ExchangeLoop(ctx, stack, clientH1, upstreamH1, p, sessOpts, target, logger)
+			runHTTP1ExchangeLoop(ctx, stack, clientH1, upstreamH1, p, deps, sessOpts, target, logger)
 			return
 		}
 
@@ -718,6 +718,17 @@ func buildOnStack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) connecto
 // shared across all exchanges; each goroutine's dial closure calls
 // upstreamH1.OpenExchange() to register its per-exchange response slot.
 //
+// USK-934: each exchange is run through connector.DispatchH1Channel
+// before entering RunStackSessionExchange. When the request's content-
+// type matches application/grpc-web[-text][+proto|...], the client-side
+// per-exchange Channel is wrapped with grpcweb.Wrap (RoleServer) and the
+// upstream-side Channel is wrapped via connector.WrapH1UpstreamForDispatch
+// (RoleClient). Envelopes emitted by these wraps carry
+// Protocol=ProtocolGRPCWeb so the canonical record_step.maybeRetagProtocol
+// re-tags Stream.Protocol from "http" to "grpc-web". For any non-grpc-web
+// content-type the dispatch is a no-op and the exchange flows through
+// unchanged.
+//
 // Upgrade flow (WS / SSE) is owned by RunStackSessionExchange; on detach
 // the http1 Layer's spawn loop closes Channels() and the loop exits.
 func runHTTP1ExchangeLoop(
@@ -725,10 +736,12 @@ func runHTTP1ExchangeLoop(
 	stack *connector.ConnectionStack,
 	clientH1, upstreamH1 *http1.Layer,
 	p *pipeline.Pipeline,
+	deps Deps,
 	sessOpts session.SessionOptions,
 	target string,
 	logger *slog.Logger,
 ) {
+	grpcwebOpts := connector.GRPCWebOptionsFromBuildConfig(deps.BuildConfig)
 	var wg sync.WaitGroup
 	for {
 		select {
@@ -743,18 +756,85 @@ func runHTTP1ExchangeLoop(
 			wg.Add(1)
 			go func(ch layer.Channel) {
 				defer wg.Done()
-				dial := func(_ context.Context, _ *envelope.Envelope) (layer.Channel, error) {
-					upCh := upstreamH1.OpenExchange()
-					if upCh == nil {
-						return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)
-					}
-					return upCh, nil
-				}
-				if err := session.RunStackSessionExchange(ctx, stack, ch, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Debug("proxybuild: http1 exchange ended with error", "target", target, "error", err)
-				}
+				runHTTP1Exchange(ctx, stack, ch, upstreamH1, p, deps, sessOpts, target, grpcwebOpts, logger)
 			}(clientCh)
 		}
+	}
+}
+
+// runHTTP1Exchange runs one HTTP/1.x per-exchange Channel through the
+// H1 dispatcher (content-type-based grpc-web auto-classify, USK-934) and
+// then into session.RunStackSessionExchange. Extracted from
+// runHTTP1ExchangeLoop for readability — the wrap + dial-closure
+// composition has grown beyond the inline goroutine body it used to be.
+//
+// Per-exchange grpc-web record callback: when the request matches
+// application/grpc-web[-text][+proto|...], the per-exchange
+// session.GRPCWebBase64RecordOption installs the WireLevel=grpcweb-base64
+// overlay producer on BOTH the client-side and upstream-side
+// grpcweb.Wrap calls. Same closure → independent per-direction sequence
+// counters → distinct (StreamID, Direction, sequence, wire_level) tuples
+// per the schemaV14 UNIQUE constraint. Mirrors the H2 pattern in
+// buildOnHTTP2Stack (USK-898).
+func runHTTP1Exchange(
+	ctx context.Context,
+	stack *connector.ConnectionStack,
+	clientCh layer.Channel,
+	upstreamH1 *http1.Layer,
+	p *pipeline.Pipeline,
+	_ Deps,
+	sessOpts session.SessionOptions,
+	target string,
+	baseGRPCWebOpts []grpcweb.Option,
+	logger *slog.Logger,
+) {
+	// Per-exchange wire-record Option for the gRPC-Web text-variant
+	// base64 wire bytes. The same closure is installed on both the
+	// client-side and upstream-side grpcweb wraps; the closure runs
+	// independent per-direction sequence counters and rewrites
+	// env.StreamID to clientCh.StreamID() for unification (mirroring
+	// the H2 wiring in buildOnHTTP2Stack).
+	streamFlowCtx := envelope.EnvelopeContext{ConnID: stack.ConnID, TargetHost: target}
+	grpcWebBase64Opt := session.GRPCWebBase64RecordOption(ctx, p, clientCh.StreamID(), streamFlowCtx)
+	streamGRPCWebOpts := make([]grpcweb.Option, 0, len(baseGRPCWebOpts)+1)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, baseGRPCWebOpts...)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, grpcWebBase64Opt)
+
+	dispatchedCh, err := connector.DispatchH1Channel(ctx, clientCh, grpcweb.RoleServer, streamGRPCWebOpts, logger)
+	if err != nil {
+		// Peer hung up before sending a request, or the client Channel
+		// produced a non-HTTPMessage first envelope (programmer error
+		// elsewhere). Drop the exchange; the session loop normally
+		// surfaces these as state="error" but the dispatcher consumed
+		// the first Next so there's no envelope to drive the record
+		// path. The http1 layer cleans up its own state on Close.
+		_ = clientCh.Close()
+		if !errors.Is(err, context.Canceled) {
+			logger.Debug("proxybuild: http1 dispatch failed",
+				"target", target, "stream_id", clientCh.StreamID(), "error", err)
+		}
+		return
+	}
+
+	dial := func(_ context.Context, env *envelope.Envelope) (layer.Channel, error) {
+		upCh := upstreamH1.OpenExchange()
+		if upCh == nil {
+			return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)
+		}
+		// USK-934: wrap the upstream channel with the same per-protocol
+		// layer the client side chose. Without this dispatch the upstream
+		// stays a bare http1 Channel and rejects GRPCStartMessage on the
+		// first Send (the http1 Channel only accepts *envelope.HTTPMessage),
+		// aborting the exchange before any envelope reaches the Pipeline.
+		// Mirrors USK-771's H2 symmetry fix.
+		var reqProto envelope.Protocol
+		if env != nil {
+			reqProto = env.Protocol
+		}
+		return connector.WrapH1UpstreamForDispatch(upCh, reqProto, streamGRPCWebOpts), nil
+	}
+	if err := session.RunStackSessionExchange(ctx, stack, dispatchedCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Debug("proxybuild: http1 exchange ended with error", "target", target, "error", err)
 	}
 }
 

--- a/internal/proxybuild/tcp_forward.go
+++ b/internal/proxybuild/tcp_forward.go
@@ -621,7 +621,7 @@ func (m *Manager) handleTCPForwardConnL7(
 	// state="error" Stream via the Pipeline-Drop audit hook.
 	sessOpts := m.tcpForwardSessionOpts(parentStack, connCtx)
 	filter := exchangeFilterFor(protocol, connLogger)
-	runTCPForwardHTTP1ExchangeLoop(connCtx, stack, clientH1, upstreamH1, parentStack.Pipeline, sessOpts, entry.target, connLogger, filter)
+	runTCPForwardHTTP1ExchangeLoop(connCtx, stack, clientH1, upstreamH1, parentStack, parentStack.Pipeline, sessOpts, entry.target, connLogger, filter)
 }
 
 // tcpForwardSessionOpts builds session.SessionOptions for a TCP forward

--- a/internal/proxybuild/tcp_forward_grpcweb_integration_test.go
+++ b/internal/proxybuild/tcp_forward_grpcweb_integration_test.go
@@ -1,0 +1,493 @@
+//go:build e2e && !e2e_smoke
+
+// Package proxybuild_test exhaustive tier — USK-934 H1 grpc-web
+// auto-classify. Validates the Issue repro: a tcp_forwards listener
+// configured with Protocol="http" carrying gRPC-Web traffic on HTTP/1.1
+// must record Stream.Protocol="grpc-web" (not "http"), so the flow is
+// queryable via filter.protocol=grpc-web.
+//
+// Pre-USK-934 behaviour: the H1 path never inspected content-type to
+// dispatch to grpcweb.Wrap, so all HTTP/1.x grpc-web traffic was recorded
+// as protocol=http (wire bytes preserved, classification wrong).
+//
+// USK-934 fix: DispatchH1Channel + WrapH1UpstreamForDispatch in the H1
+// per-exchange dispatcher (sibling of H2's DispatchH2Stream pattern).
+package proxybuild_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/testutil"
+)
+
+// stdBase64Encode wraps the stdlib base64 encoder so the per-helper
+// callsites stay readable.
+func stdBase64Encode(b []byte) string {
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// h1GRPCWebEchoUpstream starts a minimal HTTP/1.1 server that responds to
+// any POST with a gRPC-Web LPM data frame echoing a fixed message + a
+// trailer LPM frame (grpc-status: 0). Returns (addr, shutdown).
+//
+// We don't use net/http here — the response must contain a verbatim
+// trailer LPM frame inside the response body (per gRPC-Web RFC). The
+// minimal handler is a hand-rolled accept loop that reads the request
+// header section, drains the body, then writes a static response.
+func h1GRPCWebEchoUpstream(t *testing.T, contentType string) (addr string, shutdown func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	stop := make(chan struct{})
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleH1GRPCWebConn(c, contentType, stop)
+		}
+	}()
+	return ln.Addr().String(), func() {
+		close(stop)
+		_ = ln.Close()
+	}
+}
+
+func handleH1GRPCWebConn(c net.Conn, contentType string, _ <-chan struct{}) {
+	defer c.Close()
+	// Allow keep-alive: loop reading requests until the conn closes.
+	br := bufio.NewReader(c)
+	for {
+		// Read headers (until blank line).
+		reqHdr, err := readH1Headers(br)
+		if err != nil {
+			return
+		}
+		// Drain request body if Content-Length specified.
+		cl, _ := strconv.Atoi(strings.TrimSpace(reqHdr["content-length"]))
+		if cl > 0 {
+			if _, err := io.CopyN(io.Discard, br, int64(cl)); err != nil {
+				return
+			}
+		}
+
+		// Build the response body: one data LPM frame ("hello!!" payload)
+		// + one trailer LPM frame.
+		var bodyBuf bytes.Buffer
+		payload := []byte("hello!!")
+		// Data LPM: flags=0, length=7, payload=hello!!
+		bodyBuf.WriteByte(0x00)
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(payload)))
+		bodyBuf.Write(lenBuf[:])
+		bodyBuf.Write(payload)
+		// Trailer LPM: flags=0x80, payload="grpc-status: 0\r\n"
+		trailerText := []byte("grpc-status: 0\r\n")
+		bodyBuf.WriteByte(0x80)
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(trailerText)))
+		bodyBuf.Write(lenBuf[:])
+		bodyBuf.Write(trailerText)
+		body := bodyBuf.Bytes()
+
+		// Write a minimal HTTP/1.1 response.
+		fmt.Fprintf(c, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprintf(c, "Content-Type: %s\r\n", contentType)
+		fmt.Fprintf(c, "Content-Length: %d\r\n", len(body))
+		fmt.Fprintf(c, "Connection: keep-alive\r\n")
+		fmt.Fprintf(c, "\r\n")
+		if _, err := c.Write(body); err != nil {
+			return
+		}
+		// Loop for keep-alive — but the test sends a single request, so
+		// the conn usually closes on the next ReadString failure.
+	}
+}
+
+// readH1Headers reads HTTP/1.x request lines + headers until the blank
+// terminator and returns a normalised lowercase header map (first value
+// per name). The request line is consumed but not parsed beyond the
+// blank-line gate.
+func readH1Headers(br *bufio.Reader) (map[string]string, error) {
+	// Request line.
+	if _, err := br.ReadString('\n'); err != nil {
+		return nil, err
+	}
+	hdr := make(map[string]string)
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			return hdr, nil
+		}
+		i := strings.IndexByte(line, ':')
+		if i < 0 {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(line[:i]))
+		value := strings.TrimSpace(line[i+1:])
+		if _, ok := hdr[name]; !ok {
+			hdr[name] = value
+		}
+	}
+}
+
+// startH1ForwardListener spins up the proxy with one TCP forward entry
+// targeting upstreamAddr with Protocol="http" (h1 path). Returns the
+// bound forward address.
+func startH1ForwardListener(t *testing.T, ctx context.Context, upstreamAddr string) (
+	mgr *proxybuild.Manager, fwdAddr string, store *flowStoreCapture,
+) {
+	t.Helper()
+	store = &flowStoreCapture{}
+	logger := testutil.DiscardLogger()
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca.Generate: %v", err)
+	}
+	buildCfg := &connector.BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             cert.NewIssuer(ca),
+		InsecureSkipVerify: true,
+	}
+	factory := func(ctx context.Context, name, addr string) (*proxybuild.Stack, error) {
+		return proxybuild.BuildLiveStack(ctx, proxybuild.Deps{
+			Logger:       logger,
+			ListenerName: name,
+			ListenAddr:   addr,
+			FlowStore:    store,
+			BuildConfig:  buildCfg,
+		})
+	}
+	m, err := proxybuild.NewManager(proxybuild.ManagerConfig{
+		Logger:       logger,
+		StackFactory: factory,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.StopAll(context.Background()) })
+
+	if err := m.Start(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatalf("manager.Start: %v", err)
+	}
+	if err := m.StartTCPForwards(ctx, proxybuild.TCPForwardParams{
+		Forwards: map[string]*config.ForwardConfig{
+			"0": {Target: upstreamAddr, Protocol: "http"},
+		},
+	}); err != nil {
+		t.Fatalf("StartTCPForwards(http): %v", err)
+	}
+	addrs := m.TCPForwardAddrs()
+	fwdAddr = addrs["0"]
+	if fwdAddr == "" {
+		t.Fatalf("TCPForwardAddrs missing port 0: %v", addrs)
+	}
+	return m, fwdAddr, store
+}
+
+// sendH1GRPCWebRequest dials the proxy's H1 forward listener, writes a
+// minimal POST with the supplied content-type + LPM body, and returns
+// the raw response bytes.
+func sendH1GRPCWebRequest(t *testing.T, proxyAddr, contentType string, lpmBody []byte) []byte {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	var req bytes.Buffer
+	fmt.Fprintf(&req, "POST /hello.HelloService/SayHello HTTP/1.1\r\n")
+	fmt.Fprintf(&req, "Host: %s\r\n", proxyAddr)
+	fmt.Fprintf(&req, "Content-Type: %s\r\n", contentType)
+	fmt.Fprintf(&req, "Content-Length: %d\r\n", len(lpmBody))
+	fmt.Fprintf(&req, "Connection: close\r\n")
+	fmt.Fprintf(&req, "\r\n")
+	req.Write(lpmBody)
+
+	if _, err := conn.Write(req.Bytes()); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	respBytes, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return respBytes
+}
+
+// buildLPMBody returns the LPM-framed body for a request: one data
+// frame with the supplied payload.
+func buildLPMBody(payload []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(0x00)
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(payload)))
+	buf.Write(lenBuf[:])
+	buf.Write(payload)
+	return buf.Bytes()
+}
+
+// TestProxybuild_TCPForward_H1_GRPCWeb_Binary_AutoClassify is the
+// authoritative Issue repro: a tcp_forwards entry with Protocol="http"
+// carrying application/grpc-web+proto LPM traffic over HTTP/1.1 must
+// produce a Stream with Protocol="grpc-web". Pre-USK-934 this assertion
+// failed (Protocol stayed at "http").
+func TestProxybuild_TCPForward_H1_GRPCWeb_Binary_AutoClassify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, upStop := h1GRPCWebEchoUpstream(t, "application/grpc-web+proto")
+	defer upStop()
+
+	mgr, fwdAddr, store := startH1ForwardListener(t, ctx, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	reqBody := buildLPMBody([]byte("ping"))
+	respBytes := sendH1GRPCWebRequest(t, fwdAddr, "application/grpc-web+proto", reqBody)
+	if !bytes.Contains(respBytes, []byte("HTTP/1.1 200")) {
+		t.Fatalf("expected HTTP/1.1 200 in response, got: %q", string(respBytes))
+	}
+	// Verify the body contains the upstream's data LPM payload "hello!!".
+	if !bytes.Contains(respBytes, []byte("hello!!")) {
+		t.Errorf("response missing upstream LPM payload; got %q", string(respBytes))
+	}
+
+	// Wait for asynchronous Stream/Flow recording to complete.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasStreamWithProtocol(store, "grpc-web") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	streams := store.Streams()
+	if len(streams) < 1 {
+		t.Fatalf("expected at least 1 stream recorded, got %d", len(streams))
+	}
+
+	// The H1 grpc-web dispatch path produces a Stream initially tagged
+	// http; record_step.maybeRetagProtocol then UpdateStream-rewrites the
+	// Protocol to "grpc-web" when the first grpcweb envelope hits Record.
+	// Our flowStoreCapture applies StreamUpdate.Protocol to the in-memory
+	// row, so the final state should be Protocol="grpc-web".
+	checkStreamProtocolEventually(t, store, "grpc-web")
+}
+
+// TestProxybuild_TCPForward_H1_GRPCWeb_Text_AutoClassify exercises the
+// base64-encoded text variant (application/grpc-web-text). Same Issue
+// scope — the dispatcher must wrap regardless of binary vs text.
+func TestProxybuild_TCPForward_H1_GRPCWeb_Text_AutoClassify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upAddr, upStop := h1GRPCWebEchoUpstreamBase64(t, "application/grpc-web-text+proto")
+	defer upStop()
+
+	mgr, fwdAddr, store := startH1ForwardListener(t, ctx, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	reqBody := buildBase64LPMBody([]byte("ping"))
+	respBytes := sendH1GRPCWebRequest(t, fwdAddr, "application/grpc-web-text+proto", reqBody)
+	if !bytes.Contains(respBytes, []byte("HTTP/1.1 200")) {
+		t.Fatalf("expected HTTP/1.1 200 in response, got: %q", string(respBytes))
+	}
+
+	checkStreamProtocolEventually(t, store, "grpc-web")
+}
+
+// TestProxybuild_TCPForward_H1_JSONPOST_StaysHTTP is the negative
+// control: a non-grpc-web POST (application/json) flowing through the
+// same H1 forward path must NOT be re-tagged to grpc-web. The
+// dispatcher's content-type discriminator is the only gate.
+func TestProxybuild_TCPForward_H1_JSONPOST_StaysHTTP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Reuse the gRPC-Web echo upstream but advertise application/json
+	// on the response. The handler still writes its (now-meaningless)
+	// LPM bytes, but the proxy must not classify it as grpc-web because
+	// the REQUEST content-type drives the dispatcher.
+	upAddr, upStop := h1GRPCWebEchoUpstream(t, "application/json")
+	defer upStop()
+
+	mgr, fwdAddr, store := startH1ForwardListener(t, ctx, upAddr)
+	defer mgr.StopAll(context.Background())
+
+	respBytes := sendH1GRPCWebRequest(t, fwdAddr, "application/json", []byte(`{"hello":"world"}`))
+	if !bytes.Contains(respBytes, []byte("HTTP/1.1 200")) {
+		t.Fatalf("expected HTTP/1.1 200 in response, got: %q", string(respBytes))
+	}
+
+	// Wait for recording to settle.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.Streams()) >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	streams := store.Streams()
+	if len(streams) < 1 {
+		t.Fatalf("expected at least 1 stream recorded, got %d", len(streams))
+	}
+	// None of the streams should be re-tagged to grpc-web.
+	for _, st := range streams {
+		// Take updates into account (the maybeRetagProtocol path).
+		final := finalStreamProtocol(store, st.ID)
+		if final == "grpc-web" {
+			t.Errorf("stream %q was re-tagged to grpc-web for a JSON POST (negative-control violation): %+v",
+				st.ID, st)
+		}
+	}
+}
+
+// buildBase64LPMBody returns the base64-encoded LPM body for a request
+// payload (text variant).
+func buildBase64LPMBody(payload []byte) []byte {
+	bin := buildLPMBody(payload)
+	// std base64 (no URL-safe variant per RFC).
+	return []byte(stdBase64Encode(bin))
+}
+
+// h1GRPCWebEchoUpstreamBase64 is identical to h1GRPCWebEchoUpstream
+// except the response body is base64-encoded (text variant). The
+// content-type advertises the text format.
+func h1GRPCWebEchoUpstreamBase64(t *testing.T, contentType string) (addr string, shutdown func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	stop := make(chan struct{})
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleH1GRPCWebConnBase64(c, contentType, stop)
+		}
+	}()
+	return ln.Addr().String(), func() {
+		close(stop)
+		_ = ln.Close()
+	}
+}
+
+func handleH1GRPCWebConnBase64(c net.Conn, contentType string, _ <-chan struct{}) {
+	defer c.Close()
+	br := bufio.NewReader(c)
+	for {
+		hdr, err := readH1Headers(br)
+		if err != nil {
+			return
+		}
+		cl, _ := strconv.Atoi(strings.TrimSpace(hdr["content-length"]))
+		if cl > 0 {
+			if _, err := io.CopyN(io.Discard, br, int64(cl)); err != nil {
+				return
+			}
+		}
+		payload := []byte("hello!!")
+		var bin bytes.Buffer
+		bin.WriteByte(0x00)
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(payload)))
+		bin.Write(lenBuf[:])
+		bin.Write(payload)
+		trailerText := []byte("grpc-status: 0\r\n")
+		bin.WriteByte(0x80)
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(trailerText)))
+		bin.Write(lenBuf[:])
+		bin.Write(trailerText)
+		body := []byte(stdBase64Encode(bin.Bytes()))
+
+		fmt.Fprintf(c, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprintf(c, "Content-Type: %s\r\n", contentType)
+		fmt.Fprintf(c, "Content-Length: %d\r\n", len(body))
+		fmt.Fprintf(c, "Connection: keep-alive\r\n")
+		fmt.Fprintf(c, "\r\n")
+		if _, err := c.Write(body); err != nil {
+			return
+		}
+	}
+}
+
+// hasStreamWithProtocol returns true when any recorded Stream's
+// effective Protocol (after StreamUpdate replay) matches want.
+func hasStreamWithProtocol(store *flowStoreCapture, want string) bool {
+	for _, st := range store.Streams() {
+		if finalStreamProtocol(store, st.ID) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// finalStreamProtocol returns the effective Protocol for a Stream after
+// folding all recorded StreamUpdates over the initial SaveStream value.
+// Required because flowStoreCapture's UpdateStream stores updates in a
+// side map rather than mutating the original Stream row.
+func finalStreamProtocol(store *flowStoreCapture, streamID string) string {
+	var initial string
+	for _, st := range store.Streams() {
+		if st.ID == streamID {
+			initial = st.Protocol
+			break
+		}
+	}
+	final := initial
+	for _, upd := range store.StreamUpdates(streamID) {
+		if upd.Protocol != "" {
+			final = upd.Protocol
+		}
+	}
+	return final
+}
+
+// checkStreamProtocolEventually polls store for up to 3s until at least
+// one Stream is observed with effective Protocol == want. Fails the
+// test if the deadline elapses first.
+func checkStreamProtocolEventually(t *testing.T, store *flowStoreCapture, want string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasStreamWithProtocol(store, want) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Build a diagnostic dump.
+	var lines []string
+	for _, st := range store.Streams() {
+		final := finalStreamProtocol(store, st.ID)
+		lines = append(lines, fmt.Sprintf("stream %q initial=%q final=%q state=%q",
+			st.ID, st.Protocol, final, st.State))
+	}
+	t.Fatalf("no stream observed with Protocol=%q after 3s; recorded streams:\n%s",
+		want, strings.Join(lines, "\n"))
+}

--- a/internal/proxybuild/tcp_forward_l7.go
+++ b/internal/proxybuild/tcp_forward_l7.go
@@ -13,6 +13,7 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/grpcweb"
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
 	"github.com/usk6666/yorishiro-proxy/internal/pipeline"
 	"github.com/usk6666/yorishiro-proxy/internal/session"
@@ -104,12 +105,23 @@ func runTCPForwardHTTP1ExchangeLoop(
 	ctx context.Context,
 	stack *connector.ConnectionStack,
 	clientH1, upstreamH1 *http1.Layer,
+	parentStack *Stack,
 	p *pipeline.Pipeline,
 	sessOpts session.SessionOptions,
 	target string,
 	logger *slog.Logger,
 	filter exchangeFilter,
 ) {
+	// USK-934: derive base grpc-web Layer Options from the parent Stack's
+	// BuildConfig (matches the live data path's
+	// GRPCWebOptionsFromBuildConfig invocation in builder.go). The
+	// per-exchange goroutine layers the wire-record callback on top via
+	// session.GRPCWebBase64RecordOption — same wiring shape as the
+	// MITM-routed path.
+	var baseGRPCWebOpts []grpcweb.Option
+	if parentStack != nil {
+		baseGRPCWebOpts = connector.GRPCWebOptionsFromBuildConfig(parentStack.BuildConfig)
+	}
 	var wg sync.WaitGroup
 	for {
 		select {
@@ -124,7 +136,7 @@ func runTCPForwardHTTP1ExchangeLoop(
 			wg.Add(1)
 			go func(ch layer.Channel) {
 				defer wg.Done()
-				runForwardHTTP1Exchange(ctx, stack, ch, upstreamH1, p, sessOpts, target, logger, filter)
+				runForwardHTTP1Exchange(ctx, stack, ch, upstreamH1, p, sessOpts, target, logger, filter, baseGRPCWebOpts)
 			}(clientCh)
 		}
 	}
@@ -163,23 +175,88 @@ func runForwardHTTP1Exchange(
 	target string,
 	logger *slog.Logger,
 	filter exchangeFilter,
+	baseGRPCWebOpts []grpcweb.Option,
 ) {
-	// No filter: vanilla per-exchange dispatch — same shape as the
-	// builder.go runHTTP1ExchangeLoop goroutine.
+	// USK-934: per-exchange grpc-web auto-classify Options. The same
+	// closure is installed on both the client-side DispatchH1Channel and
+	// the upstream-side WrapH1UpstreamForDispatch so wire-record envelopes
+	// from both wraps land under the same Stream row.
+	streamFlowCtx := envelope.EnvelopeContext{ConnID: stack.ConnID, TargetHost: target}
+	grpcWebBase64Opt := session.GRPCWebBase64RecordOption(ctx, p, clientCh.StreamID(), streamFlowCtx)
+	streamGRPCWebOpts := make([]grpcweb.Option, 0, len(baseGRPCWebOpts)+1)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, baseGRPCWebOpts...)
+	streamGRPCWebOpts = append(streamGRPCWebOpts, grpcWebBase64Opt)
+
 	if filter == nil {
-		dial := func(_ context.Context, _ *envelope.Envelope) (layer.Channel, error) {
-			upCh := upstreamH1.OpenExchange()
-			if upCh == nil {
-				return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)
-			}
-			return upCh, nil
-		}
-		if err := session.RunStackSessionExchange(ctx, stack, clientCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Debug("proxybuild: tcp forward http1 exchange ended with error", "target", target, "error", err)
+		runForwardHTTP1ExchangeNoFilter(ctx, stack, clientCh, upstreamH1, p, sessOpts, target, logger, streamGRPCWebOpts)
+		return
+	}
+	runForwardHTTP1ExchangeWithFilter(ctx, stack, clientCh, upstreamH1, p, sessOpts, target, logger, filter, streamGRPCWebOpts)
+}
+
+// runForwardHTTP1ExchangeNoFilter is the no-filter arm of
+// runForwardHTTP1Exchange. Dispatches through H1 grpc-web auto-classify
+// (USK-934) and runs the vanilla per-exchange session. Mirrors
+// builder.go runHTTP1Exchange.
+func runForwardHTTP1ExchangeNoFilter(
+	ctx context.Context,
+	stack *connector.ConnectionStack,
+	clientCh layer.Channel,
+	upstreamH1 *http1.Layer,
+	p *pipeline.Pipeline,
+	sessOpts session.SessionOptions,
+	target string,
+	logger *slog.Logger,
+	streamGRPCWebOpts []grpcweb.Option,
+) {
+	dispatchedCh, err := connector.DispatchH1Channel(ctx, clientCh, grpcweb.RoleServer, streamGRPCWebOpts, logger)
+	if err != nil {
+		_ = clientCh.Close()
+		if !errors.Is(err, context.Canceled) {
+			logger.Debug("proxybuild: tcp forward http1 dispatch failed",
+				"target", target, "stream_id", clientCh.StreamID(), "error", err)
 		}
 		return
 	}
+	dial := func(_ context.Context, env *envelope.Envelope) (layer.Channel, error) {
+		upCh := upstreamH1.OpenExchange()
+		if upCh == nil {
+			return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)
+		}
+		var reqProto envelope.Protocol
+		if env != nil {
+			reqProto = env.Protocol
+		}
+		return connector.WrapH1UpstreamForDispatch(upCh, reqProto, streamGRPCWebOpts), nil
+	}
+	if err := session.RunStackSessionExchange(ctx, stack, dispatchedCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Debug("proxybuild: tcp forward http1 exchange ended with error", "target", target, "error", err)
+	}
+}
 
+// runForwardHTTP1ExchangeWithFilter is the filter arm of
+// runForwardHTTP1Exchange. The Protocol="websocket"/"sse" expectation
+// filter is applied first on the first request envelope. If the filter
+// passes, the request is replayed through DispatchH1Channel for
+// grpc-web auto-classify (USK-934); the response-phase filter remains
+// in place via filterUpstreamChannel. A websocket/sse filtered exchange
+// will not be a grpc-web request in practice (Upgrade: websocket header
+// is incompatible with application/grpc-web), so the DispatchH1Channel
+// branch on the replay channel will be the default no-wrap path — but
+// we keep it for symmetry with the no-filter arm and to preserve
+// protocol-detection correctness if the filter ever loosens.
+func runForwardHTTP1ExchangeWithFilter(
+	ctx context.Context,
+	stack *connector.ConnectionStack,
+	clientCh layer.Channel,
+	upstreamH1 *http1.Layer,
+	p *pipeline.Pipeline,
+	sessOpts session.SessionOptions,
+	target string,
+	logger *slog.Logger,
+	filter exchangeFilter,
+	streamGRPCWebOpts []grpcweb.Option,
+) {
 	// Request-phase filter: peek the first envelope. If the filter rejects,
 	// synthesise a 502, fire the Pipeline-Drop audit, and return without
 	// touching upstream.
@@ -203,24 +280,38 @@ func runForwardHTTP1Exchange(
 	}
 
 	// Request passed the filter: build a replay-channel that yields `first`
-	// once then delegates to the underlying Channel. RunStackSessionExchange
-	// is otherwise oblivious to the peek.
+	// once then delegates to the underlying Channel, then run it through
+	// DispatchH1Channel for grpc-web auto-classify (USK-934).
 	replayCh := &http1ReplayChannel{
 		underlying: clientCh,
 		queued:     []*envelope.Envelope{first},
+	}
+	dispatchedCh, err := connector.DispatchH1Channel(ctx, replayCh, grpcweb.RoleServer, streamGRPCWebOpts, logger)
+	if err != nil {
+		_ = clientCh.Close()
+		if !errors.Is(err, context.Canceled) {
+			logger.Debug("proxybuild: tcp forward http1 dispatch failed",
+				"target", target, "stream_id", clientCh.StreamID(), "error", err)
+		}
+		return
 	}
 
 	// Response-phase filter: wrap the upstream dial so the upstream
 	// Channel's first Receive is checked. The wrapper writes a 502 back
 	// to the client when the first response fails the filter and returns
 	// io.EOF on subsequent Next calls so the session loop unwinds.
-	dial := func(_ context.Context, _ *envelope.Envelope) (layer.Channel, error) {
+	dial := func(_ context.Context, env *envelope.Envelope) (layer.Channel, error) {
 		upCh := upstreamH1.OpenExchange()
 		if upCh == nil {
 			return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)
 		}
+		var reqProto envelope.Protocol
+		if env != nil {
+			reqProto = env.Protocol
+		}
+		wrappedUp := connector.WrapH1UpstreamForDispatch(upCh, reqProto, streamGRPCWebOpts)
 		return &filterUpstreamChannel{
-			Channel:  upCh,
+			Channel:  wrappedUp,
 			filter:   filter,
 			clientCh: clientCh,
 			onDrop: func(env *envelope.Envelope, blockedBy string) {
@@ -231,7 +322,7 @@ func runForwardHTTP1Exchange(
 		}, nil
 	}
 
-	if err := session.RunStackSessionExchange(ctx, stack, replayCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
+	if err := session.RunStackSessionExchange(ctx, stack, dispatchedCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Debug("proxybuild: tcp forward http1 exchange ended with error", "target", target, "error", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `internal/connector/h1_dispatch.go` — sibling of `h2_dispatch.go` providing `DispatchH1Channel` (downstream per-exchange content-type wrap) and `WrapH1UpstreamForDispatch` (upstream symmetry mirroring USK-771's H2 fix).
- Wire the H1 dispatcher into `runHTTP1ExchangeLoop` (live MITM path) and `runForwardHTTP1Exchange` (tcp_forward path), with the existing websocket/sse expectation filter applied before dispatch so the filter contract is preserved.
- Reuse the existing `flow.WireLevelGRPCWebBase64` overlay callback via `session.GRPCWebBase64RecordOption` on the H1 path (identical wiring to the H2 path in `buildOnHTTP2Stack`).
- Tests: `internal/connector/h1_dispatch_test.go` unit tests for content-type classification, replay-channel behaviour, and upstream wrap symmetry; `internal/proxybuild/tcp_forward_grpcweb_integration_test.go` e2e tests covering binary + base64 variants + JSON-POST negative control.

## Root cause
`Stream.Protocol` derives from `env.Protocol` via `record_step.go` `maybeRetagProtocol` + `createStream`. `Protocol=ProtocolGRPCWeb` is only stamped by `grpcweb.Channel`, which is wrapped by `grpcweb.Wrap` — but the H1 dispatch path (tcp_forward, CONNECT-MITM plaintext, ALPN-h1) never inspected content-type to invoke `grpcweb.Wrap`. So all H1 grpc-web traffic stayed `Protocol=ProtocolHTTP`. Wire bytes were preserved correctly throughout.

## Test plan
- [x] `make build` passes
- [x] `make lint` passes (gocyclo split runForwardHTTP1Exchange into no-filter / with-filter arms)
- [x] `make test` (fast tier) passes
- [x] `make test-e2e-smoke` (smoke tier) passes
- [x] New e2e tests pass under `go test -tags 'e2e' -race`:
  - `TestProxybuild_TCPForward_H1_GRPCWeb_Binary_AutoClassify` — Issue repro
  - `TestProxybuild_TCPForward_H1_GRPCWeb_Text_AutoClassify` — base64 text variant
  - `TestProxybuild_TCPForward_H1_JSONPOST_StaysHTTP` — negative control
- [x] Issue repro returns `protocol=grpc-web` flow via final Stream.Protocol projection

## Notes for review-gate
- **Deferred** WireLevelTap interface refactor (#13 in the design): NOT in this PR — separate follow-up. The five per-Layer record callbacks (http2 frame, http1 chunk, grpc LPM, aggregator h2-frame, grpcweb base64) satisfy Rule-of-Three but the refactor is scoped separately.
- **Per-exchange wrap rationale**: HTTP/1.1 keep-alive can mix grpc-web POST and JSON POST on the same connection, so the dispatch decision must be made per-exchange — not at stack-build time. This mirrors the H2 per-stream dispatch pattern.
- **CT mismatch policy**: request-side decision wins. The H2 sibling also classifies on first HEADERS only (h2_dispatch.go:131). Response-side content-type is NOT consulted for dispatch; anomalies surface via grpcweb's `classifyParseError` → Anomaly Start envelope.

Resolves USK-934
Linear: https://linear.app/usk6666/issue/USK-934

🤖 Generated with [Claude Code](https://claude.com/claude-code)