### PR TITLE
fix(connector): classify ECONNRESET as tunneled in TLS passthrough audit outcome (USK-952)

### DIFF
--- a/internal/connector/tls_passthrough.go
+++ b/internal/connector/tls_passthrough.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -319,17 +320,22 @@ func hostOnly(authority string) string {
 // vs "the proxy aborted mid-relay". Connection-close conditions —
 // io.EOF, "use of closed network connection" once the client or
 // upstream initiated TCP FIN, broken-pipe race after a peer-side close,
-// and io.ErrClosedPipe on net.Pipe-backed test fixtures — are all
-// "tunneled" outcomes from the audit perspective: they describe the
-// terminal close, not a mid-stream failure.
+// io.ErrClosedPipe on net.Pipe-backed test fixtures, and
+// "connection reset by peer" (ECONNRESET) when a peer closes without
+// draining pending bytes (TLS close_notify in flight, abrupt browser /
+// mobile-handover close, etc.) — are all "tunneled" outcomes from the
+// audit perspective: they describe the terminal close, not a mid-stream
+// failure.
 //
 // This classification is deliberately tolerant: under-classifying an
 // outcome as "failed" trains operators to ignore the field, which is
 // worse than the rare false-tunneled on a genuine partial-relay error.
-// When a connection genuinely fails mid-relay the dial path or the
-// io.Copy errors out with a non-close error (e.g. "i/o timeout",
-// "connection reset by peer" while still sending data) and that lands
-// in the "failed" bucket.
+// When a connection genuinely fails the dial path or io.Copy errors
+// out with a non-close error (e.g. "i/o timeout" mid-stream, a
+// deadline-exceeded read, "no route to host") and that lands in the
+// "failed" bucket. ECONNRESET intentionally moved to "tunneled" after
+// USK-952: in MITM passthrough the dominant cause is ungraceful peer
+// close after bytes have flowed, not a genuine partial-relay error.
 func isTunneledOutcome(err error) bool {
 	if err == nil {
 		return true
@@ -341,6 +347,9 @@ func isTunneledOutcome(err error) bool {
 		return true
 	}
 	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
 		return true
 	}
 	return false

--- a/internal/connector/tls_passthrough_test.go
+++ b/internal/connector/tls_passthrough_test.go
@@ -2,7 +2,11 @@ package connector
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -120,5 +124,35 @@ func TestRelayBidirectional_OneDirectionClose(t *testing.T) {
 	case <-errCh:
 	case <-time.After(3 * time.Second):
 		t.Fatal("relay did not complete")
+	}
+}
+
+func TestIsTunneledOutcome(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, true},
+		{"io.EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("readfrom: %w", io.EOF), true},
+		{"io.ErrClosedPipe", io.ErrClosedPipe, true},
+		{"net.ErrClosed", net.ErrClosed, true},
+		{"wrapped net.ErrClosed", fmt.Errorf("write tcp: %w", net.ErrClosed), true},
+		// USK-952: ECONNRESET on a passthrough relay is dominated by
+		// ungraceful peer close after bytes have flowed (TLS close_notify
+		// in flight, mobile-handover, browser tab close). Classify as
+		// tunneled per the function's tolerance policy.
+		{"syscall.ECONNRESET", syscall.ECONNRESET, true},
+		{"wrapped ECONNRESET", fmt.Errorf("read tcp: %w", syscall.ECONNRESET), true},
+		{"unrelated error", errors.New("i/o timeout mid-relay"), false},
+		{"DNS error", errors.New("no such host"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTunneledOutcome(tc.err); got != tc.want {
+				t.Errorf("isTunneledOutcome(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `syscall.ECONNRESET` (and wrapped forms via `errors.Is`) to `isTunneledOutcome` in `internal/connector/tls_passthrough.go`.
- Updates the function's doc comment to record the new policy and the USK-952 rationale.
- Adds a table-driven unit test `TestIsTunneledOutcome` covering nil / EOF / ErrClosedPipe / net.ErrClosed / ECONNRESET / wrapped / unrelated cases.

## Why

`TestProxybuild_TLSPassthrough_InScope_HostnameMatch` (`internal/proxybuild/passthrough_audit_integration_test.go:429`) flakes ~15% in the nightly e2e (full) tier with `Stream.State = "error", want complete`. Failing-run proxy logs show the relay observing `read tcp ...: read: connection reset by peer` after the client closes without draining the upstream's `close_notify`. The pre-fix classifier treated this as a relay failure even though bytes had flowed for the lifetime of the connection — exactly the over-classification the existing comment warns against.

In MITM passthrough, ECONNRESET is dominated by ungraceful peer close (mobile-handover, browser tab close, app force-quit, TLS close without draining). Reclassifying it as `tunneled` follows the function's stated tolerance policy.

## Test plan

- [x] `make test` — fast tier passes.
- [x] `make test-e2e-smoke` — smoke tier passes on this branch.
- [x] `go test -race -tags e2e -run TestProxybuild_TLSPassthrough_InScope_HostnameMatch -count=20 ./internal/proxybuild/` — 20/20 (pre-fix flaked 3/20 on the same machine).
- [x] `go test -race -run TestIsTunneledOutcome ./internal/connector/` — new unit test green.

Closes USK-952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)