### PR TITLE
fix(mcp/fuzz_http test): poll fuzz_jobs.completed_at after cancelled CallTool (USK-953)

### DIFF
--- a/internal/mcp/fuzz_http_integration_test.go
+++ b/internal/mcp/fuzz_http_integration_test.go
@@ -1106,24 +1106,39 @@ func TestFuzzHTTP_FinalizesUnderCallerCancel(t *testing.T) {
 	})
 	_ = res // either an in-band stopped_reason or a transport-level cancel error is OK
 
-	// Query fuzz_jobs through a fresh context (the caller cancel does
-	// not affect this query).
-	jobsRes, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
-		Name: "query",
-		Arguments: map[string]any{
-			"resource": "fuzz_jobs",
-			"filter":   map[string]any{"tag": "usk-827-cancel"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("query fuzz_jobs: %v", err)
-	}
-	if jobsRes.IsError {
-		t.Fatalf("query fuzz_jobs returned error: %+v", jobsRes.Content)
-	}
+	// The cancelled CallTool may return to the client before the server's
+	// handler has actually finished. The finalize step uses context.Background()
+	// internally, so it WILL eventually land — but not necessarily before
+	// this test continues. Poll the query tool until fuzz_jobs.completed_at
+	// is non-nil (USK-953). The polling interval is short so the typical
+	// case completes within a few iterations.
+	pollDeadline := time.Now().Add(2 * time.Second)
 	var jobsOut queryFuzzJobsResult
-	if err := json.Unmarshal([]byte(jobsRes.Content[0].(*gomcp.TextContent).Text), &jobsOut); err != nil {
-		t.Fatalf("unmarshal jobs: %v", err)
+	for {
+		jobsRes, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+			Name: "query",
+			Arguments: map[string]any{
+				"resource": "fuzz_jobs",
+				"filter":   map[string]any{"tag": "usk-827-cancel"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("query fuzz_jobs: %v", err)
+		}
+		if jobsRes.IsError {
+			t.Fatalf("query fuzz_jobs returned error: %+v", jobsRes.Content)
+		}
+		jobsOut = queryFuzzJobsResult{}
+		if err := json.Unmarshal([]byte(jobsRes.Content[0].(*gomcp.TextContent).Text), &jobsOut); err != nil {
+			t.Fatalf("unmarshal jobs: %v", err)
+		}
+		if jobsOut.Total == 1 && jobsOut.Jobs[0].CompletedAt != nil {
+			break
+		}
+		if time.Now().After(pollDeadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	if jobsOut.Total != 1 {
 		t.Fatalf("jobs total = %d, want 1 (start INSERT must land via background ctx)", jobsOut.Total)


### PR DESCRIPTION
## Summary

- Replaces the single-shot `query fuzz_jobs` in `TestFuzzHTTP_FinalizesUnderCallerCancel` with a 2 s polling loop that exits once `completed_at != nil`.
- Assertion semantics are unchanged: \"finalize must land via the background ctx even on caller cancel.\" Only the wait tightens to absorb the handler's tail latency.

## Why

`TestFuzzHTTP_FinalizesUnderCallerCancel` (`internal/mcp/fuzz_http_integration_test.go:1059`) flakes ~20% in the nightly e2e (full) tier with `fuzz_jobs.completed_at = nil after caller cancel; finalize did not land`.

Production code is correct: `finalizeFuzzHTTPJob` is invoked with `context.Background()` so the closing UPDATE is unaffected by caller-side cancel (`internal/mcp/fuzz_http.go:202`).

The race is in the test. With the in-memory MCP transport, `cs.CallTool` returns to the client as soon as the handler's ctx is cancelled — but the server-side handler is still running, returning from `runFuzzHTTPVariants`, then synchronously running the background-ctx finalize. The test then immediately queries `fuzz_jobs` and observes `completed_at = nil` because the server hasn't drained its write yet.

## Test plan

- [x] `make test` — fast tier passes.
- [x] `make test-e2e-smoke` — smoke tier passes on this branch.
- [x] `go test -race -tags e2e -run TestFuzzHTTP_FinalizesUnderCallerCancel -count=20 ./internal/mcp/` — 20/20 (pre-fix flaked 2/10 on the same machine).

Closes USK-953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)