### PR TITLE
docs(mcp): proxy_start reset semantics + configure guidance (USK-950)

### DIFF
--- a/internal/mcp/configure_tool.go
+++ b/internal/mcp/configure_tool.go
@@ -418,7 +418,9 @@ func (s *Server) registerConfigure() {
 		Description: "Update runtime proxy settings on a running listener (upstream proxy, TLS passthrough, " +
 			"intercept rules + queue, auto-transform, SOCKS5 auth, TLS fingerprint, connection/timeout limits). " +
 			"operation='merge' (default) applies incremental add/remove changes; 'replace' replaces entire sections. " +
-			"Only specified sections are modified. Settings are session-only — to persist them use the config file. " +
+			"Only specified sections are modified — use this tool for in-session partial updates instead of " +
+			"re-calling `proxy_start` (which fully resets all prior settings on every invocation). " +
+			"Settings are session-only — to persist them use the config file. " +
 			"The optional top-level 'name' field scopes upstream_proxy to a single listener (default: 'default'); " +
 			"other sections (capture_scope, tls_passthrough, intercept_rules, auto_transform, ...) currently remain " +
 			"process-global regardless of 'name'. Multi-listener chained MITM requires per-listener upstream_proxy " +

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -217,12 +217,18 @@ type proxyStartResult struct {
 func (s *Server) registerProxyStart() {
 	gomcp.AddTool(s.server, &gomcp.Tool{
 		Name: "proxy_start",
-		Description: "Start a proxy listener on a loopback address with HTTP/HTTPS/SOCKS5 MITM. " +
+		Description: "Start (or initialize) a proxy listener on a loopback address with HTTP/HTTPS/SOCKS5 MITM. " +
+			"Intended for first-time startup / session initialization. " +
 			"Multiple named listeners are supported via 'name' (default: 'default'). " +
-			"All configuration sections (upstream proxy, TLS passthrough, intercept/transform rules, " +
-			"SOCKS5 auth, TLS fingerprint, connection/timeout limits, tcp_forwards) are session-only " +
-			"and are reset to defaults on each invocation; persistent settings belong in the config file. " +
-			"See yorishiro://help/proxy_start for parameter details.",
+			"IMPORTANT: each call fully resets all prior settings to the values in this request — " +
+			"omitted fields revert to defaults (capture_scope, tls_passthrough, intercept_rules, " +
+			"auto_transform, tcp_forwards, SOCKS5 auth, TLS fingerprint, connection/timeout limits). " +
+			"Do NOT call proxy_start repeatedly just to add one intercept_rule or transform rule — " +
+			"that wipes other settings such as capture_scope / tls_passthrough / tcp_forwards. " +
+			"For in-session partial updates (add/remove a single rule, change one timeout) use the " +
+			"`configure` tool with operation='merge' or 'replace' instead. " +
+			"Persistent settings belong in the config file. " +
+			"See yorishiro://help/proxy_start for parameter details and misuse patterns.",
 	}, s.handleProxyStart)
 }
 

--- a/internal/mcp/proxy_start_tool_test.go
+++ b/internal/mcp/proxy_start_tool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -1997,4 +1998,99 @@ func combineCallToolText(result *gomcp.CallToolResult) string {
 		}
 	}
 	return out
+}
+
+// TestProxyStartTool_DescriptionGuidesToConfigure asserts that the
+// proxy_start tool description contains the key phrases that steer AI
+// agents away from the documented misuse pattern (USK-950): re-calling
+// proxy_start to add a single rule, which silently resets every other
+// session setting (USK-407 semantics).
+//
+// Each row asserts on a substring rather than the entire description so
+// cosmetic edits do not cascade into test churn. The intent is to fail
+// loudly if the reset-semantics warning or the configure-guidance phrase
+// is removed.
+func TestProxyStartTool_DescriptionGuidesToConfigure(t *testing.T) {
+	desc := lookupToolDescription(t, "proxy_start")
+
+	cases := []struct {
+		name   string
+		phrase string
+	}{
+		{
+			name:   "reset semantics warning",
+			phrase: "resets all prior settings",
+		},
+		{
+			name:   "configure tool recommended for partial updates",
+			phrase: "configure",
+		},
+		{
+			name:   "misuse pattern named",
+			phrase: "Do NOT call proxy_start repeatedly",
+		},
+		{
+			name:   "links to help resource",
+			phrase: "yorishiro://help/proxy_start",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(desc, tc.phrase) {
+				t.Errorf("proxy_start Description missing key phrase %q\n--- description ---\n%s\n--- end ---",
+					tc.phrase, desc)
+			}
+		})
+	}
+}
+
+// TestConfigureTool_DescriptionPointsAtProxyStart asserts the reciprocal
+// cross-reference (USK-950): the configure tool description names
+// proxy_start as the tool whose reset semantics configure replaces for
+// in-session partial updates. Substring assertions only — wording may be
+// refined without breaking the test as long as the concept survives.
+func TestConfigureTool_DescriptionPointsAtProxyStart(t *testing.T) {
+	desc := lookupToolDescription(t, "configure")
+
+	cases := []struct {
+		name   string
+		phrase string
+	}{
+		{
+			name:   "names proxy_start as the alternative to NOT re-call",
+			phrase: "proxy_start",
+		},
+		{
+			name:   "describes configure as the partial-update path",
+			phrase: "in-session partial updates",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(desc, tc.phrase) {
+				t.Errorf("configure Description missing key phrase %q\n--- description ---\n%s\n--- end ---",
+					tc.phrase, desc)
+			}
+		})
+	}
+}
+
+// lookupToolDescription returns the Description field of the named MCP
+// tool by listing tools through a fully-wired client session. Fails the
+// test fatally when the tool is not registered.
+func lookupToolDescription(t *testing.T, name string) string {
+	t.Helper()
+	manager := newTestProxybuildManager(t)
+	cs := setupProxyStartTestSession(t, manager, nil)
+	res, err := cs.ListTools(context.Background(), &gomcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	for _, tool := range res.Tools {
+		if tool.Name == name {
+			return tool.Description
+		}
+	}
+	t.Fatalf("tool %q not found in ListTools result", name)
+	return ""
 }

--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -1,6 +1,8 @@
 # proxy_start
 
-Start the proxy server with optional configuration. The proxy listens on the specified address and begins intercepting HTTP/HTTPS/SOCKS5 traffic.
+Start (or initialize) the proxy server with optional configuration. The proxy listens on the specified address and begins intercepting HTTP/HTTPS/SOCKS5 traffic.
+
+**Reset semantics (USK-407)**: each `proxy_start` call fully resets all prior session settings to the values supplied in the request. Fields omitted from the request revert to their defaults — including `capture_scope`, `tls_passthrough`, `intercept_rules`, `auto_transform`, `tcp_forwards`, SOCKS5 auth, TLS fingerprint, and connection/timeout limits. Use `proxy_start` for first-time startup or session initialization. For in-session partial updates to a running listener (adding a single rule, changing one timeout, etc.), use the [`configure`](yorishiro://help/configure) tool instead.
 
 ## Parameters
 
@@ -164,6 +166,54 @@ Example:
   }
 }
 ```
+
+## Common Misuse: proxy_start as a partial-update tool
+
+`proxy_start` is **not** a delta-apply tool. Calling it repeatedly to "add one more intercept rule" wipes every other setting that was previously established for the listener.
+
+### Anti-pattern (do NOT do this)
+
+```json
+// Step 1: set up the session.
+{ "method": "proxy_start", "params": {
+    "listen_addr": "127.0.0.1:8080",
+    "capture_scope": { "includes": [{ "hostname": "api.target.com" }] },
+    "tls_passthrough": ["*.googleapis.com"]
+}}
+
+// Step 2 (WRONG): adding an intercept rule by re-calling proxy_start.
+//   This RESETS capture_scope back to "capture all" and clears tls_passthrough,
+//   because both fields are omitted from this second request.
+{ "method": "proxy_start", "params": {
+    "listen_addr": "127.0.0.1:8080",
+    "intercept_rules": [
+      { "id": "r1", "enabled": true, "direction": "request",
+        "http": { "host_pattern": "api\\.target\\.com" } }
+    ]
+}}
+```
+
+### Recommended pattern: initialize with `proxy_start`, update with `configure`
+
+```json
+// Step 1: one-shot initialization.
+{ "method": "proxy_start", "params": {
+    "listen_addr": "127.0.0.1:8080",
+    "capture_scope": { "includes": [{ "hostname": "api.target.com" }] },
+    "tls_passthrough": ["*.googleapis.com"]
+}}
+
+// Step 2: in-session update — add an intercept rule without touching the rest.
+{ "method": "configure", "params": {
+    "operation": "merge",
+    "intercept_rules": { "add": [
+      { "id": "r1", "enabled": true, "direction": "request",
+        "http": { "host_pattern": "api\\.target\\.com" } }
+    ]}
+}}
+```
+
+See the [`configure`](yorishiro://help/configure) tool for the full merge / replace surface (add, remove, enable, disable per rule ID, or full-section replacement).
 
 ## Usage Examples
 


### PR DESCRIPTION
## Summary
- Document `proxy_start` full-reset semantics (USK-407) in the tool description.
- Guide AI agents to `configure` for in-session partial updates (USK-794).
- Add misuse-pattern section to `help_proxy_start.md`.
- Mirror the cross-reference in `configure` tool description.
- Add snapshot-style assertion test on the new description key phrases.

No behavior change to `proxy_start` or `configure` — docs/test only.

## Test plan
- [ ] `make lint` clean
- [ ] `make build` succeeds
- [ ] `make test` passes (new description-assertion test included)
- [ ] Spot-check the rendered help_proxy_start.md misuse section reads correctly

Resolves USK-950
Linear: https://linear.app/usk6666/issue/USK-950

🤖 Generated with [Claude Code](https://claude.com/claude-code)