### PR TITLE
feat(proxybuild,connector,config): per-listener upstream proxy rotation for live MITM data path (USK-959)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -621,8 +621,22 @@ type ProxyConfig struct {
 	// Use UnmarshalJSON for backward-compatible parsing.
 	TCPForwards map[string]*ForwardConfig `json:"tcp_forwards,omitempty"`
 
-	// UpstreamProxy is the upstream proxy URL for proxy chaining.
-	UpstreamProxy string `json:"upstream_proxy,omitempty"`
+	// UpstreamProxy is the upstream proxy URL for proxy chaining (legacy
+	// USK-826 string form). When the config file uses the structured
+	// object form (USK-959), this field holds the URL extracted from the
+	// object's "url" key — or remains empty when "url_template" is set
+	// instead. Use UpstreamProxyStruct for the full structured form
+	// (URL, URLTemplate, Rotation).
+	//
+	// Wire schema: the JSON key "upstream_proxy" is polymorphic — string
+	// (legacy) or object (USK-959). ProxyConfig.UnmarshalJSON dispatches.
+	UpstreamProxy string `json:"-"`
+
+	// UpstreamProxyStruct carries the structured per-listener upstream
+	// proxy config (USK-959). Set by ProxyConfig.UnmarshalJSON when the
+	// "upstream_proxy" JSON value is an object; nil when the legacy
+	// string form is used (UpstreamProxy holds the literal URL then).
+	UpstreamProxyStruct *UpstreamProxyConfig `json:"-"`
 
 	// TLSFingerprint selects the TLS ClientHello fingerprint profile for upstream connections.
 	// Valid values: "chrome" (default), "firefox", "safari", "edge", "random", "none" (standard crypto/tls).
@@ -807,27 +821,37 @@ func (c *ProxyConfig) Validate() error {
 	if err := c.GRPCSchema.Validate(); err != nil {
 		return err
 	}
+	if c.UpstreamProxyStruct != nil {
+		if err := c.UpstreamProxyStruct.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler for ProxyConfig.
-// It handles backward-compatible deserialization of TCPForwards, which can be
-// either a string value (legacy: "host:port") or a structured ForwardConfig object.
+// It handles backward-compatible deserialization of:
+//   - TCPForwards, which can be either a string value (legacy: "host:port")
+//     or a structured ForwardConfig object.
+//   - UpstreamProxy, which can be either a string (legacy USK-826
+//     literal URL) or an object (USK-959 structured: url|url_template +
+//     rotation).
 func (c *ProxyConfig) UnmarshalJSON(data []byte) error {
 	// Use an alias type to avoid infinite recursion.
 	type proxyConfigAlias ProxyConfig
-	// Temporarily override TCPForwards to capture raw JSON.
-	type proxyConfigWithRawForwards struct {
+	// Temporarily override polymorphic fields to capture raw JSON.
+	type proxyConfigWithRaw struct {
 		proxyConfigAlias
-		TCPForwards json.RawMessage `json:"tcp_forwards,omitempty"`
+		TCPForwards   json.RawMessage `json:"tcp_forwards,omitempty"`
+		UpstreamProxy json.RawMessage `json:"upstream_proxy,omitempty"`
 	}
 
-	var raw proxyConfigWithRawForwards
+	var raw proxyConfigWithRaw
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Copy all fields except TCPForwards.
+	// Copy all fields except the polymorphic ones.
 	*c = ProxyConfig(raw.proxyConfigAlias)
 
 	// Parse TCPForwards with backward compatibility.
@@ -839,7 +863,48 @@ func (c *ProxyConfig) UnmarshalJSON(data []byte) error {
 		c.TCPForwards = parsed
 	}
 
+	// Parse UpstreamProxy: string (legacy) or object (USK-959).
+	if len(raw.UpstreamProxy) > 0 {
+		s, obj, err := unmarshalUpstreamProxy(raw.UpstreamProxy)
+		if err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+		c.UpstreamProxy = s
+		c.UpstreamProxyStruct = obj
+	}
+
 	return nil
+}
+
+// unmarshalUpstreamProxy parses a JSON value that can be either a
+// string (legacy USK-826 literal URL) or an object (USK-959 structured
+// form with url|url_template + rotation). Returns the legacy string
+// form (populated for both legacy and object-with-url shapes) plus the
+// structured form (nil when the input was a plain string).
+func unmarshalUpstreamProxy(data json.RawMessage) (string, *UpstreamProxyConfig, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return "", nil, nil
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return "", nil, fmt.Errorf("must be a string or object: %w", err)
+		}
+		return s, nil, nil
+	}
+	var obj UpstreamProxyConfig
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", nil, err
+	}
+	// Mirror the URL form into the legacy string field so existing
+	// callers (proxy_start_tool defaults merge) keep working without
+	// branching on the polymorphic shape.
+	legacy := ""
+	if obj.URL != "" {
+		legacy = obj.URL
+	}
+	return legacy, &obj, nil
 }
 
 // unmarshalTCPForwards parses a JSON value that can be either:

--- a/internal/config/upstream_proxy.go
+++ b/internal/config/upstream_proxy.go
@@ -11,6 +11,8 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -165,13 +167,19 @@ func (c *UpstreamProxyConfig) UnmarshalJSON(data []byte) error {
 // the macro engine + scheme whitelist locally to avoid pulling in
 // internal/connector at config-time (which would create an import
 // cycle: connector → config → connector).
+//
+// The KV provided here must match the runtime resolver's KV exactly
+// (`internal/connector/upstream_proxy_rotation.go`), otherwise a
+// template that probes clean here can still fail at first live dial
+// (Stage 2). The live resolver populates only `__nonce`; do not add
+// `__iteration` or any other key — `§__iteration§` is intentionally
+// not exposed on the live data path (USK-959 binding decision #7).
 func probeExpandTemplate(tpl string) error {
 	if tpl == "" {
 		return fmt.Errorf("url_template is empty")
 	}
 	kv := map[string]string{
-		macro.ReservedKeyPrefix + "nonce":     uuid.NewString(),
-		macro.ReservedKeyPrefix + "iteration": "0",
+		macro.ReservedKeyPrefix + "nonce": uuid.NewString(),
 	}
 	expanded, err := macro.ExpandTemplate(tpl, kv)
 	if err != nil {
@@ -183,9 +191,30 @@ func probeExpandTemplate(tpl string) error {
 	// Lightweight scheme + host:port check; the canonical parse lives
 	// in connector.ParseUpstreamProxy which the live dial path calls
 	// per request. We do not depend on that package here to avoid the
-	// import cycle described above.
+	// import cycle described above, but the checks below mirror what
+	// ParseUpstreamProxy does so that any input that probes clean here
+	// will also pass the runtime parse — Stage 1 / Stage 2 parity.
 	if !strings.HasPrefix(expanded, "http://") && !strings.HasPrefix(expanded, "socks5://") {
 		return fmt.Errorf("expanded URL must use scheme http:// or socks5://")
+	}
+	u, err := url.Parse(expanded)
+	if err != nil {
+		// e.g. an unsubstituted §-macro left in the URL — the section
+		// sign is rejected by url.Parse as invalid userinfo. Surfacing
+		// it here means the operator sees the error at config-apply
+		// time rather than at the first live dial (Stage 2 fail-closed
+		// also catches it, but later).
+		return fmt.Errorf("parse expanded URL: %w", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("expanded URL has no host")
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return fmt.Errorf("expanded URL must include a port (e.g. %s://host:port)", u.Scheme)
+	}
+	if host == "" || port == "" {
+		return fmt.Errorf("expanded URL has empty host or port")
 	}
 	return nil
 }

--- a/internal/config/upstream_proxy.go
+++ b/internal/config/upstream_proxy.go
@@ -1,0 +1,191 @@
+// upstream_proxy.go carries the per-listener upstream-proxy
+// configuration (USK-959). The wire schema is polymorphic: the
+// "upstream_proxy" config key accepts either a plain string (legacy
+// USK-826 shape: literal URL applied to the default listener) OR an
+// object with {url|url_template, rotation}.
+//
+// ProxyConfig.UnmarshalJSON (in config.go) dispatches the polymorphism;
+// this file owns the validation + types only.
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/usk6666/yorishiro-proxy/internal/macro"
+)
+
+// UpstreamProxyConfig is the file-level structured per-listener
+// upstream-proxy configuration (USK-959). Exactly one of URL /
+// URLTemplate must be set; Rotation is required when URLTemplate is
+// set and forbidden when URL is set (a static URL has nothing to
+// rotate).
+//
+// The wire surface accepts the legacy ProxyConfig.UpstreamProxy string
+// for backwards compatibility — the string is parsed into
+// UpstreamProxyConfig{URL: s} by ProxyConfig.UnmarshalJSON.
+type UpstreamProxyConfig struct {
+	// URL is a literal upstream proxy URL (http:// or socks5://). When
+	// set, the listener dials through this URL on every request without
+	// rotation. Mutually exclusive with URLTemplate.
+	URL string `json:"url,omitempty" jsonschema:"literal upstream proxy URL (http:// or socks5://); mutually exclusive with url_template"`
+
+	// URLTemplate is the macro-template form (USK-959). Supports
+	// §__nonce§ (per-resolution UUID) for residential-proxy IP
+	// rotation. Mutually exclusive with URL; requires Rotation.
+	URLTemplate string `json:"url_template,omitempty" jsonschema:"upstream proxy URL template; supports §__nonce§ (per-resolution UUID); requires rotation"`
+
+	// Rotation selects the rotation policy. Required when URLTemplate
+	// is set; forbidden when URL is set.
+	Rotation *UpstreamProxyRotation `json:"rotation,omitempty" jsonschema:"rotation policy; required with url_template"`
+}
+
+// UpstreamProxyRotation describes how often a URLTemplate is expanded
+// during the listener's lifetime (USK-959).
+type UpstreamProxyRotation struct {
+	// Policy selects how often the resolver mints a fresh URL.
+	//
+	// Valid values:
+	//   - per_request: expand at every outbound TCP dial
+	//   - per_connection: cache by inbound proxy ConnID
+	//   - per_target_host: cache by (listener, upstream host)
+	//   - sticky: mint once for the listener's lifetime
+	Policy string `json:"policy" jsonschema:"rotation policy: per_request | per_connection | per_target_host | sticky"`
+}
+
+// Validate reports the first problem with the structured per-listener
+// upstream-proxy config. It enforces the URL ⊕ URLTemplate exclusivity,
+// rotation policy whitelist, and probe-expands the template once with
+// a synthetic nonce so a clearly-malformed template surfaces at
+// config-apply time rather than at the first live dial (Stage 1
+// fail-closed in the binding decisions).
+func (c *UpstreamProxyConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.URL != "" && c.URLTemplate != "" {
+		return fmt.Errorf("upstream_proxy: url and url_template are mutually exclusive")
+	}
+	if c.URL == "" && c.URLTemplate == "" {
+		return fmt.Errorf("upstream_proxy: one of url or url_template is required")
+	}
+	if c.URL != "" {
+		if c.Rotation != nil {
+			return fmt.Errorf("upstream_proxy: rotation is not valid with url (set url_template to enable rotation)")
+		}
+		// USK-826 string form: defer URL parsing to the runtime
+		// connector.ParseUpstreamProxy (the file-level config layer
+		// historically did not parse, so a malformed URL surfaces at
+		// proxy_start). Match that behaviour.
+		return nil
+	}
+	// URLTemplate path
+	if c.Rotation == nil {
+		return fmt.Errorf("upstream_proxy: rotation is required with url_template")
+	}
+	if err := c.Rotation.Validate(); err != nil {
+		return fmt.Errorf("upstream_proxy: %w", err)
+	}
+	// Probe-expand with a synthetic nonce so a malformed template (bad
+	// scheme, missing port, CRLF) fails at config-apply time rather
+	// than at the first live dial. The probe does not commit any
+	// resolver state — it is a pure validation step.
+	if err := probeExpandTemplate(c.URLTemplate); err != nil {
+		return fmt.Errorf("upstream_proxy.url_template: %w", err)
+	}
+	return nil
+}
+
+// Validate reports the first problem with the rotation config. Currently
+// limited to the policy whitelist; future extensions (cooldown
+// intervals, error-driven rotation) land here.
+func (r *UpstreamProxyRotation) Validate() error {
+	if r == nil {
+		return nil
+	}
+	switch r.Policy {
+	case "per_request", "per_connection", "per_target_host", "sticky":
+		return nil
+	case "":
+		return fmt.Errorf("rotation.policy is required (per_request | per_connection | per_target_host | sticky)")
+	default:
+		return fmt.Errorf("rotation.policy %q not supported (per_request | per_connection | per_target_host | sticky)", r.Policy)
+	}
+}
+
+// IsRotating reports whether the config carries a rotating template
+// (URLTemplate set + Rotation policy validated). False for the legacy
+// static URL form.
+func (c *UpstreamProxyConfig) IsRotating() bool {
+	return c != nil && c.URLTemplate != "" && c.Rotation != nil
+}
+
+// MarshalJSON serialises the structured form verbatim. The legacy
+// string form is round-tripped by ProxyConfig.UnmarshalJSON, which
+// promotes a JSON-string value into UpstreamProxyConfig{URL: s} on
+// load; the symmetric promotion on save would require a heuristic and
+// is out of scope.
+func (c *UpstreamProxyConfig) MarshalJSON() ([]byte, error) {
+	type alias UpstreamProxyConfig
+	return json.Marshal((*alias)(c))
+}
+
+// UnmarshalJSON accepts either a string (legacy literal URL) or an
+// object (USK-959 structured shape). String values are stored as
+// {URL: s}; object values are decoded verbatim.
+func (c *UpstreamProxyConfig) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("upstream_proxy: must be a string or object: %w", err)
+		}
+		c.URL = s
+		c.URLTemplate = ""
+		c.Rotation = nil
+		return nil
+	}
+	type alias UpstreamProxyConfig
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return fmt.Errorf("upstream_proxy: %w", err)
+	}
+	*c = UpstreamProxyConfig(tmp)
+	return nil
+}
+
+// probeExpandTemplate runs macro expansion + CRLF guard +
+// supportedUpstreamSchemes check against a synthetic nonce. Imports
+// the macro engine + scheme whitelist locally to avoid pulling in
+// internal/connector at config-time (which would create an import
+// cycle: connector → config → connector).
+func probeExpandTemplate(tpl string) error {
+	if tpl == "" {
+		return fmt.Errorf("url_template is empty")
+	}
+	kv := map[string]string{
+		macro.ReservedKeyPrefix + "nonce":     uuid.NewString(),
+		macro.ReservedKeyPrefix + "iteration": "0",
+	}
+	expanded, err := macro.ExpandTemplate(tpl, kv)
+	if err != nil {
+		return fmt.Errorf("expand: %w", err)
+	}
+	if strings.ContainsAny(expanded, "\r\n") {
+		return fmt.Errorf("expanded URL contains CR/LF (CWE-93 guard)")
+	}
+	// Lightweight scheme + host:port check; the canonical parse lives
+	// in connector.ParseUpstreamProxy which the live dial path calls
+	// per request. We do not depend on that package here to avoid the
+	// import cycle described above.
+	if !strings.HasPrefix(expanded, "http://") && !strings.HasPrefix(expanded, "socks5://") {
+		return fmt.Errorf("expanded URL must use scheme http:// or socks5://")
+	}
+	return nil
+}

--- a/internal/config/upstream_proxy_test.go
+++ b/internal/config/upstream_proxy_test.go
@@ -57,6 +57,26 @@ func TestUpstreamProxyConfig_Validate_RotationProbeRejectsMalformed(t *testing.T
 	}
 }
 
+// TestUpstreamProxyConfig_Validate_RotationProbeRejectsIterationMacro
+// verifies Stage 1 / Stage 2 KV parity: §__iteration§ is NOT exposed on
+// the live data path (the runtime resolver populates only §__nonce§),
+// so a template referencing §__iteration§ must be rejected at
+// config-apply time rather than passing the probe and then failing at
+// the first live dial. Locks in the USK-959 review fix (F-2).
+func TestUpstreamProxyConfig_Validate_RotationProbeRejectsIterationMacro(t *testing.T) {
+	c := &UpstreamProxyConfig{
+		URLTemplate: "http://session-§__iteration§@proxy.example:8080",
+		Rotation:    &UpstreamProxyRotation{Policy: "per_request"},
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("expected probe to reject §__iteration§ template at config time")
+	}
+	if !strings.Contains(err.Error(), "url_template") {
+		t.Errorf("error missing user-facing prefix: %v", err)
+	}
+}
+
 // TestUpstreamProxyConfig_Validate_URLAndTemplateMutuallyExclusive
 // verifies the URL ⊕ URLTemplate guard.
 func TestUpstreamProxyConfig_Validate_URLAndTemplateMutuallyExclusive(t *testing.T) {

--- a/internal/config/upstream_proxy_test.go
+++ b/internal/config/upstream_proxy_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestUpstreamProxyConfig_UnmarshalString verifies the polymorphic
+// UnmarshalJSON honours the legacy USK-826 string form.
+func TestUpstreamProxyConfig_UnmarshalString(t *testing.T) {
+	var c UpstreamProxyConfig
+	if err := json.Unmarshal([]byte(`"http://proxy.example:8080"`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.URL != "http://proxy.example:8080" {
+		t.Errorf("URL = %q, want http://proxy.example:8080", c.URL)
+	}
+	if c.URLTemplate != "" || c.Rotation != nil {
+		t.Errorf("string form should leave URLTemplate/Rotation empty: %+v", c)
+	}
+}
+
+// TestUpstreamProxyConfig_UnmarshalObject verifies the polymorphic
+// UnmarshalJSON honours the USK-959 structured form.
+func TestUpstreamProxyConfig_UnmarshalObject(t *testing.T) {
+	var c UpstreamProxyConfig
+	body := `{
+		"url_template": "http://session-§__nonce§:pass@proxy.example:8080",
+		"rotation": {"policy": "per_request"}
+	}`
+	if err := json.Unmarshal([]byte(body), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.URLTemplate == "" {
+		t.Errorf("URLTemplate empty after unmarshal")
+	}
+	if c.Rotation == nil || c.Rotation.Policy != "per_request" {
+		t.Errorf("Rotation = %+v, want policy=per_request", c.Rotation)
+	}
+}
+
+// TestUpstreamProxyConfig_Validate_RotationProbeRejectsMalformed
+// verifies Stage 1 probe-expansion at config-validate time rejects a
+// malformed template before any live dial.
+func TestUpstreamProxyConfig_Validate_RotationProbeRejectsMalformed(t *testing.T) {
+	c := &UpstreamProxyConfig{
+		URLTemplate: "ftp://nope.example:21",
+		Rotation:    &UpstreamProxyRotation{Policy: "per_request"},
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("expected probe-expansion error for ftp scheme")
+	}
+	if !strings.Contains(err.Error(), "url_template") {
+		t.Errorf("error missing user-facing prefix: %v", err)
+	}
+}
+
+// TestUpstreamProxyConfig_Validate_URLAndTemplateMutuallyExclusive
+// verifies the URL ⊕ URLTemplate guard.
+func TestUpstreamProxyConfig_Validate_URLAndTemplateMutuallyExclusive(t *testing.T) {
+	c := &UpstreamProxyConfig{
+		URL:         "http://proxy.example:8080",
+		URLTemplate: "http://§__nonce§@proxy.example:8080",
+		Rotation:    &UpstreamProxyRotation{Policy: "per_request"},
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("expected error for URL + URLTemplate")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error message missing 'mutually exclusive': %v", err)
+	}
+}
+
+// TestUpstreamProxyConfig_Validate_RotationRequiredWithTemplate
+// verifies a URLTemplate without rotation is rejected.
+func TestUpstreamProxyConfig_Validate_RotationRequiredWithTemplate(t *testing.T) {
+	c := &UpstreamProxyConfig{
+		URLTemplate: "http://§__nonce§@proxy.example:8080",
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("expected error for url_template without rotation")
+	}
+	if !strings.Contains(err.Error(), "rotation is required") {
+		t.Errorf("error message missing 'rotation is required': %v", err)
+	}
+}
+
+// TestUpstreamProxyConfig_ProxyConfigPolymorphism verifies the outer
+// ProxyConfig.UnmarshalJSON correctly dispatches the polymorphic
+// upstream_proxy key.
+func TestUpstreamProxyConfig_ProxyConfigPolymorphism(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantURL  string
+		wantTmpl string
+		wantPol  string
+	}{
+		{
+			name:    "string-form",
+			input:   `{"upstream_proxy": "http://proxy.example:8080"}`,
+			wantURL: "http://proxy.example:8080",
+		},
+		{
+			name: "object-form-rotation",
+			input: `{
+				"upstream_proxy": {
+					"url_template": "http://§__nonce§:pass@proxy.example:8080",
+					"rotation": {"policy": "per_request"}
+				}
+			}`,
+			wantTmpl: "http://§__nonce§:pass@proxy.example:8080",
+			wantPol:  "per_request",
+		},
+		{
+			name: "object-form-literal",
+			input: `{
+				"upstream_proxy": {
+					"url": "http://proxy.example:8080"
+				}
+			}`,
+			// Legacy string field is mirrored from object.URL.
+			wantURL: "http://proxy.example:8080",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg ProxyConfig
+			if err := json.Unmarshal([]byte(tc.input), &cfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if cfg.UpstreamProxy != tc.wantURL {
+				t.Errorf("UpstreamProxy = %q, want %q", cfg.UpstreamProxy, tc.wantURL)
+			}
+			if tc.wantTmpl != "" {
+				if cfg.UpstreamProxyStruct == nil {
+					t.Fatalf("UpstreamProxyStruct nil, want set")
+				}
+				if cfg.UpstreamProxyStruct.URLTemplate != tc.wantTmpl {
+					t.Errorf("URLTemplate = %q, want %q", cfg.UpstreamProxyStruct.URLTemplate, tc.wantTmpl)
+				}
+				if cfg.UpstreamProxyStruct.Rotation == nil || cfg.UpstreamProxyStruct.Rotation.Policy != tc.wantPol {
+					t.Errorf("Rotation = %+v, want policy=%s", cfg.UpstreamProxyStruct.Rotation, tc.wantPol)
+				}
+			}
+		})
+	}
+}

--- a/internal/connector/connect_handler.go
+++ b/internal/connector/connect_handler.go
@@ -137,16 +137,22 @@ type CONNECTHandlerConfig struct {
 
 // passDialOpts builds DialRawOpts for TLS passthrough relay. It safely
 // handles a nil BuildCfg (only UpstreamProxy is needed for passthrough).
-// EffectiveUpstreamProxyForCtx is consulted so a runtime proxy_start /
+// EffectiveUpstreamProxyForCtxErr is consulted so a runtime proxy_start /
 // configure switch reaches the next passthrough dial (USK-734) AND a
-// per-listener override (USK-826) takes effect when the ctx carries the
-// listener name.
-func passDialOpts(ctx context.Context, buildCfg *BuildConfig) DialRawOpts {
+// per-listener override (USK-826) + rotation (USK-959) take effect when
+// the ctx carries the listener name. Returns an error on rotation
+// resolver failure — caller must fail-closed (close client conn) rather
+// than dial direct (privacy regression).
+func passDialOpts(ctx context.Context, buildCfg *BuildConfig) (DialRawOpts, error) {
 	var opts DialRawOpts
 	if buildCfg != nil {
-		opts.UpstreamProxy = buildCfg.EffectiveUpstreamProxyForCtx(ctx)
+		u, err := buildCfg.EffectiveUpstreamProxyForCtxErr(ctx)
+		if err != nil {
+			return opts, err
+		}
+		opts.UpstreamProxy = u
 	}
-	return opts
+	return opts, nil
 }
 
 // NewCONNECTHandler returns a HandlerFunc that processes CONNECT tunnel
@@ -240,7 +246,16 @@ func connectPassthrough(ctx context.Context, cfg CONNECTHandlerConfig, pc *PeekC
 		return false
 	}
 	logger.Debug("TLS passthrough relay", "target", target)
-	relayErr := runPassthroughRelay(ctx, pc, target, passDialOpts(ctx, cfg.BuildCfg), cfg.PassthroughObserver)
+	// USK-959: stamp the dial target on ctx so the per_target_host
+	// rotation policy can scope state by upstream host.
+	dialCtx := ContextWithDialTarget(ctx, target)
+	opts, perr := passDialOpts(dialCtx, cfg.BuildCfg)
+	if perr != nil {
+		logger.Warn("TLS passthrough upstream proxy rotation failed; failing closed",
+			"target", target, "error", perr)
+		return true
+	}
+	relayErr := runPassthroughRelay(dialCtx, pc, target, opts, cfg.PassthroughObserver)
 	if relayErr != nil {
 		logger.Warn("TLS passthrough ended", "target", target, "sni_peek_target", host, "error", relayErr)
 	}
@@ -313,6 +328,9 @@ func runTLSMITM(
 		}
 		return
 	}
+	// USK-959: wire the BuildConfig in so ConnectionStack.Close can
+	// release per-connection rotation state when the client disconnects.
+	stack.SetBuildConfig(buildCfg)
 	logger.Debug("connection stack built")
 	dispatchStack(ctx, stack, clientSnap, upstreamSnap, target, buildCfg, onStack, onHTTP2Stack)
 }

--- a/internal/connector/connect_inner_dispatch.go
+++ b/internal/connector/connect_inner_dispatch.go
@@ -306,7 +306,12 @@ func BuildBytechunkStack(
 func dialPlainUpstream(ctx context.Context, target string, cfg *BuildConfig) (net.Conn, error) {
 	var dialOpts DialRawOpts
 	if cfg != nil {
-		dialOpts.UpstreamProxy = cfg.EffectiveUpstreamProxyForCtx(ctx)
+		u, err := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+		if err != nil {
+			// USK-959: fail-closed on rotation resolver error.
+			return nil, fmt.Errorf("connector: plain upstream dial for %s: upstream proxy rotation: %w", target, err)
+		}
+		dialOpts.UpstreamProxy = u
 	}
 	conn, _, err := DialUpstreamRaw(ctx, target, dialOpts)
 	if err != nil {

--- a/internal/connector/connection_stack.go
+++ b/internal/connector/connection_stack.go
@@ -52,6 +52,13 @@ type ConnectionStack struct {
 	// poolKey is the PoolKey under which upstreamH2 was obtained. Zero value
 	// when upstreamH2 is nil.
 	poolKey pool.PoolKey
+
+	// buildCfg is the BuildConfig that produced this stack, captured for
+	// per-connection cleanup (USK-959: per_request and per_connection
+	// rotation resolvers track state by ConnID, which must be released
+	// on stack Close). nil when the stack was constructed without
+	// proxybuild wiring (e.g. unit tests).
+	buildCfg *BuildConfig
 }
 
 // sideSubStack pairs the stream-scoped client and upstream Layer overlays
@@ -73,6 +80,19 @@ type sideStack struct {
 // connection identifier.
 func NewConnectionStack(connID string) *ConnectionStack {
 	return &ConnectionStack{ConnID: connID}
+}
+
+// SetBuildConfig wires the BuildConfig that produced this stack so
+// Close can fire per-connection cleanup (USK-959 rotation resolver
+// state). No-op when cfg is nil; subsequent Close still runs the
+// standard Layer teardown.
+func (s *ConnectionStack) SetBuildConfig(cfg *BuildConfig) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buildCfg = cfg
 }
 
 // PushClient adds a new top layer to the client side and makes it the
@@ -326,6 +346,10 @@ func (s *ConnectionStack) Close() error {
 	s.mu.Lock()
 	subs := s.streamSubStacks
 	s.streamSubStacks = nil
+	// Snapshot the cleanup deps under the same lock so concurrent
+	// SetBuildConfig writes do not race with Close. ConnID is immutable
+	// (set at construction) so we don't need to snapshot it.
+	buildCfg := s.buildCfg
 	defer s.mu.Unlock()
 
 	var firstErr error
@@ -361,6 +385,12 @@ func (s *ConnectionStack) Close() error {
 	s.upstream = sideStack{}
 	// Intentionally NOT clearing upstreamH2 / poolKey: the pool owns the
 	// Layer and the handler is still responsible for Pool.Put using poolKey.
+
+	// USK-959: release per-connection rotation state. Fires AFTER Layer
+	// teardown so any in-flight resolver lookups have already returned.
+	if buildCfg != nil {
+		buildCfg.ReleaseConnectionState(s.ConnID)
+	}
 
 	if firstErr != nil {
 		return fmt.Errorf("connection stack close: %w", firstErr)

--- a/internal/connector/context.go
+++ b/internal/connector/context.go
@@ -86,6 +86,39 @@ func LoggerFromContext(ctx context.Context, fallback *slog.Logger) *slog.Logger 
 	return slog.Default()
 }
 
+// Dial target context key for the live MITM data path. The TCP-level
+// target ("host" or "host:port") is attached when entering BuildConnectionStack
+// / passthrough relays / forward dials so downstream resolvers (notably
+// the per-listener upstream-proxy rotation resolver, USK-959) can scope
+// state by upstream host without re-threading the target through every
+// dial helper signature.
+//
+// Distinct from forwardTargetCtxKey (TCP-forward-mode signal) and from
+// envelope.EnvelopeContext.TargetHost (carried inside envelopes, not
+// the dial-time-only signal). Empty when the dial path did not stamp
+// it (e.g. control-plane dials).
+type dialTargetCtxKey struct{}
+
+// ContextWithDialTarget stores the dial-time upstream target string on
+// ctx. The string is opaque to this package: typically "host:port" for
+// CONNECT/SOCKS5 paths, "host" without port for plain HTTP forward.
+// Callers must pass the value they will dial — the rotation resolver
+// (USK-959) uses the verbatim string as the per_target_host cache key
+// so distinct services on the same host get distinct rotation slots.
+func ContextWithDialTarget(ctx context.Context, target string) context.Context {
+	return context.WithValue(ctx, dialTargetCtxKey{}, target)
+}
+
+// DialTargetFromContext retrieves the dial-time upstream target string
+// stored via ContextWithDialTarget. Returns empty string when no target
+// was attached (e.g. plain control-plane dials).
+func DialTargetFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(dialTargetCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
 // Forward target context key for storing TCP forwarding metadata, used by TCP
 // forward listeners to pass the target to L7 protocol handlers without
 // requiring CONNECT or other protocol-level target resolution.

--- a/internal/connector/h2_pool.go
+++ b/internal/connector/h2_pool.go
@@ -88,6 +88,13 @@ func poolKeyForH2(ctx context.Context, target string, cfg *BuildConfig, hostTLS 
 	// transit a different upstream proxy (USK-734); pooled entries
 	// established for listener A must not be reused for listener B
 	// (USK-826).
+	//
+	// USK-959: For per_request rotation, every dial mints a fresh URL so
+	// the pool key always differs — no pooling reuse, as intended (each
+	// HTTP/2 outbound TCP dial gets its own URL → its own pooled Layer
+	// keyspace). Resolver errors are swallowed here (key minted with
+	// empty proxyURL); the live dial path catches the error via
+	// EffectiveUpstreamProxyForCtxErr and fails closed there.
 	proxyURL := ""
 	if cfg != nil {
 		if u := cfg.EffectiveUpstreamProxyForCtx(ctx); u != nil {

--- a/internal/connector/http1_forward_handler.go
+++ b/internal/connector/http1_forward_handler.go
@@ -189,16 +189,29 @@ func NewHTTP1ForwardHandler(cfg HTTP1ForwardHandlerConfig) HandlerFunc {
 
 		// Step 4: Dial upstream plain TCP. TLSConfig=nil → DialUpstreamRaw
 		// returns a plain net.Conn with no TLS handshake. UpstreamProxy is
-		// honored when configured. EffectiveUpstreamProxyForCtx is
+		// honored when configured. EffectiveUpstreamProxyForCtxErr is
 		// consulted so runtime proxy_start / configure updates reach this
-		// dial AND per-listener overrides apply (USK-734 + USK-826).
+		// dial AND per-listener overrides + rotation apply (USK-734 +
+		// USK-826 + USK-959). On rotation resolver error, fail-closed
+		// with 502 — silent direct-dial fallback is a privacy regression.
 		var dialOpts DialRawOpts
+		// USK-959: stamp the dial target on ctx so the per_target_host
+		// rotation policy can scope state by upstream host.
+		dialCtx := ContextWithDialTarget(ctx, target)
 		if cfg.BuildCfg != nil {
-			dialOpts.UpstreamProxy = cfg.BuildCfg.EffectiveUpstreamProxyForCtx(ctx)
+			u, perr := cfg.BuildCfg.EffectiveUpstreamProxyForCtxErr(dialCtx)
+			if perr != nil {
+				connLogger.Warn("plain HTTP upstream proxy rotation failed; failing closed",
+					"target", target, "error", perr)
+				writeForwardErrorResponse(pc, 502, "Bad Gateway",
+					"yorishiro-proxy: upstream proxy rotation failed")
+				return nil
+			}
+			dialOpts.UpstreamProxy = u
 		}
 		dialOpts.DialTimeout = dialTimeoutPlainHTTP
 
-		upstreamConn, _, derr := DialUpstreamRaw(ctx, target, dialOpts)
+		upstreamConn, _, derr := DialUpstreamRaw(dialCtx, target, dialOpts)
 		if derr != nil {
 			connLogger.Debug("plain HTTP upstream dial failed", "error", derr)
 			writeForwardErrorResponse(pc, 502, "Bad Gateway",

--- a/internal/connector/rotation_host_cache.go
+++ b/internal/connector/rotation_host_cache.go
@@ -1,0 +1,110 @@
+package connector
+
+import (
+	"container/list"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// rotationHostCache is a bounded LRU + TTL cache for the
+// RotationPerTargetHost policy. Mirrors the ALPNCache shape so the
+// eviction behaviour is familiar: capacity-driven LRU, lazy TTL
+// expiry on Get.
+type rotationHostCache struct {
+	mu    sync.Mutex
+	max   int
+	ttl   time.Duration
+	ll    *list.List
+	index map[string]*list.Element
+	nowFn func() time.Time
+}
+
+// rotationHostNode bundles a hostKey with its cached URL + expiry for
+// storage in the LRU list.
+type rotationHostNode struct {
+	host   string
+	url    *url.URL
+	expiry time.Time
+}
+
+// newRotationHostCache constructs a cache with the given capacity and
+// TTL. Non-positive values fall back to the package defaults.
+func newRotationHostCache(maxEntries int, ttl time.Duration) *rotationHostCache {
+	if maxEntries <= 0 {
+		maxEntries = DefaultRotationPerHostCacheSize
+	}
+	if ttl <= 0 {
+		ttl = DefaultRotationPerHostCacheTTL
+	}
+	return &rotationHostCache{
+		max:   maxEntries,
+		ttl:   ttl,
+		ll:    list.New(),
+		index: make(map[string]*list.Element),
+		nowFn: time.Now,
+	}
+}
+
+// get returns the cached URL for host if present and unexpired. Expired
+// entries are removed lazily so repeated lookups stay cheap.
+func (c *rotationHostCache) get(host string) (*url.URL, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.index[host]
+	if !ok {
+		return nil, false
+	}
+	node := el.Value.(*rotationHostNode)
+	if c.nowFn().After(node.expiry) {
+		c.ll.Remove(el)
+		delete(c.index, host)
+		return nil, false
+	}
+	c.ll.MoveToFront(el)
+	return node.url, true
+}
+
+// set stores u under host with a fresh expiry. Capacity overflow
+// evicts the least recently used entry.
+func (c *rotationHostCache) set(host string, u *url.URL) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	expiry := c.nowFn().Add(c.ttl)
+	if el, ok := c.index[host]; ok {
+		node := el.Value.(*rotationHostNode)
+		node.url = u
+		node.expiry = expiry
+		c.ll.MoveToFront(el)
+		return
+	}
+	node := &rotationHostNode{host: host, url: u, expiry: expiry}
+	el := c.ll.PushFront(node)
+	c.index[host] = el
+	for c.ll.Len() > c.max {
+		back := c.ll.Back()
+		if back == nil {
+			break
+		}
+		c.ll.Remove(back)
+		delete(c.index, back.Value.(*rotationHostNode).host)
+	}
+}
+
+// clear removes every entry. Called from RotationResolver.Reset when
+// configure_tool reloads the rotation configuration.
+func (c *rotationHostCache) clear() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ll = list.New()
+	c.index = make(map[string]*list.Element)
+}

--- a/internal/connector/socks5_handler.go
+++ b/internal/connector/socks5_handler.go
@@ -152,7 +152,16 @@ func socks5Passthrough(ctx context.Context, cfg SOCKS5HandlerConfig, pc *PeekCon
 		return false
 	}
 	logger.Debug("TLS passthrough relay", "target", target)
-	relayErr := runPassthroughRelay(ctx, pc, target, passDialOpts(ctx, cfg.BuildCfg), cfg.PassthroughObserver)
+	// USK-959: stamp the dial target on ctx so the per_target_host
+	// rotation policy can scope state by upstream host.
+	dialCtx := ContextWithDialTarget(ctx, target)
+	opts, perr := passDialOpts(dialCtx, cfg.BuildCfg)
+	if perr != nil {
+		logger.Warn("TLS passthrough upstream proxy rotation failed (socks5); failing closed",
+			"target", target, "error", perr)
+		return true
+	}
+	relayErr := runPassthroughRelay(dialCtx, pc, target, opts, cfg.PassthroughObserver)
 	if relayErr != nil {
 		logger.Warn("TLS passthrough ended", "target", target, "sni_peek_target", host, "error", relayErr)
 	}

--- a/internal/connector/stack_builder.go
+++ b/internal/connector/stack_builder.go
@@ -107,6 +107,21 @@ type BuildConfig struct {
 	upstreamProxyPerListenerMu sync.RWMutex
 	upstreamProxyPerListener   map[string]*url.URL
 
+	// rotationByListener stores per-listener RotationResolvers for the
+	// per-listener template-driven rotation surface (USK-959). The
+	// dial path consults the resolver INSIDE EffectiveUpstreamProxyForCtx
+	// between the ctx-override (priority 0) and the per-listener static
+	// URL (priority 1) so all upstream-proxy call sites participate
+	// without per-site edits. The map is keyed by listener name; a
+	// resolver presence overrides the static per-listener URL for that
+	// listener.
+	//
+	// Writers are MCP-tool goroutines (configure_tool /
+	// proxy_start_tool); readers are per-connection dial-path
+	// goroutines. RWMutex matches the per-listener static map.
+	rotationByListenerMu sync.RWMutex
+	rotationByListener   map[string]*RotationResolver
+
 	// HostTLSResolver resolves per-host TLS overrides (InsecureSkipVerify,
 	// ClientCert, RootCAs). Nil means use global settings for all hosts.
 	HostTLSResolver *HostTLSResolver
@@ -379,6 +394,72 @@ func (c *BuildConfig) UpstreamProxyForListener(name string) *url.URL {
 	return c.upstreamProxyPerListener[name]
 }
 
+// SetRotationForListener installs (or clears) a per-listener
+// RotationResolver (USK-959). When non-nil, the resolver overrides
+// the per-listener static URL (SetUpstreamProxyForListener) so the
+// dial path mints / consults an expanded URL per pass according to
+// the resolver's policy. Passing nil clears the resolver so the
+// static per-listener URL re-emerges.
+//
+// An empty name is treated as DefaultListenerName. Writers are
+// configure_tool / proxy_start_tool goroutines; readers are
+// per-connection dial-path goroutines.
+func (c *BuildConfig) SetRotationForListener(name string, r *RotationResolver) {
+	if c == nil {
+		return
+	}
+	if name == "" {
+		name = DefaultListenerName
+	}
+	c.rotationByListenerMu.Lock()
+	defer c.rotationByListenerMu.Unlock()
+	if r == nil {
+		delete(c.rotationByListener, name)
+		return
+	}
+	if c.rotationByListener == nil {
+		c.rotationByListener = make(map[string]*RotationResolver)
+	}
+	c.rotationByListener[name] = r
+}
+
+// RotationForListener returns the per-listener RotationResolver
+// installed via SetRotationForListener, or nil when no resolver is
+// configured. An empty name is treated as DefaultListenerName.
+func (c *BuildConfig) RotationForListener(name string) *RotationResolver {
+	if c == nil {
+		return nil
+	}
+	if name == "" {
+		name = DefaultListenerName
+	}
+	c.rotationByListenerMu.RLock()
+	defer c.rotationByListenerMu.RUnlock()
+	return c.rotationByListener[name]
+}
+
+// ReleaseConnectionState drops any per-connection state held by
+// per-listener resolvers for connID (USK-959). Called from
+// ConnectionStack.Close so per_connection rotation entries do not leak
+// across the client disconnect. No-op when c is nil or no resolvers
+// are installed.
+func (c *BuildConfig) ReleaseConnectionState(connID string) {
+	if c == nil || connID == "" {
+		return
+	}
+	c.rotationByListenerMu.RLock()
+	resolvers := make([]*RotationResolver, 0, len(c.rotationByListener))
+	for _, r := range c.rotationByListener {
+		if r != nil {
+			resolvers = append(resolvers, r)
+		}
+	}
+	c.rotationByListenerMu.RUnlock()
+	for _, r := range resolvers {
+		r.ReleaseConnection(connID)
+	}
+}
+
 // EffectiveUpstreamProxyForCtx returns the upstream proxy URL the live
 // dial path should use for a connection whose ctx carries a listener name
 // (set by FullListener via ContextWithListenerName) (USK-826).
@@ -389,10 +470,20 @@ func (c *BuildConfig) UpstreamProxyForListener(name string) *url.URL {
 //     resolver returns nil without consulting any lower-priority slot.
 //     Used by control-plane resend / fuzz per-iteration rotation
 //     (residential proxy IP switching).
-//  1. Per-listener override installed via SetUpstreamProxyForListener for
-//     the ctx's listener name.
-//  2. Process-global override installed via SetUpstreamProxy.
-//  3. Boot-time UpstreamProxy field.
+//  1. Per-listener RotationResolver installed via SetRotationForListener
+//     for the ctx's listener name (USK-959). The resolver mints / picks
+//     an expanded URL according to its policy. A resolver error (macro
+//     expansion / CRLF / parse failure) is silently swallowed in this
+//     accessor — callers that need the error must use the parallel
+//     EffectiveUpstreamProxyForCtxErr method. Existing legacy callers
+//     using this method continue to work but observe a nil URL on
+//     resolver error (effectively "direct dial" fallback). USK-959
+//     migrates all dial-path callers to the Err variant so this
+//     fail-open path is unreachable in production.
+//  2. Per-listener static URL installed via SetUpstreamProxyForListener
+//     for the ctx's listener name.
+//  3. Process-global override installed via SetUpstreamProxy.
+//  4. Boot-time UpstreamProxy field.
 //
 // Falls back to EffectiveUpstreamProxy() when the ctx does not carry a
 // listener name (e.g. control-plane resend paths that do not flow through
@@ -400,21 +491,43 @@ func (c *BuildConfig) UpstreamProxyForListener(name string) *url.URL {
 // once USK-826 is wired in; callers must NOT read the UpstreamProxy field
 // directly because it observes only the boot-time value.
 func (c *BuildConfig) EffectiveUpstreamProxyForCtx(ctx context.Context) *url.URL {
+	u, _ := c.EffectiveUpstreamProxyForCtxErr(ctx)
+	return u
+}
+
+// EffectiveUpstreamProxyForCtxErr is the error-returning sibling of
+// EffectiveUpstreamProxyForCtx (USK-959). Returns the resolved URL plus
+// any error surfaced by a per-listener RotationResolver (macro expansion
+// / CRLF guard / ParseUpstreamProxy failure). Callers MUST fail closed
+// on a non-nil error — never fall back to a direct dial, which would
+// silently bypass the configured upstream proxy and leak the dial to the
+// open internet.
+//
+// Resolution order matches EffectiveUpstreamProxyForCtx; the only
+// difference is the surfaced error on rotation failure.
+func (c *BuildConfig) EffectiveUpstreamProxyForCtxErr(ctx context.Context) (*url.URL, error) {
 	if c == nil {
-		return nil
+		return nil, nil
 	}
 	if u, present := UpstreamProxyOverrideFromContext(ctx); present {
-		return u
+		return u, nil
 	}
 	if name := ListenerNameFromContext(ctx); name != "" {
+		c.rotationByListenerMu.RLock()
+		resolver := c.rotationByListener[name]
+		c.rotationByListenerMu.RUnlock()
+		if resolver != nil {
+			target := DialTargetFromContext(ctx)
+			return resolver.Resolve(ctx, name, target)
+		}
 		c.upstreamProxyPerListenerMu.RLock()
 		u, ok := c.upstreamProxyPerListener[name]
 		c.upstreamProxyPerListenerMu.RUnlock()
 		if ok {
-			return u
+			return u, nil
 		}
 	}
-	return c.EffectiveUpstreamProxy()
+	return c.EffectiveUpstreamProxy(), nil
 }
 
 // EffectiveTLSFingerprint returns the uTLS browser fingerprint profile
@@ -505,6 +618,12 @@ func BuildConnectionStack(
 	if cfg == nil || cfg.ProxyConfig == nil {
 		return nil, nil, nil, fmt.Errorf("connector: BuildConnectionStack: nil config")
 	}
+	// USK-959: stamp the dial target on ctx so the per-listener
+	// rotation resolver (consulted inside dialUpstreamWithALPN via
+	// EffectiveUpstreamProxyForCtxErr) can scope state by upstream
+	// host. Idempotent — re-stamping the same key on a child ctx is
+	// harmless.
+	ctx = ContextWithDialTarget(ctx, target)
 	if cfg.Issuer == nil {
 		return nil, nil, nil, fmt.Errorf("connector: BuildConnectionStack: nil issuer")
 	}
@@ -1190,13 +1309,21 @@ func dialUpstreamWithALPN(
 		upstreamTLSCfg.RootCAs = rootCAsConfig.RootCAs
 	}
 
+	upstreamProxy, proxyErr := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if proxyErr != nil {
+		// USK-959: fail-closed on rotation resolver error. Do NOT fall
+		// back to a direct dial — silent bypass = privacy regression.
+		slog.WarnContext(ctx, "connector: upstream proxy rotation failed; failing closed",
+			"target", target, "error", proxyErr)
+		return nil, nil, fmt.Errorf("connector: upstream dial for %s: upstream proxy rotation: %w", target, proxyErr)
+	}
 	conn, snap, err := DialUpstreamRaw(ctx, target, DialRawOpts{
 		TLSConfig:          upstreamTLSCfg,
 		InsecureSkipVerify: insecureSkip,
 		UTLSProfile:        cfg.EffectiveTLSFingerprint(),
 		ClientCert:         clientCert,
 		OfferALPN:          offerALPN,
-		UpstreamProxy:      cfg.EffectiveUpstreamProxyForCtx(ctx),
+		UpstreamProxy:      upstreamProxy,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("connector: upstream dial for %s: %w", target, err)
@@ -1578,13 +1705,20 @@ func buildRawPassthroughStack(
 		upstreamTLSCfg.RootCAs = hostTLS.rootCAs.RootCAs
 	}
 
+	upstreamProxy, proxyErr := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if proxyErr != nil {
+		clientTLSConn.Close()
+		slog.WarnContext(ctx, "connector: upstream proxy rotation failed (raw passthrough); failing closed",
+			"target", target, "error", proxyErr)
+		return nil, nil, nil, fmt.Errorf("connector: upstream dial for %s: upstream proxy rotation: %w", target, proxyErr)
+	}
 	upstreamConn, upstreamSnap, err := DialUpstreamRaw(ctx, target, DialRawOpts{
 		TLSConfig:          upstreamTLSCfg,
 		InsecureSkipVerify: insecureSkip,
 		UTLSProfile:        cfg.EffectiveTLSFingerprint(),
 		ClientCert:         clientCert,
 		OfferALPN:          []string{"http/1.1"},
-		UpstreamProxy:      cfg.EffectiveUpstreamProxyForCtx(ctx),
+		UpstreamProxy:      upstreamProxy,
 	})
 	if err != nil {
 		clientTLSConn.Close()

--- a/internal/connector/upstream_proxy.go
+++ b/internal/connector/upstream_proxy.go
@@ -55,24 +55,58 @@ func ParseUpstreamProxy(rawURL string) (*url.URL, error) {
 }
 
 // RedactProxyURL returns a copy of the raw proxy URL string with the password
-// portion of userinfo replaced by "xxxxx". If the URL cannot be parsed or has
-// no password, it is returned unchanged.
+// portion of userinfo replaced by "xxxxx". If the URL cannot be parsed and
+// contains userinfo characters, the userinfo region (text between "://" and
+// "@") is redacted via lexical substring replacement. If the URL has no
+// userinfo or no password, it is returned unchanged.
+//
+// The lexical fallback exists for USK-959 templates: a §__nonce§ macro in
+// the userinfo position breaks url.Parse (the section sign is not valid
+// userinfo), so without this branch a template like
+//
+//	http://session-§__nonce§:secret-pass@proxy.example:8080
+//
+// would leak the literal password to the status surface. The lexical path
+// preserves the URL shape (scheme + ://, host:port) while wiping anything
+// between "://" and the FIRST "@" that precedes the host.
 func RedactProxyURL(rawURL string) string {
 	if rawURL == "" {
 		return ""
 	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
+	if u, err := url.Parse(rawURL); err == nil {
+		if u.User == nil {
+			return rawURL
+		}
+		if _, hasPassword := u.User.Password(); !hasPassword {
+			return rawURL
+		}
+		u.User = url.UserPassword(u.User.Username(), "xxxxx")
+		return u.String()
+	}
+	// Fallback: lexical redact of userinfo region. Bounded by the
+	// FIRST '@' after the scheme delimiter so we do not consume past
+	// the host segment if the password contains an '@' (unusual but
+	// possible). The redacted form keeps the same shape so callers
+	// can see scheme + host:port without exposing credentials.
+	schemeIdx := strings.Index(rawURL, "://")
+	if schemeIdx < 0 {
 		return rawURL
 	}
-	if u.User == nil {
+	userinfoStart := schemeIdx + 3
+	atIdx := strings.Index(rawURL[userinfoStart:], "@")
+	if atIdx < 0 {
 		return rawURL
 	}
-	if _, hasPassword := u.User.Password(); !hasPassword {
+	atIdx += userinfoStart
+	// Within userinfo, redact only the password half (after ":") if
+	// present so the username remains visible for diagnostics.
+	colonIdx := strings.Index(rawURL[userinfoStart:atIdx], ":")
+	if colonIdx < 0 {
+		// No password — leave untouched.
 		return rawURL
 	}
-	u.User = url.UserPassword(u.User.Username(), "xxxxx")
-	return u.String()
+	colonIdx += userinfoStart
+	return rawURL[:colonIdx+1] + "xxxxx" + rawURL[atIdx:]
 }
 
 // MaybeDialViaUpstreamProxy dials targetAddr either directly or through

--- a/internal/connector/upstream_proxy.go
+++ b/internal/connector/upstream_proxy.go
@@ -54,21 +54,28 @@ func ParseUpstreamProxy(rawURL string) (*url.URL, error) {
 	return u, nil
 }
 
-// RedactProxyURL returns a copy of the raw proxy URL string with the password
-// portion of userinfo replaced by "xxxxx". If the URL cannot be parsed and
-// contains userinfo characters, the userinfo region (text between "://" and
-// "@") is redacted via lexical substring replacement. If the URL has no
-// userinfo or no password, it is returned unchanged.
+// RedactProxyURL returns a copy of the raw proxy URL string with the
+// credential portion of userinfo replaced by "xxxxx". When a ":password"
+// is present, the username remains visible and only the password is
+// masked. When no ":" is present in userinfo (the entire token is a
+// single secret — e.g. an API key or session token), the WHOLE userinfo
+// region is masked so it does not leak to status surfaces (CWE-200). If
+// the URL cannot be parsed (e.g. contains §macro§ characters that
+// url.Parse rejects), the same rule is applied via lexical substring
+// replacement. If the URL has no userinfo, it is returned unchanged.
 //
-// The lexical fallback exists for USK-959 templates: a §__nonce§ macro in
-// the userinfo position breaks url.Parse (the section sign is not valid
-// userinfo), so without this branch a template like
+// The lexical fallback exists for USK-959 templates: a §__nonce§ macro
+// in the userinfo position breaks url.Parse (the section sign is not
+// valid userinfo), so without this branch a template like
 //
 //	http://session-§__nonce§:secret-pass@proxy.example:8080
 //
-// would leak the literal password to the status surface. The lexical path
-// preserves the URL shape (scheme + ://, host:port) while wiping anything
-// between "://" and the FIRST "@" that precedes the host.
+// would leak the literal password to the status surface. The lexical
+// path preserves the URL shape (scheme + ://, host:port) while wiping
+// the userinfo region — the bounds are "://" .. the FIRST "@" after
+// the scheme delimiter, which is the userinfo / host boundary per
+// RFC 3986. (A literal "@" inside a percent-encoded password would
+// appear as "%40" and not match here.)
 func RedactProxyURL(rawURL string) string {
 	if rawURL == "" {
 		return ""
@@ -78,16 +85,22 @@ func RedactProxyURL(rawURL string) string {
 			return rawURL
 		}
 		if _, hasPassword := u.User.Password(); !hasPassword {
-			return rawURL
+			// Single-token userinfo (no ":password" colon) — mask the
+			// whole thing. A bare username may itself be a session
+			// token / API key, so leaving it visible would leak the
+			// credential (CWE-200). url.User emits "<name>@host" with
+			// no ":", preserving the no-password shape of the input.
+			u.User = url.User("xxxxx")
+			return u.String()
 		}
 		u.User = url.UserPassword(u.User.Username(), "xxxxx")
 		return u.String()
 	}
 	// Fallback: lexical redact of userinfo region. Bounded by the
-	// FIRST '@' after the scheme delimiter so we do not consume past
-	// the host segment if the password contains an '@' (unusual but
-	// possible). The redacted form keeps the same shape so callers
-	// can see scheme + host:port without exposing credentials.
+	// FIRST '@' after the scheme delimiter — that delimiter marks the
+	// userinfo / host boundary per RFC 3986. The redacted form keeps
+	// the same shape so callers can see scheme + host:port without
+	// exposing credentials.
 	schemeIdx := strings.Index(rawURL, "://")
 	if schemeIdx < 0 {
 		return rawURL
@@ -98,12 +111,13 @@ func RedactProxyURL(rawURL string) string {
 		return rawURL
 	}
 	atIdx += userinfoStart
-	// Within userinfo, redact only the password half (after ":") if
-	// present so the username remains visible for diagnostics.
+	// Within userinfo, redact the password half (after ":") if present
+	// so the username remains visible for diagnostics. When no ":" is
+	// present, redact the entire userinfo region — a bare token in
+	// userinfo is itself a credential (CWE-200).
 	colonIdx := strings.Index(rawURL[userinfoStart:atIdx], ":")
 	if colonIdx < 0 {
-		// No password — leave untouched.
-		return rawURL
+		return rawURL[:userinfoStart] + "xxxxx" + rawURL[atIdx:]
 	}
 	colonIdx += userinfoStart
 	return rawURL[:colonIdx+1] + "xxxxx" + rawURL[atIdx:]

--- a/internal/connector/upstream_proxy_rotation.go
+++ b/internal/connector/upstream_proxy_rotation.go
@@ -1,0 +1,381 @@
+// upstream_proxy_rotation.go implements upstream-proxy URL template
+// expansion and per-listener rotation policy resolution.
+//
+// Two consumers share this file:
+//
+//  1. The control-plane resend / fuzz MCP tools (USK-954) call
+//     UpstreamProxyConfig.ResolveForIteration once per iteration to expand
+//     a §-template into a per-flow override that is attached to ctx via
+//     ContextWithUpstreamProxyOverride. The package internal/mcp keeps a
+//     thin type alias so the existing MCP wire schema is unchanged.
+//
+//  2. The live MITM data path (USK-959) consults a per-listener
+//     RotationResolver via BuildConfig.EffectiveUpstreamProxyForCtx ahead
+//     of the per-listener static URL and the process-global slot. Each
+//     listener owns its own resolver instance; multi-listener setups
+//     therefore cannot leak rotation state across listeners.
+//
+// Reserved variables (prefix "__") cannot be set or shadowed by
+// user-supplied macros — see internal/macro/reserved.go.
+package connector
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/usk6666/yorishiro-proxy/internal/macro"
+)
+
+// UpstreamProxyConfig is the per-iteration upstream proxy configuration
+// for control-plane fuzz / resend MCP tools. Optional — when nil or
+// URLTemplate is empty, the iteration uses the default (direct) dial
+// path without attaching any upstream-proxy override to ctx.
+//
+// URLTemplate supports the §var§ macro template syntax with the
+// following runtime-reserved variables (always present per iteration):
+//
+//	§__iteration§ — zero-based iteration index for the current MCP call
+//	§__nonce§     — fresh UUID minted per iteration
+//
+// Reserved variables cannot be overridden by user input. The parsed
+// upstream proxy URL must use scheme http:// or socks5:// (validated by
+// ParseUpstreamProxy). CRLF guards (CWE-93) apply to the expanded URL
+// so a §__nonce§-substituted credential cannot smuggle a
+// Proxy-Authorization header injection into the downstream CONNECT
+// request.
+//
+// The struct is intentionally a single-field carrier so future
+// extensions (rotation policy, session-id sticky window, error-driven
+// rotation) can land as additional optional fields without breaking the
+// MCP wire schema.
+type UpstreamProxyConfig struct {
+	URLTemplate string `json:"url_template,omitempty" jsonschema:"upstream proxy URL template (http:// or socks5://). Supports §var§ macro syntax with reserved variables §__iteration§ (zero-based index) and §__nonce§ (per-iteration UUID) for residential-proxy IP rotation. Example: http://user-session-§__nonce§:password@residential.example:8080"`
+}
+
+// ResolveForIteration expands the URL template for iteration N, parses
+// the result as an upstream proxy URL, and returns a ctx carrying the
+// per-flow override (ContextWithUpstreamProxyOverride). Returns the
+// input ctx unchanged when the configuration is nil or URLTemplate is
+// empty — the caller falls through to the default dial path.
+//
+// Errors are returned with the user-facing prefix
+// "upstream_proxy.url_template" so MCP tool handlers can surface them
+// verbatim.
+func (c *UpstreamProxyConfig) ResolveForIteration(ctx context.Context, iteration int) (context.Context, error) {
+	if c == nil || c.URLTemplate == "" {
+		return ctx, nil
+	}
+
+	kvStore := map[string]string{
+		macro.ReservedKeyPrefix + "iteration": strconv.Itoa(iteration),
+		macro.ReservedKeyPrefix + "nonce":     uuid.NewString(),
+	}
+
+	parsed, err := expandAndParseTemplate(c.URLTemplate, kvStore)
+	if err != nil {
+		return nil, err
+	}
+
+	return ContextWithUpstreamProxyOverride(ctx, parsed), nil
+}
+
+// expandAndParseTemplate performs macro expansion, CRLF guard, and
+// ParseUpstreamProxy on the supplied template against kvStore. Returns
+// errors with the "upstream_proxy.url_template" prefix so callers can
+// surface them verbatim. Shared by ResolveForIteration (MCP control
+// plane) and RotationResolver.Resolve (live data path) so both surfaces
+// fail with the same diagnostic shape.
+func expandAndParseTemplate(template string, kvStore map[string]string) (*url.URL, error) {
+	expanded, err := macro.ExpandTemplate(template, kvStore)
+	if err != nil {
+		return nil, fmt.Errorf("upstream_proxy.url_template: expand: %w", err)
+	}
+
+	if strings.ContainsAny(expanded, "\r\n") {
+		return nil, fmt.Errorf("upstream_proxy.url_template: expanded URL contains CR/LF (CWE-93 guard)")
+	}
+
+	parsed, err := ParseUpstreamProxy(expanded)
+	if err != nil {
+		return nil, fmt.Errorf("upstream_proxy.url_template: %w", err)
+	}
+	return parsed, nil
+}
+
+// RotationPolicy controls how often a RotationResolver mints a fresh
+// upstream-proxy URL from its template.
+type RotationPolicy string
+
+const (
+	// RotationPerRequest expands the template at every outbound TCP dial
+	// for the listener. For HTTP/2 this means once per dialled upstream
+	// connection — the dial is the rotation event, not the individual
+	// h2 stream (multiple streams multiplex onto a single TCP dial).
+	// Operators wanting per-stream rotation must either disable HTTP/2
+	// connection pooling or use per_connection scoping on a listener
+	// that only ever speaks HTTP/1.
+	RotationPerRequest RotationPolicy = "per_request"
+
+	// RotationPerConnection caches the expanded URL per inbound proxy
+	// connection (keyed by ConnID). All outbound dials triggered by the
+	// same client connection share the URL; a new client connection
+	// (and therefore a new ConnID) mints a fresh URL. State is dropped
+	// when the connector closes the ConnectionStack — i.e. when the
+	// client disconnects.
+	RotationPerConnection RotationPolicy = "per_connection"
+
+	// RotationPerTargetHost caches the expanded URL per (listener,
+	// target host) pair. All connections to the same upstream host
+	// observe the same URL until the LRU TTL expires; distinct upstream
+	// hosts get distinct URLs. Useful for sticky-by-target rotation
+	// (e.g. one residential IP per session per upstream).
+	RotationPerTargetHost RotationPolicy = "per_target_host"
+
+	// RotationSticky mints the URL once for the listener's lifetime and
+	// then reuses it for every subsequent dial. Reload via configure_tool
+	// (or proxy_start) clears the sticky value so the next dial mints
+	// fresh. Useful for "one residential IP per listener until I say
+	// rotate".
+	RotationSticky RotationPolicy = "sticky"
+)
+
+// String returns the policy as its wire-format string.
+func (p RotationPolicy) String() string { return string(p) }
+
+// IsValid reports whether p matches one of the four supported policies.
+func (p RotationPolicy) IsValid() bool {
+	switch p {
+	case RotationPerRequest, RotationPerConnection, RotationPerTargetHost, RotationSticky:
+		return true
+	}
+	return false
+}
+
+// DefaultRotationPerHostCacheSize / DefaultRotationPerHostCacheTTL bound the
+// per-target-host cache. Defaults mirror the ALPNCache shape so an operator
+// pattern is familiar: 10000 hosts × 1h TTL covers a long browsing session
+// before a stale cached URL forces a re-mint.
+const (
+	DefaultRotationPerHostCacheSize = 10_000
+	DefaultRotationPerHostCacheTTL  = time.Hour
+)
+
+// RotationConfig describes a single rotation resolver: the template plus
+// the policy. ListenerName is informational and used in slog warnings on
+// fail-closed events.
+type RotationConfig struct {
+	// Template is the §-template URL. Must expand to a valid upstream
+	// proxy URL after substitution.
+	Template string
+
+	// Policy selects how often the template is expanded.
+	Policy RotationPolicy
+
+	// ListenerName is included in log records on fail-closed events so
+	// operators can correlate the warning to a specific listener. Empty
+	// is permitted.
+	ListenerName string
+}
+
+// RotationResolver evaluates a RotationConfig per dial event. Methods
+// are safe for concurrent use; state caches are per-resolver so two
+// listeners with the same template still mint independent nonces.
+//
+// The resolver is intentionally separate from BuildConfig so a single
+// BuildConfig can carry a different resolver per listener without
+// per-site map lookups on the hot dial path — proxybuild assembles the
+// resolver and installs it via BuildConfig.SetRotationForListener.
+type RotationResolver struct {
+	cfg RotationConfig
+
+	// perConn caches URLs by ConnID for the RotationPerConnection policy.
+	// Entries are deleted from ReleaseConnection when the connector
+	// closes the ConnectionStack.
+	perConn sync.Map // map[string]*url.URL
+
+	// perTargetHost caches URLs by target host for the
+	// RotationPerTargetHost policy. Uses the ALPNCache-shape LRU+TTL
+	// pattern; entries expire lazily when the LRU is full.
+	perTargetHost *rotationHostCache
+
+	// sticky stores the lifetime-of-listener URL for RotationSticky.
+	// Protected by stickyMu.
+	stickyMu sync.RWMutex
+	sticky   *url.URL
+}
+
+// NewRotationResolver constructs a RotationResolver. cfg.Template is
+// not validated here; the proxybuild layer probe-expands at config
+// apply time. Resolve performs the per-dial expansion and surfaces any
+// expansion / parse / CRLF guard error to the caller.
+//
+// hostCacheSize / hostCacheTTL bound the per-target-host cache. Zero
+// values fall back to DefaultRotationPerHostCacheSize /
+// DefaultRotationPerHostCacheTTL respectively.
+func NewRotationResolver(cfg RotationConfig, hostCacheSize int, hostCacheTTL time.Duration) *RotationResolver {
+	if hostCacheSize <= 0 {
+		hostCacheSize = DefaultRotationPerHostCacheSize
+	}
+	if hostCacheTTL <= 0 {
+		hostCacheTTL = DefaultRotationPerHostCacheTTL
+	}
+	return &RotationResolver{
+		cfg:           cfg,
+		perTargetHost: newRotationHostCache(hostCacheSize, hostCacheTTL),
+	}
+}
+
+// Policy returns the resolver's rotation policy. Read by
+// status surfaces (ListenerStatus.UpstreamProxyRotationPolicy).
+func (r *RotationResolver) Policy() RotationPolicy {
+	if r == nil {
+		return ""
+	}
+	return r.cfg.Policy
+}
+
+// Template returns the resolver's URL template verbatim. Use
+// RedactProxyURL before surfacing to operators; the template carries
+// userinfo macros that may resolve to credentials.
+func (r *RotationResolver) Template() string {
+	if r == nil {
+		return ""
+	}
+	return r.cfg.Template
+}
+
+// Resolve picks (or mints) the upstream proxy URL for the next dial
+// triggered by a connection on listenerName targeting targetHost. ctx
+// is consulted for ConnID (per_connection scope). Returns the URL plus
+// nil on success, nil + error on macro expansion / CRLF / parse
+// failure. The caller is responsible for fail-closed handling: do NOT
+// fall back to direct dial on a non-nil error — that would silently
+// bypass the configured upstream proxy.
+func (r *RotationResolver) Resolve(ctx context.Context, listenerName, targetHost string) (*url.URL, error) {
+	if r == nil {
+		return nil, nil
+	}
+
+	switch r.cfg.Policy {
+	case RotationPerRequest:
+		return r.expandFresh()
+
+	case RotationPerConnection:
+		connID := ConnIDFromContext(ctx)
+		if connID == "" {
+			// No ConnID on ctx — fall back to a fresh mint. This is
+			// not a programming error: control-plane callers can
+			// install a resolver but never set ConnID. Per-conn
+			// scope only makes sense on the live data path where
+			// FullListener attaches ConnID via ContextWithConnID.
+			return r.expandFresh()
+		}
+		if cached, ok := r.perConn.Load(connID); ok {
+			return cached.(*url.URL), nil
+		}
+		u, err := r.expandFresh()
+		if err != nil {
+			return nil, err
+		}
+		// LoadOrStore handles the race where two dials on the same
+		// ConnID race here: the loser observes the winner's URL.
+		actual, _ := r.perConn.LoadOrStore(connID, u)
+		return actual.(*url.URL), nil
+
+	case RotationPerTargetHost:
+		// Empty targetHost is unusual (the caller would not normally
+		// reach the resolver without a target) but treat it as a
+		// fresh-mint fallback rather than a panic-inducing edge.
+		if targetHost == "" {
+			return r.expandFresh()
+		}
+		// Use the full "host:port" so distinct services on the same
+		// host (e.g. example.com:443 vs example.com:8443) get
+		// distinct rotation slots. Operators who want host-level
+		// (not service-level) scoping must normalise upstream port
+		// configuration; the resolver itself never aggregates.
+		if cached, ok := r.perTargetHost.get(targetHost); ok {
+			return cached, nil
+		}
+		u, err := r.expandFresh()
+		if err != nil {
+			return nil, err
+		}
+		r.perTargetHost.set(targetHost, u)
+		return u, nil
+
+	case RotationSticky:
+		r.stickyMu.RLock()
+		s := r.sticky
+		r.stickyMu.RUnlock()
+		if s != nil {
+			return s, nil
+		}
+		u, err := r.expandFresh()
+		if err != nil {
+			return nil, err
+		}
+		r.stickyMu.Lock()
+		// Recheck under write lock in case a concurrent first-Resolve
+		// already set sticky.
+		if r.sticky != nil {
+			s = r.sticky
+			r.stickyMu.Unlock()
+			return s, nil
+		}
+		r.sticky = u
+		r.stickyMu.Unlock()
+		return u, nil
+
+	default:
+		return nil, fmt.Errorf("upstream_proxy.rotation: unknown policy %q", r.cfg.Policy)
+	}
+}
+
+// ReleaseConnection drops any per-connection state held by the resolver
+// for connID. Called from ConnectionStack.Close so per_connection
+// entries do not leak after the client disconnects. No-op for policies
+// that do not maintain per-conn state.
+func (r *RotationResolver) ReleaseConnection(connID string) {
+	if r == nil || connID == "" {
+		return
+	}
+	r.perConn.Delete(connID)
+}
+
+// Reset clears all resolver-side state caches. Called from
+// configure_tool / proxy_start when the operator reloads the rotation
+// configuration so the next dial mints fresh. In-flight connections
+// keep the URL they already captured; only future dials see the new
+// state.
+func (r *RotationResolver) Reset() {
+	if r == nil {
+		return
+	}
+	r.perConn.Range(func(k, _ any) bool {
+		r.perConn.Delete(k)
+		return true
+	})
+	r.perTargetHost.clear()
+	r.stickyMu.Lock()
+	r.sticky = nil
+	r.stickyMu.Unlock()
+}
+
+// expandFresh runs the macro expansion + CRLF guard + ParseUpstreamProxy
+// against a fresh nonce. Used by every policy that needs a brand-new
+// URL (per_request always; per_connection / per_target_host / sticky on
+// first-use).
+func (r *RotationResolver) expandFresh() (*url.URL, error) {
+	kv := map[string]string{
+		macro.ReservedKeyPrefix + "nonce": uuid.NewString(),
+	}
+	return expandAndParseTemplate(r.cfg.Template, kv)
+}

--- a/internal/connector/upstream_proxy_rotation_integration_test.go
+++ b/internal/connector/upstream_proxy_rotation_integration_test.go
@@ -570,15 +570,11 @@ func TestLiveProxy_PerConnectionRotation_DistinctAcrossClients(t *testing.T) {
 		t.Fatalf("CONNECT proxy saw %d tunnels, want %d", len(auths), clientCount)
 	}
 	seen := make(map[string]struct{})
-	for i, a := range auths {
+	for _, a := range auths {
 		user := decodeBasicUser(t, a)
 		seen[user] = struct{}{}
-		_ = i
 	}
 	if len(seen) != clientCount {
 		t.Errorf("per_connection across clients: distinct count = %d, want %d", len(seen), clientCount)
 	}
 }
-
-// To keep go vet happy when this file builds standalone.
-var _ = atomic.AddInt32

--- a/internal/connector/upstream_proxy_rotation_integration_test.go
+++ b/internal/connector/upstream_proxy_rotation_integration_test.go
@@ -1,0 +1,584 @@
+//go:build e2e && !e2e_smoke
+
+package connector_test
+
+// upstream_proxy_rotation_integration_test.go covers the USK-959 live
+// MITM data-path rotation surface. The shape is parallel to
+// upstream_proxy_perlistener_integration_test.go (USK-826): real
+// FullListener + ConnectionStack + Pipeline + RecordStep, all wired
+// against a real upstream HTTPS server. The CONNECT proxy in the
+// middle records the Proxy-Authorization headers it observes so the
+// test can assert per-rotation-event distinctness.
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+)
+
+// tlsListenMultiAccept binds a TLS listener on 127.0.0.1:0 with the
+// test TLS config. Used by startMultiAcceptUpstreamHTTPS so the
+// rotation tests can drive multiple consecutive HTTPS requests
+// (startUpstreamHTTPS accepts only one).
+func tlsListenMultiAccept(t *testing.T) (net.Listener, error) {
+	return tls.Listen("tcp", "127.0.0.1:0", newTestTLSConfig(t))
+}
+
+// startMultiAcceptUpstreamHTTPS builds a TLS HTTPS server that
+// accepts multiple connections in a loop (unlike startUpstreamHTTPS
+// which accepts only one). Each accepted connection reads one HTTP
+// request, writes the handler's response, and closes. The returned
+// counter tracks total accept-count so tests can assert per-request
+// rotation drove a fresh upstream dial.
+func startMultiAcceptUpstreamHTTPS(t *testing.T, response []byte) (net.Listener, func() int) {
+	t.Helper()
+	ln, err := tlsListenMultiAccept(t)
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	var count atomic.Int64
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			count.Add(1)
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+				br := bufio.NewReader(c)
+				_, _ = readHTTPRequest(br)
+				_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				_, _ = c.Write(response)
+			}(conn)
+		}
+	}()
+	return ln, func() int { return int(count.Load()) }
+}
+
+// startCONNECTProxyRecorder stands up an HTTP CONNECT proxy that
+// records each connection's Proxy-Authorization header and tunnels
+// the rest of the stream to the requested target. Returns the
+// listener's bound address and an accessor for the captured headers.
+func startCONNECTProxyRecorder(t *testing.T) (addr string, observedAuth func() []string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen recorder: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	var mu sync.Mutex
+	var seen []string
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleConnectRotationProxy(conn, &mu, &seen)
+		}
+	}()
+
+	return ln.Addr().String(), func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(seen))
+		copy(out, seen)
+		return out
+	}
+}
+
+// handleConnectRotationProxy processes a single client connection:
+// parse CONNECT, record Proxy-Authorization, reply 200, then bridge
+// bytes.
+func handleConnectRotationProxy(client net.Conn, mu *sync.Mutex, seen *[]string) {
+	defer client.Close()
+	br := bufio.NewReader(client)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		return
+	}
+	if req.Method != http.MethodConnect {
+		return
+	}
+	auth := req.Header.Get("Proxy-Authorization")
+	mu.Lock()
+	*seen = append(*seen, auth)
+	mu.Unlock()
+	upstream, err := net.Dial("tcp", req.Host)
+	if err != nil {
+		_, _ = client.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+		return
+	}
+	defer upstream.Close()
+	if _, err := client.Write([]byte("HTTP/1.1 200 OK\r\n\r\n")); err != nil {
+		return
+	}
+	if n := br.Buffered(); n > 0 {
+		buf, _ := br.Peek(n)
+		_, _ = upstream.Write(buf)
+		_, _ = br.Discard(n)
+	}
+	done := make(chan struct{}, 2)
+	pipe := func(dst, src net.Conn) {
+		buf := make([]byte, 4096)
+		for {
+			n, err := src.Read(buf)
+			if n > 0 {
+				if _, werr := dst.Write(buf[:n]); werr != nil {
+					break
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}
+	go pipe(upstream, client)
+	go pipe(client, upstream)
+	<-done
+}
+
+// decodeBasicUser decodes Basic auth "Basic base64(user:pass)" and
+// returns the username portion. Returns the raw header on error so
+// the test surfaces the unparseable bytes verbatim.
+func decodeBasicUser(t *testing.T, auth string) string {
+	t.Helper()
+	if !strings.HasPrefix(auth, "Basic ") {
+		t.Errorf("Proxy-Authorization missing Basic prefix: %q", auth)
+		return auth
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		t.Errorf("base64 decode: %v", err)
+		return auth
+	}
+	userPass := string(decoded)
+	colon := strings.IndexByte(userPass, ':')
+	if colon < 0 {
+		return userPass
+	}
+	return userPass[:colon]
+}
+
+// buildRotationBuildConfig builds a BuildConfig + Issuer for the
+// rotation e2e harness. Mirrors the minimal shape used by
+// upstream_proxy_perlistener_integration_test.go.
+func buildRotationBuildConfig(t *testing.T) *connector.BuildConfig {
+	t.Helper()
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("ca generate: %v", err)
+	}
+	issuer := cert.NewIssuer(ca)
+	return &connector.BuildConfig{
+		ProxyConfig:        &config.ProxyConfig{},
+		Issuer:             issuer,
+		InsecureSkipVerify: true,
+	}
+}
+
+// rotationListenerDeps starts a named listener with the supplied
+// BuildConfig + a fresh testStore/WaitGroup. Returns the bound addr.
+func rotationListenerDeps(t *testing.T, ctx context.Context, name string, buildCfg *connector.BuildConfig) (addr string, store *testStore, wg *sync.WaitGroup) {
+	t.Helper()
+	store = &testStore{}
+	wg = &sync.WaitGroup{}
+	addr = startNamedListenerForChain(t, ctx, name, buildCfg, store, wg)
+	return
+}
+
+// installRotation installs a RotationResolver with the supplied policy
+// + template on the BuildConfig under the listener name.
+func installRotation(t *testing.T, buildCfg *connector.BuildConfig, listenerName, template string, policy connector.RotationPolicy) {
+	t.Helper()
+	resolver := connector.NewRotationResolver(connector.RotationConfig{
+		Template:     template,
+		Policy:       policy,
+		ListenerName: listenerName,
+	}, 0, 0)
+	buildCfg.SetRotationForListener(listenerName, resolver)
+}
+
+// runOneRequestThroughListener fires a single CONNECT + GET through
+// the named listener, returning the response body excerpt and any
+// error from the response parse. Used by per-request rotation tests
+// that fire multiple independent requests.
+func runOneRequestThroughListener(t *testing.T, listenerAddr, target, path string, wg *sync.WaitGroup) string {
+	t.Helper()
+	wg.Add(1)
+	rawReq := fmt.Sprintf("GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", path, target)
+	resp := connectAndSendHTTP(t, listenerAddr, target, rawReq)
+	waitSessionDone(t, wg)
+	return resp
+}
+
+// TestLiveProxy_PerRequestRotation_DistinctNonces verifies that the
+// per_request policy mints a fresh upstream-proxy URL per outbound
+// TCP dial — each request transits through the CONNECT proxy with a
+// distinct Proxy-Authorization (Basic auth derived from the §__nonce§
+// substitution).
+func TestLiveProxy_PerRequestRotation_DistinctNonces(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstreamLn, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	proxyAddr, observedAuth := startCONNECTProxyRecorder(t)
+
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, wg := rotationListenerDeps(t, ctx, "rot-per-request", buildCfg)
+	installRotation(t, buildCfg, "rot-per-request",
+		fmt.Sprintf("http://session-§__nonce§:pass@%s", proxyAddr),
+		connector.RotationPerRequest)
+
+	const requestCount = 3
+	for i := 0; i < requestCount; i++ {
+		resp := runOneRequestThroughListener(t, listenerAddr, target, fmt.Sprintf("/r%d", i), wg)
+		if !strings.Contains(resp, "200 OK") {
+			t.Fatalf("request %d: response missing 200 OK: %q", i, resp)
+		}
+	}
+
+	auths := observedAuth()
+	if len(auths) != requestCount {
+		t.Fatalf("CONNECT proxy saw %d tunnels, want %d", len(auths), requestCount)
+	}
+	seen := make(map[string]struct{}, requestCount)
+	for i, a := range auths {
+		user := decodeBasicUser(t, a)
+		if !strings.HasPrefix(user, "session-") {
+			t.Errorf("request %d: username = %q, want session-<nonce>", i, user)
+		}
+		if _, dup := seen[user]; dup {
+			t.Errorf("request %d: duplicate nonce %q (rotation failed)", i, user)
+		}
+		seen[user] = struct{}{}
+	}
+	if len(seen) != requestCount {
+		t.Errorf("distinct nonce count = %d, want %d", len(seen), requestCount)
+	}
+}
+
+// TestLiveProxy_PerTargetHostRotation_SamePerHost verifies that
+// per_target_host caches the URL by upstream host: distinct hosts get
+// distinct nonces, same host gets the same nonce across requests.
+func TestLiveProxy_PerTargetHostRotation_SamePerHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Two upstreams so we can drive distinct target hosts.
+	upstreamA, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nA"))
+	defer upstreamA.Close()
+	upstreamB, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nB"))
+	defer upstreamB.Close()
+	targetA := upstreamA.Addr().String()
+	targetB := upstreamB.Addr().String()
+
+	proxyAddr, observedAuth := startCONNECTProxyRecorder(t)
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, wg := rotationListenerDeps(t, ctx, "rot-per-host", buildCfg)
+	installRotation(t, buildCfg, "rot-per-host",
+		fmt.Sprintf("http://session-§__nonce§:pass@%s", proxyAddr),
+		connector.RotationPerTargetHost)
+
+	// Two requests to A, one to B, one back to A.
+	for _, target := range []string{targetA, targetA, targetB, targetA} {
+		resp := runOneRequestThroughListener(t, listenerAddr, target, "/", wg)
+		if !strings.Contains(resp, "200 OK") {
+			t.Fatalf("request to %s: missing 200 OK: %q", target, resp)
+		}
+	}
+
+	auths := observedAuth()
+	if len(auths) != 4 {
+		t.Fatalf("CONNECT proxy saw %d tunnels, want 4", len(auths))
+	}
+	users := make([]string, len(auths))
+	for i, a := range auths {
+		users[i] = decodeBasicUser(t, a)
+	}
+	// users[0,1,3] are all for targetA → must be identical.
+	if users[0] != users[1] {
+		t.Errorf("per_target_host: users[0]=%q users[1]=%q expected equal (same target)", users[0], users[1])
+	}
+	if users[0] != users[3] {
+		t.Errorf("per_target_host: users[0]=%q users[3]=%q expected equal (same target)", users[0], users[3])
+	}
+	// users[2] is for targetB → must differ from A.
+	if users[2] == users[0] {
+		t.Errorf("per_target_host: users[2]=%q users[0]=%q expected different (different target)", users[2], users[0])
+	}
+}
+
+// TestLiveProxy_StickyRotation_FixedForListenerLifetime verifies that
+// sticky mints once and reuses for the listener's lifetime, then
+// resets when the rotation is reloaded (configure_tool path).
+func TestLiveProxy_StickyRotation_FixedForListenerLifetime(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstreamLn, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	proxyAddr, observedAuth := startCONNECTProxyRecorder(t)
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, wg := rotationListenerDeps(t, ctx, "rot-sticky", buildCfg)
+	installRotation(t, buildCfg, "rot-sticky",
+		fmt.Sprintf("http://session-§__nonce§:pass@%s", proxyAddr),
+		connector.RotationSticky)
+
+	// First two requests should share the same nonce.
+	for i := 0; i < 2; i++ {
+		resp := runOneRequestThroughListener(t, listenerAddr, target, fmt.Sprintf("/r%d", i), wg)
+		if !strings.Contains(resp, "200 OK") {
+			t.Fatalf("request %d: %q", i, resp)
+		}
+	}
+	auths := observedAuth()
+	if len(auths) < 2 {
+		t.Fatalf("phase 1: %d tunnels, want >=2", len(auths))
+	}
+	user1 := decodeBasicUser(t, auths[0])
+	user2 := decodeBasicUser(t, auths[1])
+	if user1 != user2 {
+		t.Errorf("sticky: phase 1 users differ: %q vs %q", user1, user2)
+	}
+
+	// Simulate configure_tool reload: install a fresh resolver, drop
+	// the previous sticky state. Resolver is a new instance so the
+	// previous sticky URL is GCed; the new resolver mints fresh on
+	// next dial.
+	installRotation(t, buildCfg, "rot-sticky",
+		fmt.Sprintf("http://session-§__nonce§:pass@%s", proxyAddr),
+		connector.RotationSticky)
+	resp := runOneRequestThroughListener(t, listenerAddr, target, "/r-reload", wg)
+	if !strings.Contains(resp, "200 OK") {
+		t.Fatalf("post-reload request: %q", resp)
+	}
+	auths = observedAuth()
+	if len(auths) < 3 {
+		t.Fatalf("post-reload: %d tunnels, want >=3", len(auths))
+	}
+	user3 := decodeBasicUser(t, auths[len(auths)-1])
+	if user3 == user1 {
+		t.Errorf("sticky: post-reload user %q expected to differ from pre-reload %q", user3, user1)
+	}
+}
+
+// TestLiveProxy_MalformedTemplate_FailClosed verifies that a
+// malformed template fails the live dial path closed: the request
+// is rejected without falling back to a direct dial (no silent
+// bypass). The CONNECT proxy must observe zero tunnels.
+func TestLiveProxy_MalformedTemplate_FailClosed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	upstreamLn, getUpstreamCount := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, _ := rotationListenerDeps(t, ctx, "rot-malformed", buildCfg)
+	// ftp:// scheme is rejected by ParseUpstreamProxy → resolver error
+	// → dial fail-closed.
+	installRotation(t, buildCfg, "rot-malformed",
+		"ftp://broken-§__nonce§.example:21",
+		connector.RotationPerRequest)
+
+	rawReq := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", target)
+	// The CONNECT phase may complete (200 OK) before the inner dial
+	// happens — at that point the proxy realises the upstream dial
+	// failed and aborts. quickAttemptThroughProxy times out reading
+	// the response. We don't assert response content; we assert the
+	// *upstream* saw no traffic (no silent direct-dial fallback).
+	_ = quickAttemptThroughProxy(t, listenerAddr, target, rawReq)
+
+	// Pause briefly so any in-flight dial completes (or fails).
+	time.Sleep(200 * time.Millisecond)
+
+	if n := getUpstreamCount(); n != 0 {
+		t.Errorf("upstream saw %d connections, want 0 (silent direct-dial fallback regression)", n)
+	}
+}
+
+// quickAttemptThroughProxy issues CONNECT + write but tolerates the
+// dial-time failure so the test can inspect post-conditions. Returns
+// any response bytes received before the connection closed.
+func quickAttemptThroughProxy(t *testing.T, proxyAddr, target, rawReq string) string {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	_, _ = conn.Write([]byte(connectReq))
+	// Read until the proxy closes the connection or times out.
+	buf := make([]byte, 1024)
+	n, _ := conn.Read(buf)
+	return string(buf[:n])
+}
+
+// TestLiveProxy_MultiListenerChain_NoRecursion verifies that with
+// rotation installed on listener "chained" (routing through listener
+// "outer"), listener "outer" is NOT subject to the rotation (it
+// dials direct). This is the USK-826 regression class extended to
+// USK-959: per-listener scope must isolate rotation just as it
+// isolates the literal URL.
+func TestLiveProxy_MultiListenerChain_NoRecursion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstreamLn, getUpstreamCount := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	buildCfg := buildRotationBuildConfig(t)
+	outerAddr, _, outerWg := rotationListenerDeps(t, ctx, "outer", buildCfg)
+	chainedAddr, _, chainedWg := rotationListenerDeps(t, ctx, "chained", buildCfg)
+
+	// Rotation on "chained" sends its dials through "outer". "outer"
+	// has NO override, so it must dial direct to upstream.
+	template := fmt.Sprintf("http://session-§__nonce§:pass@%s", outerAddr)
+	installRotation(t, buildCfg, "chained", template, connector.RotationPerRequest)
+
+	outerWg.Add(1)
+	chainedWg.Add(1)
+	rawReq := fmt.Sprintf("GET /chain HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", target)
+	resp := connectAndSendHTTP(t, chainedAddr, target, rawReq)
+	if !strings.Contains(resp, "200 OK") {
+		t.Fatalf("response missing 200 OK: %q", resp)
+	}
+	waitSessionDone(t, chainedWg)
+	waitSessionDone(t, outerWg)
+
+	// Exactly ONE upstream request — recursion through outer would
+	// multiply this.
+	if n := getUpstreamCount(); n != 1 {
+		t.Errorf("upstream saw %d connections, want 1 (chain recursion regression)", n)
+	}
+}
+
+// TestLiveProxy_NoDelimiterTemplate_FastPath verifies that a template
+// with no §-macro still parses (it's effectively a static URL once
+// "expanded"). Ensures the resolver's fast path remains correct for
+// non-rotating templates.
+func TestLiveProxy_NoDelimiterTemplate_FastPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstreamLn, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	proxyAddr, observedAuth := startCONNECTProxyRecorder(t)
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, wg := rotationListenerDeps(t, ctx, "rot-fastpath", buildCfg)
+	installRotation(t, buildCfg, "rot-fastpath",
+		fmt.Sprintf("http://static-user:pass@%s", proxyAddr),
+		connector.RotationPerRequest)
+
+	for i := 0; i < 3; i++ {
+		resp := runOneRequestThroughListener(t, listenerAddr, target, fmt.Sprintf("/r%d", i), wg)
+		if !strings.Contains(resp, "200 OK") {
+			t.Fatalf("request %d: %q", i, resp)
+		}
+	}
+
+	auths := observedAuth()
+	if len(auths) != 3 {
+		t.Fatalf("CONNECT proxy saw %d tunnels, want 3", len(auths))
+	}
+	for i, a := range auths {
+		user := decodeBasicUser(t, a)
+		if user != "static-user" {
+			t.Errorf("request %d: username = %q, want static-user (no macro)", i, user)
+		}
+	}
+}
+
+// TestLiveProxy_PerConnectionRotation_SameWithinConnection verifies
+// the per_connection policy via the H2 keep-alive path. Sending two
+// requests on the same upstream connection (h1 keep-alive or h2
+// stream multiplexing) should reuse the same nonce; a fresh inbound
+// proxy connection should mint a new nonce.
+//
+// NOTE: with the test harness using "Connection: close" per request,
+// every CONNECT is a fresh client connection → fresh ConnID → fresh
+// nonce. To validate per_connection without rebuilding the harness,
+// we rely on the unit test
+// TestRotationResolver_PerConnection_SameWithinConnID
+// (upstream_proxy_rotation_test.go) for the cache-hit semantics and
+// run the e2e test below to confirm that distinct client connections
+// observe distinct nonces (the "fresh ConnID = fresh nonce" half of
+// the policy).
+func TestLiveProxy_PerConnectionRotation_DistinctAcrossClients(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstreamLn, _ := startMultiAcceptUpstreamHTTPS(t,
+		[]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+	defer upstreamLn.Close()
+	target := upstreamLn.Addr().String()
+
+	proxyAddr, observedAuth := startCONNECTProxyRecorder(t)
+	buildCfg := buildRotationBuildConfig(t)
+	listenerAddr, _, wg := rotationListenerDeps(t, ctx, "rot-per-conn", buildCfg)
+	installRotation(t, buildCfg, "rot-per-conn",
+		fmt.Sprintf("http://session-§__nonce§:pass@%s", proxyAddr),
+		connector.RotationPerConnection)
+
+	const clientCount = 3
+	for i := 0; i < clientCount; i++ {
+		resp := runOneRequestThroughListener(t, listenerAddr, target, fmt.Sprintf("/c%d", i), wg)
+		if !strings.Contains(resp, "200 OK") {
+			t.Fatalf("client %d: %q", i, resp)
+		}
+	}
+
+	auths := observedAuth()
+	if len(auths) != clientCount {
+		t.Fatalf("CONNECT proxy saw %d tunnels, want %d", len(auths), clientCount)
+	}
+	seen := make(map[string]struct{})
+	for i, a := range auths {
+		user := decodeBasicUser(t, a)
+		seen[user] = struct{}{}
+		_ = i
+	}
+	if len(seen) != clientCount {
+		t.Errorf("per_connection across clients: distinct count = %d, want %d", len(seen), clientCount)
+	}
+}
+
+// To keep go vet happy when this file builds standalone.
+var _ = atomic.AddInt32

--- a/internal/connector/upstream_proxy_rotation_test.go
+++ b/internal/connector/upstream_proxy_rotation_test.go
@@ -1,0 +1,318 @@
+package connector
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// helperResolver builds a RotationResolver with the supplied template
+// + policy and returns it for direct testing.
+func helperResolver(t *testing.T, template string, policy RotationPolicy) *RotationResolver {
+	t.Helper()
+	return NewRotationResolver(RotationConfig{
+		Template:     template,
+		Policy:       policy,
+		ListenerName: "test",
+	}, 0, 0)
+}
+
+// TestRotationResolver_PerRequest_FreshURLPerCall confirms the
+// per_request policy mints a fresh URL on every Resolve invocation.
+func TestRotationResolver_PerRequest_FreshURLPerCall(t *testing.T) {
+	r := helperResolver(t, "http://user-§__nonce§:pass@proxy.example:8080", RotationPerRequest)
+
+	uA, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve A: %v", err)
+	}
+	uB, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve B: %v", err)
+	}
+	if uA.User.Username() == uB.User.Username() {
+		t.Errorf("per_request expected fresh nonce per call, got same %q", uA.User.Username())
+	}
+}
+
+// TestRotationResolver_PerConnection_SameWithinConnID confirms that
+// per_connection caches the URL by ConnID and mints fresh on a new
+// ConnID.
+func TestRotationResolver_PerConnection_SameWithinConnID(t *testing.T) {
+	r := helperResolver(t, "http://user-§__nonce§:pass@proxy.example:8080", RotationPerConnection)
+
+	ctxA := ContextWithConnID(context.Background(), "conn-A")
+	ctxB := ContextWithConnID(context.Background(), "conn-B")
+
+	u1, err := r.Resolve(ctxA, "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve A1: %v", err)
+	}
+	u2, err := r.Resolve(ctxA, "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve A2: %v", err)
+	}
+	if u1.User.Username() != u2.User.Username() {
+		t.Errorf("per_connection expected same nonce within conn-A, got %q vs %q",
+			u1.User.Username(), u2.User.Username())
+	}
+	u3, err := r.Resolve(ctxB, "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve B: %v", err)
+	}
+	if u3.User.Username() == u1.User.Username() {
+		t.Errorf("per_connection expected fresh nonce on new conn-B, got same %q", u3.User.Username())
+	}
+
+	// ReleaseConnection drops the conn-A entry; a subsequent Resolve
+	// on conn-A then mints fresh.
+	r.ReleaseConnection("conn-A")
+	u4, err := r.Resolve(ctxA, "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("Resolve A3 after release: %v", err)
+	}
+	if u4.User.Username() == u1.User.Username() {
+		t.Errorf("per_connection expected fresh nonce after ReleaseConnection, got same %q", u4.User.Username())
+	}
+}
+
+// TestRotationResolver_PerTargetHost_SamePerHost confirms that the
+// per_target_host cache returns the same URL for a given host and a
+// fresh URL for a different host.
+func TestRotationResolver_PerTargetHost_SamePerHost(t *testing.T) {
+	r := helperResolver(t, "http://user-§__nonce§:pass@proxy.example:8080", RotationPerTargetHost)
+
+	uA1, err := r.Resolve(context.Background(), "listener", "alice.example.com:443")
+	if err != nil {
+		t.Fatalf("alice 1: %v", err)
+	}
+	uA2, err := r.Resolve(context.Background(), "listener", "alice.example.com:443")
+	if err != nil {
+		t.Fatalf("alice 2: %v", err)
+	}
+	if uA1.User.Username() != uA2.User.Username() {
+		t.Errorf("per_target_host: expected same nonce for alice.example.com, got %q vs %q",
+			uA1.User.Username(), uA2.User.Username())
+	}
+	uB, err := r.Resolve(context.Background(), "listener", "bob.example.com:443")
+	if err != nil {
+		t.Fatalf("bob: %v", err)
+	}
+	if uB.User.Username() == uA1.User.Username() {
+		t.Errorf("per_target_host: expected fresh nonce for bob.example.com, got same %q", uB.User.Username())
+	}
+}
+
+// TestRotationResolver_Sticky_FixedForListenerLifetime confirms that
+// sticky mints once and returns the same URL for all subsequent calls.
+func TestRotationResolver_Sticky_FixedForListenerLifetime(t *testing.T) {
+	r := helperResolver(t, "http://user-§__nonce§:pass@proxy.example:8080", RotationSticky)
+
+	u1, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		u, err := r.Resolve(context.Background(), "listener", "other.example.com:443")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if u.User.Username() != u1.User.Username() {
+			t.Errorf("sticky: expected same nonce across calls, got %q vs %q",
+				u.User.Username(), u1.User.Username())
+		}
+	}
+	// Reset clears sticky; next call mints fresh.
+	r.Reset()
+	u2, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("post-reset: %v", err)
+	}
+	if u2.User.Username() == u1.User.Username() {
+		t.Errorf("sticky: expected fresh nonce after Reset, got same %q", u2.User.Username())
+	}
+}
+
+// TestRotationResolver_MalformedTemplate_SurfacesError confirms the
+// resolver returns an error for templates that fail parse, scheme, or
+// CRLF guards. Caller must fail-closed on this error.
+func TestRotationResolver_MalformedTemplate_SurfacesError(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+	}{
+		{"bad-scheme", "ftp://proxy.example:8080"},
+		{"missing-port", "http://proxy.example"},
+		{"crlf-injection", "http://user\r\nInjected: yes@proxy.example:8080"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := helperResolver(t, tc.template, RotationPerRequest)
+			_, err := r.Resolve(context.Background(), "listener", "example.com:443")
+			if err == nil {
+				t.Fatalf("expected error for template %q", tc.template)
+			}
+			if !strings.Contains(err.Error(), "upstream_proxy.url_template") {
+				t.Errorf("error missing user-facing prefix: %v", err)
+			}
+		})
+	}
+}
+
+// TestRotationResolver_FastPathNoDelimiter confirms a template with no
+// macro delimiter still parses (the engine treats unknown variables as
+// literal). Acts as the "no §" fast-path test required by the
+// implementation checklist.
+func TestRotationResolver_FastPathNoDelimiter(t *testing.T) {
+	r := helperResolver(t, "http://static-user:pass@proxy.example:8080", RotationPerRequest)
+	u, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if u.User.Username() != "static-user" {
+		t.Errorf("username = %q, want static-user", u.User.Username())
+	}
+}
+
+// TestRedactProxyURL_OnTemplate verifies that RedactProxyURL operates
+// on §-template strings verbatim — the user-facing redaction surface
+// can call it on a template URL without parsing it (binding decision
+// #13). The expected behaviour: a password-bearing template is
+// redacted; the §__nonce§ macro is left untouched.
+func TestRedactProxyURL_OnTemplate(t *testing.T) {
+	in := "http://user-§__nonce§:secret-pass@proxy.example:8080"
+	out := RedactProxyURL(in)
+	if strings.Contains(out, "secret-pass") {
+		t.Errorf("RedactProxyURL did not redact password: %q", out)
+	}
+	if !strings.Contains(out, "§__nonce§") {
+		t.Errorf("RedactProxyURL altered macro: %q", out)
+	}
+	if !strings.Contains(out, "xxxxx") {
+		t.Errorf("RedactProxyURL missing redaction marker: %q", out)
+	}
+}
+
+// TestRotationResolver_NilReturnsNil confirms the nil-receiver branch
+// returns (nil, nil) so callers can safely Resolve on a missing
+// resolver without nil panics.
+func TestRotationResolver_NilReturnsNil(t *testing.T) {
+	var r *RotationResolver
+	u, err := r.Resolve(context.Background(), "listener", "example.com:443")
+	if err != nil {
+		t.Fatalf("nil resolver should not error: %v", err)
+	}
+	if u != nil {
+		t.Errorf("nil resolver should return nil URL, got %v", u)
+	}
+}
+
+// TestBuildConfigEffectiveUpstreamProxyForCtxErr_ResolverWins verifies
+// the per-listener RotationResolver takes precedence over the
+// per-listener static URL slot in EffectiveUpstreamProxyForCtxErr.
+func TestBuildConfigEffectiveUpstreamProxyForCtxErr_ResolverWins(t *testing.T) {
+	cfg := &BuildConfig{}
+	staticURL, _ := ParseUpstreamProxy("http://static.example:9999")
+	cfg.SetUpstreamProxyForListener("L1", staticURL)
+	cfg.SetRotationForListener("L1", helperResolver(t,
+		"http://session-§__nonce§:pass@rotating.example:8080", RotationPerRequest))
+
+	ctx := ContextWithListenerName(context.Background(), "L1")
+	u, err := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if err != nil {
+		t.Fatalf("EffectiveUpstreamProxyForCtxErr: %v", err)
+	}
+	if u == nil {
+		t.Fatalf("expected resolved URL, got nil")
+	}
+	if u.Host != "rotating.example:8080" {
+		t.Errorf("resolver did not win: host=%q want rotating.example:8080", u.Host)
+	}
+}
+
+// TestBuildConfigEffectiveUpstreamProxyForCtxErr_CtxOverrideWins
+// verifies ctx-attached overrides still beat per-listener resolvers
+// (resolver should not run when a ctx override is present).
+func TestBuildConfigEffectiveUpstreamProxyForCtxErr_CtxOverrideWins(t *testing.T) {
+	cfg := &BuildConfig{}
+	cfg.SetRotationForListener("L1", helperResolver(t,
+		"http://session-§__nonce§:pass@rotating.example:8080", RotationPerRequest))
+
+	override, _ := ParseUpstreamProxy("http://override.example:7777")
+	ctx := ContextWithListenerName(context.Background(), "L1")
+	ctx = ContextWithUpstreamProxyOverride(ctx, override)
+
+	u, err := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if u == nil || u.Host != "override.example:7777" {
+		t.Errorf("ctx override did not win: got %v", u)
+	}
+}
+
+// TestRotationH2PoolKeyInvalidation_PerRequestProducesDistinctKeys
+// verifies poolKeyForH2 hashes the resolved upstream-proxy URL so
+// per_request rotation forces a fresh pool key per dial (USK-959
+// implementation checklist item: H2 pool already correct via URL
+// hash; no explicit eviction). Pool keys are stable functions of the
+// EffectiveUpstreamProxyForCtx output, so the keyspace fragments
+// automatically when the resolver mints fresh URLs.
+func TestRotationH2PoolKeyInvalidation_PerRequestProducesDistinctKeys(t *testing.T) {
+	cfg := &BuildConfig{}
+	cfg.SetRotationForListener("L1", helperResolver(t,
+		"http://session-§__nonce§:pass@proxy.example:8080", RotationPerRequest))
+
+	ctx := ContextWithListenerName(context.Background(), "L1")
+	hostTLS := &resolvedTLS{}
+
+	keyA := poolKeyForH2(ctx, "example.com:443", cfg, hostTLS)
+	keyB := poolKeyForH2(ctx, "example.com:443", cfg, hostTLS)
+	if keyA == keyB {
+		t.Errorf("per_request rotation: expected distinct pool keys, got identical %v", keyA)
+	}
+}
+
+// TestRotationH2PoolKeyInvalidation_StickyProducesStableKey verifies
+// that sticky rotation produces the same pool key across dials (the
+// resolver returns the same URL → same hash → pool reuse remains
+// possible).
+func TestRotationH2PoolKeyInvalidation_StickyProducesStableKey(t *testing.T) {
+	cfg := &BuildConfig{}
+	cfg.SetRotationForListener("L1", helperResolver(t,
+		"http://session-§__nonce§:pass@proxy.example:8080", RotationSticky))
+
+	ctx := ContextWithListenerName(context.Background(), "L1")
+	hostTLS := &resolvedTLS{}
+
+	keyA := poolKeyForH2(ctx, "example.com:443", cfg, hostTLS)
+	keyB := poolKeyForH2(ctx, "example.com:443", cfg, hostTLS)
+	if keyA != keyB {
+		t.Errorf("sticky rotation: expected identical pool keys, got %v vs %v", keyA, keyB)
+	}
+}
+
+// TestBuildConfigReleaseConnectionState_DropsPerConn confirms that
+// BuildConfig.ReleaseConnectionState propagates to per-listener
+// resolvers and drops the per_connection entry.
+func TestBuildConfigReleaseConnectionState_DropsPerConn(t *testing.T) {
+	cfg := &BuildConfig{}
+	r := helperResolver(t, "http://session-§__nonce§:pass@proxy.example:8080", RotationPerConnection)
+	cfg.SetRotationForListener("L1", r)
+
+	ctx := ContextWithListenerName(context.Background(), "L1")
+	ctx = ContextWithConnID(ctx, "conn-X")
+
+	u1, err := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if err != nil {
+		t.Fatalf("resolve 1: %v", err)
+	}
+	cfg.ReleaseConnectionState("conn-X")
+	u2, err := cfg.EffectiveUpstreamProxyForCtxErr(ctx)
+	if err != nil {
+		t.Fatalf("resolve 2: %v", err)
+	}
+	if u1.User.Username() == u2.User.Username() {
+		t.Errorf("expected fresh nonce after ReleaseConnectionState, got same %q", u1.User.Username())
+	}
+}

--- a/internal/connector/upstream_proxy_rotation_test.go
+++ b/internal/connector/upstream_proxy_rotation_test.go
@@ -193,6 +193,47 @@ func TestRedactProxyURL_OnTemplate(t *testing.T) {
 	}
 }
 
+// TestRedactProxyURL_NoPasswordMasksWholeUserinfo verifies that
+// RedactProxyURL masks the entire userinfo region when no ":password"
+// colon is present — a bare token in userinfo (e.g. session id, API
+// key) is itself a credential and must not leak to status surfaces
+// (CWE-200). Covers both the url.Parse path (plain URL) and the
+// lexical fallback (§-template URL).
+func TestRedactProxyURL_NoPasswordMasksWholeUserinfo(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "url_parse_path_no_colon",
+			in:   "http://session-token@proxy.example:8080",
+			want: "http://xxxxx@proxy.example:8080",
+		},
+		{
+			name: "lexical_fallback_no_colon",
+			in:   "http://session-§__nonce§@proxy.example:8080",
+			want: "http://xxxxx@proxy.example:8080",
+		},
+		{
+			name: "lexical_fallback_with_colon_preserves_username",
+			in:   "http://user-§__nonce§:secret@proxy.example:8080",
+			want: "http://user-§__nonce§:xxxxx@proxy.example:8080",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactProxyURL(tc.in)
+			if got != tc.want {
+				t.Errorf("RedactProxyURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, "session-token") || strings.Contains(got, "secret") {
+				t.Errorf("RedactProxyURL leaked credential: %q", got)
+			}
+		})
+	}
+}
+
 // TestRotationResolver_NilReturnsNil confirms the nil-receiver branch
 // returns (nil, nil) so callers can safely Resolve on a missing
 // resolver without nil panics.

--- a/internal/mcp/components.go
+++ b/internal/mcp/components.go
@@ -163,6 +163,16 @@ type proxyManager interface {
 	// per-listener upstream-proxy entry (USK-826). Equivalent to
 	// SetUpstreamProxyForListener(name, "").
 	ClearUpstreamProxyForListener(name string)
+	// SetUpstreamProxyRotationForListener installs (or clears) a
+	// rotating upstream-proxy resolver for the named listener
+	// (USK-959). Passing nil clears the resolver — the literal
+	// per-listener URL re-emerges (USK-826). The MCP layer is
+	// responsible for Stage 1 probe-expansion before calling.
+	SetUpstreamProxyRotationForListener(name string, cfg *connector.RotationConfig) error
+	// UpstreamProxyRotationForListener returns the operator-supplied
+	// template + policy for the named listener (USK-959). Both empty
+	// when no rotation is configured.
+	UpstreamProxyRotationForListener(name string) (template, policy string)
 	// SetTLSFingerprint installs a runtime uTLS browser fingerprint
 	// profile override on the bound BuildConfig so the live MITM
 	// data-path's next upstream dial picks up the new profile

--- a/internal/mcp/configure_tool.go
+++ b/internal/mcp/configure_tool.go
@@ -36,17 +36,29 @@ type configureInput struct {
 	// silently dropping the per-listener directive.
 	Name string `json:"name,omitempty" jsonschema:"listener name; currently scopes upstream_proxy only, other sections remain process-global (default: 'default')"`
 
-	// UpstreamProxy configures the upstream proxy URL.
-	// Set to a proxy URL (e.g. "http://proxy:3128" or "socks5://proxy:1080") to route traffic through it.
-	// Set to empty string "" to disable (direct connection).
-	// If omitted (nil pointer), the setting is not changed.
+	// UpstreamProxy configures the upstream proxy URL or rotating
+	// template (USK-826 + USK-959). Accepts two shapes:
+	//
+	// Legacy string form: a literal proxy URL ("http://proxy:3128" or
+	// "socks5://proxy:1080"). Empty string disables (direct connection).
+	//
+	// Structured object form (USK-959):
+	//   {"url_template": "http://session-§__nonce§:pass@proxy:8080",
+	//    "rotation": {"policy": "per_request"}}
+	// Supported policies: per_request, per_connection,
+	// per_target_host, sticky. §__nonce§ substitutes a fresh UUID per
+	// resolution event.
+	//
+	// JSON typing: declared as `any` so the schema generator accepts
+	// both string and object; the handler parses via
+	// parseUpstreamProxyInput at the tool entry. If omitted, the
+	// setting is not changed.
 	//
 	// USK-826: scoped to the listener identified by the top-level "name"
 	// field (default: "default"). Multi-listener chained MITM (listener
 	// B routes its traffic through listener A) requires per-listener
-	// scoping; setting upstream_proxy without "name" applies to the
-	// default listener only.
-	UpstreamProxy *string `json:"upstream_proxy,omitempty" jsonschema:"upstream proxy URL scoped to the listener named by 'name' (empty string to disable, omit to keep current)"`
+	// scoping.
+	UpstreamProxy any `json:"upstream_proxy,omitempty" jsonschema:"upstream proxy: literal URL string (http://host:port or socks5://host:port) OR object {url|url_template, rotation:{policy: per_request|per_connection|per_target_host|sticky}} (USK-959)"`
 
 	// TLSPassthrough configures TLS passthrough patterns.
 	// For merge: use add/remove arrays.
@@ -317,8 +329,20 @@ type configureResult struct {
 	// Status indicates the result of the operation.
 	Status string `json:"status"`
 
-	// UpstreamProxy shows the current upstream proxy URL (empty string means direct).
+	// UpstreamProxy shows the current upstream proxy URL (empty string
+	// means direct). When the listener is using USK-959 rotation, this
+	// field is empty and UpstreamProxyTemplate / UpstreamProxyRotationPolicy
+	// carry the rotation state instead.
 	UpstreamProxy *string `json:"upstream_proxy,omitempty"`
+
+	// UpstreamProxyTemplate echoes the current rotation template (redacted
+	// via connector.RedactProxyURL) when the listener is using USK-959
+	// rotation. Empty otherwise.
+	UpstreamProxyTemplate *string `json:"upstream_proxy_template,omitempty"`
+
+	// UpstreamProxyRotationPolicy echoes the current rotation policy
+	// when the listener is using USK-959 rotation. Empty otherwise.
+	UpstreamProxyRotationPolicy *string `json:"upstream_proxy_rotation_policy,omitempty"`
 
 	// TLSPassthrough summarizes the current TLS passthrough state.
 	TLSPassthrough *configurePassthroughResult `json:"tls_passthrough,omitempty"`
@@ -674,8 +698,21 @@ func (s *Server) configureCaptureScope(operation string, in *configureCaptureSco
 // — otherwise the call returns an error so chained-MITM misconfiguration
 // surfaces loudly rather than silently dropping the directive (this is
 // consistent with the proxy_stop / proxy_start error semantics).
+//
+// USK-959: the input is polymorphic — a JSON string is the legacy
+// literal-URL form; a JSON object enables rotation via url_template +
+// rotation policy. Stage 1 validation (URL ⊕ URLTemplate, policy
+// whitelist, template probe-expansion) runs at the input boundary so
+// malformed shapes fail the tool call rather than the first dial.
 func (s *Server) configureUpstreamProxy(input configureInput, result *configureResult) error {
 	if input.UpstreamProxy == nil {
+		return nil
+	}
+	parsed, err := parseUpstreamProxyInput(input.UpstreamProxy)
+	if err != nil {
+		return err
+	}
+	if parsed == nil {
 		return nil
 	}
 	listenerName := input.Name
@@ -693,12 +730,45 @@ func (s *Server) configureUpstreamProxy(input configureInput, result *configureR
 		return fmt.Errorf("upstream_proxy: listener %q: %w", listenerName, proxybuild.ErrListenerNotFound)
 	}
 
-	if err := s.applyUpstreamProxy(*input.UpstreamProxy, listenerName); err != nil {
-		return fmt.Errorf("upstream_proxy: %w", err)
+	if err := parsed.Validate(); err != nil {
+		return err
 	}
+
+	switch {
+	case parsed.IsRotation():
+		// USK-959: structured rotation form. The Manager wires the
+		// resolver into the BuildConfig; the literal-URL slot is
+		// cleared as part of the Manager method.
+		cfg := parsed.RotationConfig()
+		if err := s.applyUpstreamProxyRotation(cfg, listenerName); err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+	case parsed.IsLiteralDisable():
+		// Legacy: empty string disables.
+		if err := s.applyUpstreamProxy("", listenerName); err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+		// Also explicitly clear any rotation so a previous
+		// configure call's rotation does not survive.
+		_ = s.applyUpstreamProxyRotation(nil, listenerName)
+	default:
+		// Legacy literal URL form. URL may come from the string form
+		// (suppliedAsString=true) or from the object form's "url"
+		// key (no rotation).
+		if err := s.applyUpstreamProxy(parsed.LiteralURL(), listenerName); err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+	}
+
 	current := ""
 	if !managerIsNil(s.connector.manager) {
 		current = connector.RedactProxyURL(s.connector.manager.UpstreamProxyForListener(listenerName))
+		template, policy := s.connector.manager.UpstreamProxyRotationForListener(listenerName)
+		if template != "" {
+			redactedTpl := connector.RedactProxyURL(template)
+			result.UpstreamProxyTemplate = &redactedTpl
+			result.UpstreamProxyRotationPolicy = &policy
+		}
 	}
 	result.UpstreamProxy = &current
 	return nil

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -58,12 +59,28 @@ type proxyStartInput struct {
 	// Defaults to "127.0.0.1:8080" if empty.
 	ListenAddr string `json:"listen_addr,omitempty" jsonschema:"TCP address to listen on, defaults to 127.0.0.1:8080 if omitted"`
 
-	// UpstreamProxy is the URL of an upstream proxy to route all outgoing traffic through.
-	// Supported schemes: http://host:port (HTTP CONNECT proxy), socks5://host:port (SOCKS5 proxy).
-	// Authentication: http://user:pass@host:port (Basic auth), socks5://user:pass@host:port.
-	// If omitted, traffic is sent directly to the target (no upstream proxy).
-	// This setting takes precedence over HTTP_PROXY/HTTPS_PROXY environment variables.
-	UpstreamProxy string `json:"upstream_proxy,omitempty" jsonschema:"upstream proxy URL (http://host:port or socks5://host:port) for chaining proxies"`
+	// UpstreamProxy is the URL of an upstream proxy to route all outgoing
+	// traffic through.
+	//
+	// Legacy string form (USK-826): a literal proxy URL ("http://host:port"
+	// HTTP CONNECT proxy or "socks5://host:port" SOCKS5 proxy). Auth via
+	// "http://user:pass@host:port" (Basic) or socks5 equivalent.
+	//
+	// Structured object form (USK-959): enables per-listener rotation via
+	// url_template + rotation policy. Supported policies: per_request,
+	// per_connection, per_target_host, sticky. §__nonce§ substitutes a
+	// fresh UUID per resolution event for residential-proxy IP rotation.
+	// Example:
+	//
+	//   {"url_template": "http://session-§__nonce§:pass@proxy:8080",
+	//    "rotation": {"policy": "per_request"}}
+	//
+	// JSON typing: declared as `any` so the schema generator accepts
+	// both string and object; the handler parses via
+	// parseUpstreamProxyInput at the tool entry. If omitted, traffic
+	// flows direct (no upstream proxy). This setting takes precedence
+	// over HTTP_PROXY/HTTPS_PROXY environment variables.
+	UpstreamProxy any `json:"upstream_proxy,omitempty" jsonschema:"upstream proxy: literal URL string (http://host:port or socks5://host:port) OR object {url|url_template, rotation:{policy: per_request|per_connection|per_target_host|sticky}} for per-listener rotation (USK-959)"`
 
 	// TLSPassthrough is a list of domain patterns that should bypass TLS interception.
 	// Supported formats: exact match ("example.com") or wildcard ("*.example.com").
@@ -461,14 +478,8 @@ func (s *Server) applyProxyStartPipeline(input *proxyStartInput) error {
 			return err
 		}
 	}
-	if input.UpstreamProxy != "" {
-		listenerName := input.Name
-		if listenerName == "" {
-			listenerName = proxybuild.DefaultListenerName
-		}
-		if err := s.applyUpstreamProxy(input.UpstreamProxy, listenerName); err != nil {
-			return fmt.Errorf("upstream_proxy: %w", err)
-		}
+	if err := s.applyProxyStartUpstreamProxy(input); err != nil {
+		return err
 	}
 	if len(input.TLSPassthrough) > 0 {
 		if err := s.applyTLSPassthrough(input.TLSPassthrough); err != nil {
@@ -491,6 +502,49 @@ func (s *Server) applyProxyStartPipeline(input *proxyStartInput) error {
 		}
 	}
 	return s.applyProxyStartTLS(input)
+}
+
+// applyProxyStartUpstreamProxy parses the polymorphic upstream_proxy
+// input and routes to the literal-URL / rotation / disable branch.
+// Extracted from applyProxyStartPipeline to keep that function under
+// the gocyclo budget after USK-959 added the rotation surface.
+func (s *Server) applyProxyStartUpstreamProxy(input *proxyStartInput) error {
+	if input.UpstreamProxy == nil {
+		return nil
+	}
+	parsed, perr := parseUpstreamProxyInput(input.UpstreamProxy)
+	if perr != nil {
+		return perr
+	}
+	if parsed == nil {
+		return nil
+	}
+	listenerName := input.Name
+	if listenerName == "" {
+		listenerName = proxybuild.DefaultListenerName
+	}
+	if err := parsed.Validate(); err != nil {
+		return err
+	}
+	switch {
+	case parsed.IsRotation():
+		cfg := parsed.RotationConfig()
+		if err := s.applyUpstreamProxyRotation(cfg, listenerName); err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+	case parsed.IsLiteralDisable():
+		if err := s.applyUpstreamProxy("", listenerName); err != nil {
+			return fmt.Errorf("upstream_proxy: %w", err)
+		}
+	default:
+		u := parsed.LiteralURL()
+		if u != "" {
+			if err := s.applyUpstreamProxy(u, listenerName); err != nil {
+				return fmt.Errorf("upstream_proxy: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 // applyProxyStartTLS validates and applies TLS-related settings (fingerprint, client cert).
@@ -858,8 +912,23 @@ func (s *Server) applyProxyDefaultStrings(input *proxyStartInput, d *config.Prox
 	if input.ListenAddr == "" && d.ListenAddr != "" {
 		input.ListenAddr = d.ListenAddr
 	}
-	if input.UpstreamProxy == "" && d.UpstreamProxy != "" {
-		input.UpstreamProxy = d.UpstreamProxy
+	if input.UpstreamProxy == nil {
+		if d.UpstreamProxyStruct != nil && d.UpstreamProxyStruct.URLTemplate != "" {
+			// USK-959: file config carries a structured rotation. Mirror
+			// into the proxy_start input as a map (the schema is `any`
+			// so the handler accepts both shapes).
+			rotMap := map[string]any{}
+			if d.UpstreamProxyStruct.Rotation != nil {
+				rotMap["policy"] = d.UpstreamProxyStruct.Rotation.Policy
+			}
+			input.UpstreamProxy = map[string]any{
+				"url_template": d.UpstreamProxyStruct.URLTemplate,
+				"rotation":     rotMap,
+			}
+		} else if d.UpstreamProxy != "" {
+			// Legacy USK-826 string form.
+			input.UpstreamProxy = d.UpstreamProxy
+		}
 	}
 	if input.SOCKS5Auth == "" && d.SOCKS5Auth != "" {
 		input.SOCKS5Auth = d.SOCKS5Auth
@@ -999,6 +1068,53 @@ func (s *Server) applyUpstreamProxy(rawURL, listenerName string) error {
 	}
 
 	return nil
+}
+
+// applyUpstreamProxyRotation installs (or clears) a rotating upstream-
+// proxy resolver scoped to the named listener (USK-959).
+//
+// cfg must carry a non-empty Template + supported Policy. Stage 1
+// probe-expansion runs at this level (via the structured config
+// validator) so a malformed template fails the MCP tool call rather
+// than the first live dial. Passing nil clears any active rotation.
+//
+// The Manager wires the resolver into the bound BuildConfig so the
+// next live data-path dial under the listener consults the resolver.
+// configure_tool dynamic tuning: re-calling this method replaces the
+// resolver entirely, dropping per-conn / per-host / sticky caches.
+func (s *Server) applyUpstreamProxyRotation(cfg *connector.RotationConfig, listenerName string) error {
+	if listenerName == "" {
+		listenerName = proxybuild.DefaultListenerName
+	}
+	if managerIsNil(s.connector.manager) {
+		return fmt.Errorf("proxy manager is not initialized")
+	}
+	if cfg == nil {
+		return s.connector.manager.SetUpstreamProxyRotationForListener(listenerName, nil)
+	}
+	// Stage 1 fail-closed: probe-expand the template once so any
+	// macro / CRLF / scheme failure surfaces here rather than at the
+	// first dial. The probe does NOT commit any resolver state.
+	if _, err := probeRotationTemplate(cfg.Template); err != nil {
+		return fmt.Errorf("upstream_proxy.url_template: %w", err)
+	}
+	return s.connector.manager.SetUpstreamProxyRotationForListener(listenerName, cfg)
+}
+
+// probeRotationTemplate runs the connector-side resolver against a
+// synthetic nonce / iteration to confirm the template expands into a
+// well-formed upstream proxy URL. Used by the MCP layer to enforce
+// Stage 1 fail-closed at config-apply time. Returns the parsed URL on
+// success (caller may discard) plus any expansion / CRLF / parse
+// error.
+func probeRotationTemplate(template string) (*url.URL, error) {
+	cfg := &connector.UpstreamProxyConfig{URLTemplate: template}
+	ctx, err := cfg.ResolveForIteration(context.Background(), 0)
+	if err != nil {
+		return nil, err
+	}
+	u, _ := connector.UpstreamProxyOverrideFromContext(ctx)
+	return u, nil
 }
 
 // applyTLSPassthrough validates and adds the TLS passthrough patterns.

--- a/internal/mcp/upstream_proxy_input.go
+++ b/internal/mcp/upstream_proxy_input.go
@@ -1,0 +1,222 @@
+// upstream_proxy_input.go carries the polymorphic input shape for the
+// MCP-tool surface (configure_tool / proxy_start_tool) accepting an
+// upstream-proxy configuration as either a literal URL string (legacy
+// USK-826) or a structured rotation object (USK-959).
+//
+// This wraps internal/config.UpstreamProxyConfig with MCP-specific
+// validation hooks; the config struct itself is shared between file
+// config and runtime tools.
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+)
+
+// configureUpstreamProxyInput is the polymorphic JSON shape for the
+// configure / proxy_start tool's upstream_proxy field. Exactly one of
+// the URL form (URL set, IsLiteralEmpty true on the empty-string
+// signal) or the URLTemplate form (URLTemplate + Rotation set) is
+// active per call.
+type configureUpstreamProxyInput struct {
+	// URL carries the legacy literal-URL form (USK-826). An empty
+	// string is honoured as "disable upstream proxy" only when
+	// SuppliedAsString=true so the wire shape can distinguish "no
+	// upstream_proxy field" from "upstream_proxy: ''".
+	URL string `json:"url,omitempty"`
+
+	// URLTemplate carries the rotating-template form (USK-959).
+	// Mutually exclusive with URL.
+	URLTemplate string `json:"url_template,omitempty"`
+
+	// Rotation describes how often the template is expanded. Required
+	// when URLTemplate is set; forbidden when URL is set.
+	Rotation *configureUpstreamProxyRotationInput `json:"rotation,omitempty"`
+
+	// suppliedAsString is set by UnmarshalJSON when the caller passed
+	// a JSON string (rather than an object). Distinguishes
+	// "upstream_proxy: ''" (disable) from "upstream_proxy: {}" (
+	// arguably also disable, but operators may intend something else
+	// — we reject empty-object form to surface the mistake).
+	suppliedAsString bool
+}
+
+// configureUpstreamProxyRotationInput is the JSON shape for the
+// rotation sub-object. Mirrors config.UpstreamProxyRotation.
+type configureUpstreamProxyRotationInput struct {
+	Policy string `json:"policy" jsonschema:"rotation policy: per_request | per_connection | per_target_host | sticky"`
+}
+
+// UnmarshalJSON accepts either a JSON string (legacy literal URL,
+// optionally empty for disable) or a JSON object (USK-959 structured
+// form). Other shapes return a typed error.
+func (c *configureUpstreamProxyInput) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("upstream_proxy: must be a string or object: %w", err)
+		}
+		c.URL = s
+		c.URLTemplate = ""
+		c.Rotation = nil
+		c.suppliedAsString = true
+		return nil
+	}
+	type alias configureUpstreamProxyInput
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return fmt.Errorf("upstream_proxy: %w", err)
+	}
+	*c = configureUpstreamProxyInput(tmp)
+	c.suppliedAsString = false
+	return nil
+}
+
+// Validate runs Stage 1 validation (URL ⊕ URLTemplate exclusivity,
+// rotation policy whitelist). The connector / config layer's own
+// validators run on the value derived from this input, so the rules
+// applied here match the file-config path.
+//
+// Returns nil for the empty-disable string form (URL="") so callers
+// can fall through to the "clear" branch without an extra null check.
+func (c *configureUpstreamProxyInput) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.suppliedAsString {
+		// Literal URL form. Empty is "disable". Parsing is deferred
+		// to applyUpstreamProxy → connector.ParseUpstreamProxy.
+		return nil
+	}
+	if c.URL != "" && c.URLTemplate != "" {
+		return fmt.Errorf("upstream_proxy: url and url_template are mutually exclusive")
+	}
+	if c.URL == "" && c.URLTemplate == "" {
+		return fmt.Errorf("upstream_proxy: one of url or url_template is required")
+	}
+	if c.URL != "" {
+		if c.Rotation != nil {
+			return fmt.Errorf("upstream_proxy: rotation is not valid with url (set url_template to enable rotation)")
+		}
+		return nil
+	}
+	// URLTemplate form
+	if c.Rotation == nil {
+		return fmt.Errorf("upstream_proxy: rotation is required with url_template")
+	}
+	policy := connector.RotationPolicy(c.Rotation.Policy)
+	if !policy.IsValid() {
+		if c.Rotation.Policy == "" {
+			return fmt.Errorf("upstream_proxy.rotation.policy is required (per_request | per_connection | per_target_host | sticky)")
+		}
+		return fmt.Errorf("upstream_proxy.rotation.policy %q not supported (per_request | per_connection | per_target_host | sticky)", c.Rotation.Policy)
+	}
+	return nil
+}
+
+// IsLiteralDisable reports whether the input is the legacy
+// empty-string form (set explicitly to clear the upstream proxy).
+// Distinct from the "omitted entirely" case (the caller is nil).
+func (c *configureUpstreamProxyInput) IsLiteralDisable() bool {
+	return c != nil && c.suppliedAsString && c.URL == ""
+}
+
+// IsLiteralURL reports whether the input is the legacy literal-URL
+// form (non-empty URL via string). Equivalent to "USK-826 set this
+// URL on the listener".
+func (c *configureUpstreamProxyInput) IsLiteralURL() bool {
+	return c != nil && c.suppliedAsString && c.URL != ""
+}
+
+// IsRotation reports whether the input is the USK-959 structured
+// rotation form (URLTemplate + Rotation populated). Returns false for
+// the object form WITHOUT rotation (the URL-as-object shape, mainly
+// useful for parity with the file config; equivalent to a literal URL
+// when present).
+func (c *configureUpstreamProxyInput) IsRotation() bool {
+	return c != nil && !c.suppliedAsString && c.URLTemplate != "" && c.Rotation != nil
+}
+
+// RotationConfig returns the connector-side RotationConfig derived
+// from the input, or nil when the input is not a rotation form.
+// Callers must call Validate() first.
+func (c *configureUpstreamProxyInput) RotationConfig() *connector.RotationConfig {
+	if !c.IsRotation() {
+		return nil
+	}
+	return &connector.RotationConfig{
+		Template: c.URLTemplate,
+		Policy:   connector.RotationPolicy(c.Rotation.Policy),
+	}
+}
+
+// LiteralURL returns the literal URL portion of the input — either
+// the string form's URL or the object form's URL field. Empty when
+// the input is a rotation form.
+func (c *configureUpstreamProxyInput) LiteralURL() string {
+	if c == nil {
+		return ""
+	}
+	if c.suppliedAsString {
+		return c.URL
+	}
+	return c.URL
+}
+
+// parseUpstreamProxyInput coerces an `any` value (as decoded from
+// the MCP-tool JSON input) into a *configureUpstreamProxyInput. The
+// MCP wire-shape is polymorphic (string or object); we accept both
+// shapes here and a nil value (caller omitted the field entirely).
+//
+// Returns:
+//   - nil, nil — caller omitted the field; downstream skips
+//     upstream_proxy processing.
+//   - input, nil — parsed input ready for Validate().
+//   - nil, err — input shape unrecognised (not string, object, or nil).
+//
+// Accepted shapes:
+//   - nil: omitted (no change)
+//   - string: legacy USK-826 literal URL (empty for disable)
+//   - map[string]any: USK-959 structured (url|url_template + rotation)
+//   - *configureUpstreamProxyInput / configureUpstreamProxyInput:
+//     pre-typed (test harnesses, programmatic callers)
+func parseUpstreamProxyInput(raw any) (*configureUpstreamProxyInput, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	switch v := raw.(type) {
+	case string:
+		return &configureUpstreamProxyInput{URL: v, suppliedAsString: true}, nil
+	case map[string]any:
+		out := &configureUpstreamProxyInput{}
+		if u, ok := v["url"].(string); ok {
+			out.URL = u
+		}
+		if tpl, ok := v["url_template"].(string); ok {
+			out.URLTemplate = tpl
+		}
+		if rot, ok := v["rotation"].(map[string]any); ok {
+			r := &configureUpstreamProxyRotationInput{}
+			if p, ok := rot["policy"].(string); ok {
+				r.Policy = p
+			}
+			out.Rotation = r
+		}
+		return out, nil
+	case *configureUpstreamProxyInput:
+		return v, nil
+	case configureUpstreamProxyInput:
+		// Defensive copy so the returned pointer is unique.
+		cp := v
+		return &cp, nil
+	default:
+		return nil, fmt.Errorf("upstream_proxy: must be a string or object, got %T", raw)
+	}
+}

--- a/internal/mcp/upstream_proxy_input_test.go
+++ b/internal/mcp/upstream_proxy_input_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+)
+
+// TestParseUpstreamProxyInput_StringForm verifies that a plain string
+// value (legacy USK-826 wire form) deserialises into the literal-URL
+// shape with suppliedAsString=true so the consumer can distinguish
+// "empty disable" from "object with empty url".
+func TestParseUpstreamProxyInput_StringForm(t *testing.T) {
+	got, err := parseUpstreamProxyInput("http://proxy.example:8080")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if !got.IsLiteralURL() {
+		t.Errorf("expected IsLiteralURL=true, got %+v", got)
+	}
+	if got.URL != "http://proxy.example:8080" {
+		t.Errorf("URL = %q, want http://proxy.example:8080", got.URL)
+	}
+}
+
+// TestParseUpstreamProxyInput_EmptyStringDisables verifies that the
+// "" string value is honoured as a disable signal.
+func TestParseUpstreamProxyInput_EmptyStringDisables(t *testing.T) {
+	got, err := parseUpstreamProxyInput("")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !got.IsLiteralDisable() {
+		t.Errorf("expected IsLiteralDisable=true, got %+v", got)
+	}
+}
+
+// TestParseUpstreamProxyInput_ObjectRotation verifies that an object
+// with url_template + rotation deserialises into the rotation shape.
+func TestParseUpstreamProxyInput_ObjectRotation(t *testing.T) {
+	got, err := parseUpstreamProxyInput(map[string]any{
+		"url_template": "http://session-§__nonce§:pass@proxy.example:8080",
+		"rotation": map[string]any{
+			"policy": "per_request",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !got.IsRotation() {
+		t.Errorf("expected IsRotation=true, got %+v", got)
+	}
+	cfg := got.RotationConfig()
+	if cfg == nil {
+		t.Fatalf("nil RotationConfig")
+	}
+	if cfg.Policy != connector.RotationPerRequest {
+		t.Errorf("policy = %q, want per_request", cfg.Policy)
+	}
+}
+
+// TestParseUpstreamProxyInput_UnknownTypeReturnsErr verifies that
+// non-string / non-map inputs are rejected with a typed error.
+func TestParseUpstreamProxyInput_UnknownTypeReturnsErr(t *testing.T) {
+	_, err := parseUpstreamProxyInput(42)
+	if err == nil {
+		t.Fatalf("expected error for int input")
+	}
+	if !strings.Contains(err.Error(), "must be a string or object") {
+		t.Errorf("error message missing expected text: %v", err)
+	}
+}
+
+// TestUpstreamProxyInput_Validate_RotationMissingPolicyRejected
+// verifies validation rejects a rotation object without a policy.
+func TestUpstreamProxyInput_Validate_RotationMissingPolicyRejected(t *testing.T) {
+	in := &configureUpstreamProxyInput{
+		URLTemplate: "http://§__nonce§:pass@proxy.example:8080",
+		Rotation:    &configureUpstreamProxyRotationInput{},
+	}
+	err := in.Validate()
+	if err == nil {
+		t.Fatalf("expected error for rotation with empty policy")
+	}
+	if !strings.Contains(err.Error(), "policy") {
+		t.Errorf("error message missing 'policy': %v", err)
+	}
+}
+
+// TestUpstreamProxyInput_Validate_URLPlusTemplateRejected verifies
+// the URL ⊕ URLTemplate exclusivity guard.
+func TestUpstreamProxyInput_Validate_URLPlusTemplateRejected(t *testing.T) {
+	in := &configureUpstreamProxyInput{
+		URL:         "http://proxy.example:8080",
+		URLTemplate: "http://§__nonce§@proxy.example:8080",
+	}
+	err := in.Validate()
+	if err == nil {
+		t.Fatalf("expected error for url + url_template")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error message missing 'mutually exclusive': %v", err)
+	}
+}
+
+// TestUpstreamProxyInput_Validate_UnknownPolicyRejected verifies the
+// policy whitelist.
+func TestUpstreamProxyInput_Validate_UnknownPolicyRejected(t *testing.T) {
+	in := &configureUpstreamProxyInput{
+		URLTemplate: "http://§__nonce§:pass@proxy.example:8080",
+		Rotation:    &configureUpstreamProxyRotationInput{Policy: "bogus"},
+	}
+	err := in.Validate()
+	if err == nil {
+		t.Fatalf("expected error for unknown policy")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error message missing 'not supported': %v", err)
+	}
+}
+
+// TestProbeRotationTemplate_MalformedRejected verifies the Stage 1
+// probe rejects malformed templates at the MCP tool-input boundary.
+func TestProbeRotationTemplate_MalformedRejected(t *testing.T) {
+	_, err := probeRotationTemplate("ftp://broken-§__nonce§.example:21")
+	if err == nil {
+		t.Fatalf("expected error for ftp scheme")
+	}
+}
+
+// TestProbeRotationTemplate_WellFormedAccepted verifies a valid
+// template passes Stage 1 probing.
+func TestProbeRotationTemplate_WellFormedAccepted(t *testing.T) {
+	u, err := probeRotationTemplate("http://session-§__nonce§:pass@proxy.example:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u == nil {
+		t.Fatalf("nil URL")
+	}
+	if u.Host != "proxy.example:8080" {
+		t.Errorf("host = %q, want proxy.example:8080", u.Host)
+	}
+}

--- a/internal/mcp/upstream_proxy_rotation.go
+++ b/internal/mcp/upstream_proxy_rotation.go
@@ -1,15 +1,9 @@
-// upstream_proxy_rotation.go implements per-iteration upstream proxy URL
-// expansion for fuzz / resend MCP tools. Used by the residential proxy
-// IP switching workflow: each fuzz variant (or resend invocation) tunnels
-// through a distinct upstream proxy URL, so the upstream observes a
-// rotating client IP.
-//
-// The resolver expands a user-supplied URL template once per iteration
-// against a tiny runtime-supplied KV Store carrying the reserved
-// variables §__iteration§ and §__nonce§. The parsed URL is then attached
-// to ctx via connector.ContextWithUpstreamProxyOverride; downstream dial
-// helpers (connector.MaybeDialViaUpstreamProxy) read the override and
-// tunnel through the chosen upstream proxy.
+// upstream_proxy_rotation.go retains the MCP package's public alias for
+// the per-iteration upstream proxy configuration. The implementation
+// now lives in internal/connector/upstream_proxy_rotation.go (USK-959
+// lift) so the live MITM data path and the control-plane resend / fuzz
+// path share one resolver + macro-expansion engine. The wire schema is
+// unchanged.
 //
 // Reserved variables (prefix "__") cannot be set or shadowed by
 // user-supplied macros — see internal/macro/reserved.go and the
@@ -17,75 +11,10 @@
 package mcp
 
 import (
-	"context"
-	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/google/uuid"
-
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
-	"github.com/usk6666/yorishiro-proxy/internal/macro"
 )
 
-// UpstreamProxyConfig is the per-iteration upstream proxy configuration
-// for fuzz / resend MCP tools. Optional — when nil or URLTemplate is
-// empty, the iteration uses the default (direct) dial path without
-// attaching any upstream-proxy override to ctx.
-//
-// URLTemplate supports the §var§ macro template syntax with the
-// following runtime-reserved variables (always present per iteration):
-//
-//	§__iteration§ — zero-based iteration index for the current MCP call
-//	§__nonce§     — fresh UUID minted per iteration
-//
-// Reserved variables cannot be overridden by user input. The parsed
-// upstream proxy URL must use scheme http:// or socks5:// (validated by
-// connector.ParseUpstreamProxy). CRLF guards (CWE-93) apply to the
-// expanded URL so a §__nonce§-substituted credential cannot smuggle a
-// Proxy-Authorization header injection into the downstream CONNECT
-// request.
-//
-// The struct is intentionally a single-field carrier so future
-// extensions (rotation policy, session-id sticky window, error-driven
-// rotation) can land as additional optional fields without breaking the
-// MCP wire schema.
-type UpstreamProxyConfig struct {
-	URLTemplate string `json:"url_template,omitempty" jsonschema:"upstream proxy URL template (http:// or socks5://). Supports §var§ macro syntax with reserved variables §__iteration§ (zero-based index) and §__nonce§ (per-iteration UUID) for residential-proxy IP rotation. Example: http://user-session-§__nonce§:password@residential.example:8080"`
-}
-
-// ResolveForIteration expands the URL template for iteration N, parses
-// the result as an upstream proxy URL, and returns a ctx carrying the
-// per-flow override (connector.ContextWithUpstreamProxyOverride).
-// Returns the input ctx unchanged when the configuration is nil or
-// URLTemplate is empty — the caller falls through to the default dial
-// path.
-//
-// Errors are returned with the user-facing prefix "upstream_proxy.url_template"
-// so MCP tool handlers can surface them verbatim.
-func (c *UpstreamProxyConfig) ResolveForIteration(ctx context.Context, iteration int) (context.Context, error) {
-	if c == nil || c.URLTemplate == "" {
-		return ctx, nil
-	}
-
-	kvStore := map[string]string{
-		macro.ReservedKeyPrefix + "iteration": strconv.Itoa(iteration),
-		macro.ReservedKeyPrefix + "nonce":     uuid.NewString(),
-	}
-
-	expanded, err := macro.ExpandTemplate(c.URLTemplate, kvStore)
-	if err != nil {
-		return nil, fmt.Errorf("upstream_proxy.url_template: expand: %w", err)
-	}
-
-	if strings.ContainsAny(expanded, "\r\n") {
-		return nil, fmt.Errorf("upstream_proxy.url_template: expanded URL contains CR/LF (CWE-93 guard)")
-	}
-
-	parsed, err := connector.ParseUpstreamProxy(expanded)
-	if err != nil {
-		return nil, fmt.Errorf("upstream_proxy.url_template: %w", err)
-	}
-
-	return connector.ContextWithUpstreamProxyOverride(ctx, parsed), nil
-}
+// UpstreamProxyConfig aliases the connector package's type so the MCP
+// JSON schema continues to expose `upstream_proxy.url_template` exactly
+// as it did pre-USK-959.
+type UpstreamProxyConfig = connector.UpstreamProxyConfig

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -101,8 +101,25 @@ type Manager struct {
 	// parsed *url.URL. Mutations guarded by m.mu.
 	upstreamProxyPerListener map[string]string
 
+	// upstreamProxyRotationPerListener tracks the per-listener rotation
+	// state for the URL-template form (USK-959). Stored alongside the
+	// legacy string map so status surfaces can report the active
+	// template (redacted) and policy without re-stringifying the
+	// resolver's internal state. Mutations guarded by m.mu.
+	upstreamProxyRotationPerListener map[string]*upstreamProxyRotationEntry
+
 	mu        sync.Mutex
 	listeners map[string]*listenerEntry
+}
+
+// upstreamProxyRotationEntry pairs the operator-supplied template
+// (verbatim, so the status surface can redact via
+// connector.RedactProxyURL) with the resolved RotationPolicy. The
+// BuildConfig holds the live RotationResolver; this struct is purely
+// for status reporting.
+type upstreamProxyRotationEntry struct {
+	Template string
+	Policy   string
 }
 
 // NewManager constructs a Manager. cfg.StackFactory is required; nil
@@ -314,12 +331,23 @@ func (m *Manager) Status() (running bool, listenAddr string) {
 // string as stored via SetUpstreamProxyForListener, empty when no
 // per-listener override is set. The MCP status surface is responsible
 // for redaction via connector.RedactProxyURL before serialising.
+//
+// UpstreamProxyTemplate / UpstreamProxyRotationPolicy (USK-959) carry
+// the rotating-template form. Both fields are empty when the listener
+// is not using rotation (UpstreamProxy carries the literal URL or the
+// listener has no upstream proxy configured). When rotation IS active,
+// UpstreamProxy is empty (the literal URL doesn't exist — only a
+// template). The MCP status surface MUST redact UpstreamProxyTemplate
+// via connector.RedactProxyURL before serialising; the template may
+// resolve to credentials.
 type ListenerStatus struct {
-	Name              string `json:"name"`
-	ListenAddr        string `json:"listen_addr"`
-	ActiveConnections int    `json:"active_connections"`
-	UptimeSeconds     int64  `json:"uptime_seconds"`
-	UpstreamProxy     string `json:"upstream_proxy,omitempty"`
+	Name                        string `json:"name"`
+	ListenAddr                  string `json:"listen_addr"`
+	ActiveConnections           int    `json:"active_connections"`
+	UptimeSeconds               int64  `json:"uptime_seconds"`
+	UpstreamProxy               string `json:"upstream_proxy,omitempty"`
+	UpstreamProxyTemplate       string `json:"upstream_proxy_template,omitempty"`
+	UpstreamProxyRotationPolicy string `json:"upstream_proxy_rotation_policy,omitempty"`
 }
 
 // ListenerStatuses returns a snapshot of every running listener. Returns
@@ -338,13 +366,18 @@ func (m *Manager) ListenerStatuses() []ListenerStatus {
 		if !entry.startedAt.IsZero() {
 			uptime = int64(time.Since(entry.startedAt).Seconds())
 		}
-		out = append(out, ListenerStatus{
+		status := ListenerStatus{
 			Name:              name,
 			ListenAddr:        entry.listenAddr,
 			ActiveConnections: entry.stack.Listener.ActiveConnections(),
 			UptimeSeconds:     uptime,
 			UpstreamProxy:     m.upstreamProxyPerListener[name],
-		})
+		}
+		if rot := m.upstreamProxyRotationPerListener[name]; rot != nil {
+			status.UpstreamProxyTemplate = rot.Template
+			status.UpstreamProxyRotationPolicy = rot.Policy
+		}
+		out = append(out, status)
 	}
 	return out
 }
@@ -559,6 +592,10 @@ func (m *Manager) SetUpstreamProxyForListener(name, proxyURL string) {
 			m.upstreamProxyPerListener = make(map[string]string)
 		}
 		m.upstreamProxyPerListener[name] = proxyURL
+		// USK-959: setting a literal URL clears any active rotation
+		// for the listener — they are mutually exclusive at the wire
+		// level (cf. UpstreamProxyConfig.Validate).
+		delete(m.upstreamProxyRotationPerListener, name)
 	}
 	// Maintain the legacy default-listener mirror on m.upstreamProxy so
 	// UpstreamProxy() / status surfaces keep working for callers that have
@@ -568,6 +605,11 @@ func (m *Manager) SetUpstreamProxyForListener(name, proxyURL string) {
 	}
 	bc := m.buildCfg
 	m.mu.Unlock()
+	if bc != nil && proxyURL != "" {
+		// Also clear the resolver in BuildConfig so the new literal URL
+		// is consulted instead of any stale resolver.
+		bc.SetRotationForListener(name, nil)
+	}
 
 	if bc == nil {
 		return
@@ -586,11 +628,103 @@ func (m *Manager) SetUpstreamProxyForListener(name, proxyURL string) {
 }
 
 // ClearUpstreamProxyForListener removes the named listener's per-listener
-// upstream-proxy entry (USK-826). Equivalent to
-// SetUpstreamProxyForListener(name, ""). Provided as a named accessor so
-// the proxy_start reset path expresses intent clearly.
+// upstream-proxy entry (USK-826) AND any rotation resolver installed via
+// SetUpstreamProxyRotationForListener (USK-959). Equivalent to
+// SetUpstreamProxyForListener(name, "") + SetUpstreamProxyRotationForListener(name, nil).
+// Provided as a named accessor so the proxy_start reset path expresses
+// intent clearly.
 func (m *Manager) ClearUpstreamProxyForListener(name string) {
 	m.SetUpstreamProxyForListener(name, "")
+	m.SetUpstreamProxyRotationForListener(name, nil)
+}
+
+// SetUpstreamProxyRotationForListener installs (or clears) a rotating
+// upstream-proxy resolver for the named listener (USK-959). cfg.URLTemplate
+// must be non-empty, cfg.Rotation.Policy must be one of the four
+// supported policies. Passing nil clears the resolver — the listener
+// then falls back to its static per-listener URL (USK-826) or the
+// process-global / boot-time slot.
+//
+// The Manager stores the template + policy for status reporting AND
+// hands a fresh RotationResolver to the bound BuildConfig so the live
+// dial path consults it inside EffectiveUpstreamProxyForCtxErr. An
+// empty name is treated as DefaultListenerName.
+//
+// configure_tool dynamic tuning: re-calling this method with a fresh
+// cfg replaces the resolver entirely so per-conn / per-host / sticky
+// caches are dropped on the same call. In-flight connections keep the
+// URL they already captured (the previous resolver still exists in
+// goroutine-local state until GC).
+//
+// Returns an error when cfg is malformed (template fails probe
+// expansion, policy not recognised). Callers must ensure the listener
+// is running before invoking (the MCP layer enforces this).
+func (m *Manager) SetUpstreamProxyRotationForListener(name string, cfg *connector.RotationConfig) error {
+	if name == "" {
+		name = DefaultListenerName
+	}
+	m.mu.Lock()
+	if cfg == nil {
+		delete(m.upstreamProxyRotationPerListener, name)
+		bc := m.buildCfg
+		m.mu.Unlock()
+		if bc != nil {
+			bc.SetRotationForListener(name, nil)
+		}
+		return nil
+	}
+	// Defensive policy validation (the MCP layer already validated, but
+	// programmatic callers may bypass).
+	if !cfg.Policy.IsValid() {
+		m.mu.Unlock()
+		return fmt.Errorf("rotation policy %q is not supported", cfg.Policy)
+	}
+	if cfg.Template == "" {
+		m.mu.Unlock()
+		return fmt.Errorf("rotation template is empty")
+	}
+	// Record for status surfaces.
+	if m.upstreamProxyRotationPerListener == nil {
+		m.upstreamProxyRotationPerListener = make(map[string]*upstreamProxyRotationEntry)
+	}
+	m.upstreamProxyRotationPerListener[name] = &upstreamProxyRotationEntry{
+		Template: cfg.Template,
+		Policy:   string(cfg.Policy),
+	}
+	// When rotation is active, the legacy literal slot must be empty —
+	// they are mutually exclusive at the wire level.
+	delete(m.upstreamProxyPerListener, name)
+	if name == DefaultListenerName {
+		m.upstreamProxy = ""
+	}
+	bc := m.buildCfg
+	m.mu.Unlock()
+
+	if bc == nil {
+		return nil
+	}
+	// Clear any literal per-listener URL so the resolver path is the
+	// only one consulted for this listener.
+	bc.SetUpstreamProxyForListener(name, nil)
+	resolver := connector.NewRotationResolver(*cfg, 0, 0)
+	bc.SetRotationForListener(name, resolver)
+	return nil
+}
+
+// UpstreamProxyRotationForListener returns the operator-supplied
+// template and policy for the named listener (USK-959), or empty
+// strings when no rotation is configured. An empty name is treated as
+// DefaultListenerName.
+func (m *Manager) UpstreamProxyRotationForListener(name string) (template, policy string) {
+	if name == "" {
+		name = DefaultListenerName
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if rot := m.upstreamProxyRotationPerListener[name]; rot != nil {
+		return rot.Template, rot.Policy
+	}
+	return "", ""
 }
 
 // UpstreamProxy returns the stored upstream proxy URL for the default

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"sync"
 	"time"
 
@@ -584,9 +585,23 @@ func (m *Manager) SetUpstreamProxyForListener(name, proxyURL string) {
 	if name == "" {
 		name = DefaultListenerName
 	}
+	// Parse outside the lock so a malformed URL does not deadlock under
+	// m.mu — the result is consumed inside the critical section below.
+	var parsed *url.URL
+	var parseErr error
+	if proxyURL != "" {
+		parsed, parseErr = connector.ParseUpstreamProxy(proxyURL)
+	}
+
 	m.mu.Lock()
 	if proxyURL == "" {
 		delete(m.upstreamProxyPerListener, name)
+		// USK-959 (F-4): an empty proxyURL means "no upstream proxy of
+		// any flavour for this listener" — clear the rotation slot too
+		// so the setter is symmetric with the non-empty branch (which
+		// already clears rotation). Without this, calling the setter
+		// with "" would leave an orphan resolver active.
+		delete(m.upstreamProxyRotationPerListener, name)
 	} else {
 		if m.upstreamProxyPerListener == nil {
 			m.upstreamProxyPerListener = make(map[string]string)
@@ -604,27 +619,37 @@ func (m *Manager) SetUpstreamProxyForListener(name, proxyURL string) {
 		m.upstreamProxy = proxyURL
 	}
 	bc := m.buildCfg
+	// USK-959 (S-2 / CWE-362): perform BuildConfig writes under m.mu so
+	// the manager-status mutations above and the BuildConfig mutations
+	// below form one atomic critical section. Without this, two
+	// configure_tool calls racing on the same listener could observe
+	// (status says rotation X, bc has rotation Y) for a brief window.
+	// Lock ordering is m.mu → bc.upstreamProxyPerListenerMu /
+	// bc.rotationByListenerMu; no reader of those bc muxes acquires
+	// m.mu, so this is safe.
+	if bc != nil {
+		if proxyURL == "" {
+			bc.SetUpstreamProxyForListener(name, nil)
+			bc.SetRotationForListener(name, nil)
+		} else {
+			// Clear any stale rotation first so the new literal URL is
+			// the only thing the dial path consults.
+			bc.SetRotationForListener(name, nil)
+			if parseErr == nil {
+				bc.SetUpstreamProxyForListener(name, parsed)
+			}
+		}
+	}
 	m.mu.Unlock()
-	if bc != nil && proxyURL != "" {
-		// Also clear the resolver in BuildConfig so the new literal URL
-		// is consulted instead of any stale resolver.
-		bc.SetRotationForListener(name, nil)
-	}
 
-	if bc == nil {
-		return
-	}
-	if proxyURL == "" {
-		bc.SetUpstreamProxyForListener(name, nil)
-		return
-	}
-	parsed, err := connector.ParseUpstreamProxy(proxyURL)
-	if err != nil {
+	// Logging happens after releasing m.mu so a slow log sink cannot
+	// stall other manager callers. parseErr captures the malformed-URL
+	// case where status was still updated but the live dial path stays
+	// on the previous URL (the per-listener slot is not overwritten).
+	if proxyURL != "" && parseErr != nil {
 		m.logger.Warn("upstream proxy URL not applied to live dial path",
-			"listener", name, "url", connector.RedactProxyURL(proxyURL), "error", err)
-		return
+			"listener", name, "url", connector.RedactProxyURL(proxyURL), "error", parseErr)
 	}
-	bc.SetUpstreamProxyForListener(name, parsed)
 }
 
 // ClearUpstreamProxyForListener removes the named listener's per-listener

--- a/internal/proxybuild/tcp_forward_tls.go
+++ b/internal/proxybuild/tcp_forward_tls.go
@@ -465,8 +465,19 @@ func dialForwardUpstream(
 	dialOpts := connector.DialRawOpts{
 		DialTimeout: tcpForwardDialTimeout,
 	}
+	// USK-959: stamp the dial target on ctx so the per_target_host
+	// rotation policy can scope state by upstream host.
+	ctx = connector.ContextWithDialTarget(ctx, entry.target)
 	if parentStack != nil && parentStack.BuildConfig != nil {
-		dialOpts.UpstreamProxy = parentStack.BuildConfig.EffectiveUpstreamProxyForCtx(ctx)
+		u, perr := parentStack.BuildConfig.EffectiveUpstreamProxyForCtxErr(ctx)
+		if perr != nil {
+			// USK-959: fail-closed on rotation resolver error. TCP-
+			// forward TLS callers treat this as an upstream dial
+			// failure and surface a "stack build" / "upstream_tls_error"
+			// failure reason via their recorder.
+			return nil, nil, fmt.Errorf("upstream proxy rotation: %w", perr)
+		}
+		dialOpts.UpstreamProxy = u
 	}
 
 	// entry is non-nil by construction — both callers


### PR DESCRIPTION
## Summary

- Brings per-iteration upstream-proxy rotation (USK-954's MCP control-plane surface) to the **live MITM data path**. Each listener can now carry a `url_template + rotation policy`; every outbound dial expands the template against a fresh `§__nonce§` so the upstream observes a rotating client IP.
- Four policies: `per_request` (per outbound TCP dial — h2 is connection-level by construction), `per_connection` (cached by inbound ConnID, released on stack Close), `per_target_host` (LRU 10000 hosts / 1h TTL), `sticky` (one URL per listener lifetime, cleared on reload).
- Polymorphic `upstream_proxy` config: accepts either a literal URL string (legacy USK-826 shape, semantics unchanged) or an object `{url|url_template, rotation:{policy}}`. Polymorphism on the same JSON key via custom `UnmarshalJSON`.
- Fail-closed at dial on malformed templates (no direct-dial bypass — privacy regression class). Stage 1 (probe-expand at `configure_tool` / `proxy_start_tool`) → MCP error. Stage 2 (each live dial) → `slog.Warn` + 502 / REFUSED_STREAM / conn-close.
- `configure_tool` is wired for dynamic tuning: re-applying a rotation drops per-conn / per-host / sticky caches; in-flight conns retain the URL they captured.

## Design decisions (Phase 1.5 — binding)

- **Resolver placement**: per-listener `RotationResolver` slot on `BuildConfig`; consulted *inside* `EffectiveUpstreamProxyForCtxErr` so all 8 dial-path call sites pick it up without per-site edits.
- **Lift**: `UpstreamProxyConfig` + `ResolveForIteration` lifted from `internal/mcp/` → `internal/connector/upstream_proxy_rotation.go`; MCP package keeps a thin `type alias` so the wire schema is unchanged.
- **per_request × h2**: rotates per OUTBOUND TCP DIAL (not per stream — h2 multiplexes on a single dialled conn). Documented in `RotationPolicy` godoc.
- **H2 pool invalidation**: already correct via `poolKeyForH2` URL hash — per_request mints fresh URLs → fresh pool keys → no reuse. No explicit eviction code.
- **`§__iteration§` on live path**: NOT exposed. KV contains only `§__nonce§`.
- **Fail-closed (3 stages)**: probe-expand at config-apply (Stage 1) + per-dial fail-closed (Stage 2). NO direct-dial fallback.
- **Config polymorphism**: string-or-object via custom `UnmarshalJSON` (sibling: `unmarshalTCPForwards`).
- **Manager API**: new `Manager.SetUpstreamProxyRotationForListener(name, *RotationConfig)`. `SetUpstreamProxyForListener(name, string)` unchanged. The two slots are mutually exclusive at write time.
- **Status surface**: `ListenerStatus` gains `UpstreamProxyTemplate` (redacted) + `UpstreamProxyRotationPolicy`. `RedactProxyURL` extended with a lexical fallback so userinfo-bearing templates with `§` chars also redact (the section sign breaks `url.Parse`).

## Files

**New (8)**: `internal/connector/upstream_proxy_rotation.go` · `internal/connector/rotation_host_cache.go` · `internal/connector/upstream_proxy_rotation_test.go` · `internal/connector/upstream_proxy_rotation_integration_test.go` · `internal/config/upstream_proxy.go` · `internal/config/upstream_proxy_test.go` · `internal/mcp/upstream_proxy_input.go` · `internal/mcp/upstream_proxy_input_test.go`

**Modified (16)**: connector stack_builder / context / connection_stack / h2_pool / connect_handler / connect_inner_dispatch / http1_forward_handler / socks5_handler / upstream_proxy · mcp configure_tool / proxy_start_tool / components / upstream_proxy_rotation · config/config.go · proxybuild/manager.go · proxybuild/tcp_forward_tls.go

## Test plan

- [x] Unit: `TestRotationResolver_*` (8 cases — per-policy semantics + nil-receiver + malformed template + fast path)
- [x] Unit: `TestBuildConfigEffectiveUpstreamProxyForCtxErr_*` (resolver vs ctx-override priority)
- [x] Unit: `TestBuildConfigReleaseConnectionState_DropsPerConn` (per-conn cleanup propagation)
- [x] Unit: `TestRotationH2PoolKeyInvalidation_*` (per_request → distinct keys; sticky → stable key)
- [x] Unit: `TestRedactProxyURL_OnTemplate` (lexical-fallback redaction for `§`-bearing templates)
- [x] Unit: config polymorphic UnmarshalJSON + Validate (`internal/config/upstream_proxy_test.go`)
- [x] Unit: MCP polymorphic input + Stage 1 probe (`internal/mcp/upstream_proxy_input_test.go`)
- [x] e2e (`e2e && !e2e_smoke`):
  - `TestLiveProxy_PerRequestRotation_DistinctNonces` — 3 requests, 3 distinct nonces
  - `TestLiveProxy_PerTargetHostRotation_SamePerHost` — same target same nonce, different targets distinct
  - `TestLiveProxy_StickyRotation_FixedForListenerLifetime` — stable across requests, fresh after reload
  - `TestLiveProxy_MalformedTemplate_FailClosed` — upstream sees zero traffic (no direct-dial bypass)
  - `TestLiveProxy_MultiListenerChain_NoRecursion` — USK-826 regression class extended to rotation
  - `TestLiveProxy_NoDelimiterTemplate_FastPath` — non-rotating template still works
  - `TestLiveProxy_PerConnectionRotation_DistinctAcrossClients`
- [x] `make build` ✓
- [x] `make test-fast` ✓
- [x] `make test-e2e-smoke` ✓
- [x] `make lint` (gofmt + vet + staticcheck + ineffassign + gocyclo) ✓

## Notes for reviewers

- Signature migration: `EffectiveUpstreamProxyForCtx` is preserved (returns nil on resolver error — caller is the legacy 8 dial-path read; in practice unreachable now). The new `EffectiveUpstreamProxyForCtxErr` is the canonical API for the migrated dial paths; all 8 live-path callers were moved over and fail closed.
- `ConnectionStack.SetBuildConfig` is the cleanup wiring point — called from `runTLSMITM` after a successful `BuildConnectionStack` so `Stack.Close()` can call `BuildConfig.ReleaseConnectionState(connID)` and drop per-conn rotation entries.
- `ContextWithDialTarget` is the new ctx key for "the target host we're about to dial". Stamped in `BuildConnectionStack`, plain-HTTP forward handler, CONNECT/SOCKS5 passthrough, and TCP-forward TLS dial. Read by `EffectiveUpstreamProxyForCtxErr` only when a rotation resolver is installed.
- `RedactProxyURL` now has a lexical-fallback branch for URLs that don't parse (template with `§` chars). Tested in `TestRedactProxyURL_OnTemplate`.
- `per_target_host` uses the full `host:port` string (not just host) as the cache key so distinct services on the same host get distinct rotation slots.

Resolves USK-959

Linear: https://linear.app/usk6666/issue/USK-959

🤖 Generated with [Claude Code](https://claude.com/claude-code)