### PR TITLE
fix(webui/FlowDetail): propagate body_truncated and filter pseudo-only headers

### DIFF
--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -1104,11 +1104,17 @@ type queryDecodeAnomaly struct {
 
 // queryVariantRequest represents the original request before intercept/transform modification.
 type queryVariantRequest struct {
-	Method              string              `json:"method"`
-	URL                 string              `json:"url"`
-	Headers             map[string][]string `json:"headers"`
-	Body                string              `json:"body"`
-	BodyEncoding        string              `json:"body_encoding"`
+	Method       string              `json:"method"`
+	URL          string              `json:"url"`
+	Headers      map[string][]string `json:"headers"`
+	Body         string              `json:"body"`
+	BodyEncoding string              `json:"body_encoding"`
+	// BodyTruncated mirrors Flow.BodyTruncated for the original send message —
+	// set at record time when the pipeline RecordStep cap fired. Symmetric with
+	// queryVariantResponse.BodyTruncated so the UI can render the modified-vs-
+	// original diff without dropping the request-side truncation signal
+	// (USK-965).
+	BodyTruncated       bool                `json:"body_truncated"`
 	BodyDecoded         string              `json:"body_decoded,omitempty"`
 	BodyDecodedEncoding string              `json:"body_decoded_encoding,omitempty"`
 	BodyEncodingApplied string              `json:"body_encoding_applied,omitempty"`
@@ -1504,9 +1510,10 @@ func (s *Server) buildOriginalRequest(originalMsg *flow.Flow, decodeEnabled bool
 		origURLStr = originalMsg.URL.String()
 	}
 	v := &queryVariantRequest{
-		Method:  originalMsg.Method,
-		URL:     origURLStr,
-		Headers: originalMsg.Headers,
+		Method:        originalMsg.Method,
+		URL:           origURLStr,
+		Headers:       originalMsg.Headers,
+		BodyTruncated: originalMsg.BodyTruncated,
 	}
 	if !limit.includeBodies {
 		// Bodies suppressed; leave Body / BodyEncoding / Body*Decoded zero.

--- a/internal/mcp/query_tool_test.go
+++ b/internal/mcp/query_tool_test.go
@@ -1896,6 +1896,85 @@ func TestQuery_Session_VariantMessages(t *testing.T) {
 	}
 }
 
+// TestQuery_Session_VariantOriginalRequest_BodyTruncated confirms that
+// Flow.BodyTruncated on the original send message is propagated onto
+// queryVariantRequest.BodyTruncated in the flow detail response. Symmetric
+// with the existing queryVariantResponse.BodyTruncated coverage (USK-965).
+func TestQuery_Session_VariantOriginalRequest_BodyTruncated(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+
+	ctx := context.Background()
+	id := "variant-trunc-sess"
+
+	sess := &flow.Stream{
+		ID:        id,
+		ConnID:    "conn-" + id,
+		Protocol:  "HTTPS",
+		State:     "complete",
+		Timestamp: time.Now().UTC(),
+		Duration:  200 * time.Millisecond,
+	}
+	if err := store.SaveStream(ctx, sess); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+
+	origURL, _ := url.Parse("https://example.com/original")
+	originalSend := &flow.Flow{
+		ID:            id + "-send-orig",
+		StreamID:      id,
+		Sequence:      0,
+		Direction:     "send",
+		Timestamp:     time.Now().UTC(),
+		Method:        "POST",
+		URL:           origURL,
+		Headers:       map[string][]string{"Host": {"example.com"}},
+		Body:          []byte("original truncated body"),
+		BodyTruncated: true,
+		Metadata:      map[string]string{"variant": "original"},
+	}
+	if err := store.SaveFlow(ctx, originalSend); err != nil {
+		t.Fatalf("SaveFlow(original): %v", err)
+	}
+
+	modURL, _ := url.Parse("https://example.com/modified")
+	modifiedSend := &flow.Flow{
+		ID:        id + "-send-mod",
+		StreamID:  id,
+		Sequence:  1,
+		Direction: "send",
+		Timestamp: time.Now().UTC(),
+		Method:    "POST",
+		URL:       modURL,
+		Headers:   map[string][]string{"Host": {"example.com"}},
+		Body:      []byte("modified body"),
+		Metadata:  map[string]string{"variant": "modified"},
+	}
+	if err := store.SaveFlow(ctx, modifiedSend); err != nil {
+		t.Fatalf("SaveFlow(modified): %v", err)
+	}
+
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{
+		Resource: "flow",
+		ID:       id,
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	var out queryFlowResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.OriginalRequest == nil {
+		t.Fatal("original_request is nil, expected original variant data")
+	}
+	if !out.OriginalRequest.BodyTruncated {
+		t.Errorf("original_request.body_truncated = false, want true (mirrors Flow.BodyTruncated on the original send message)")
+	}
+}
+
 func TestQuery_Session_NoVariantMessages(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)

--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -370,6 +370,22 @@ export interface MessageEntry {
   body_encoding_applied?: string;
   /** Anomaly detail when decode was attempted but rejected or failed. */
   body_decode_anomaly?: DecodeAnomaly;
+  /**
+   * Record-time truncation flag: set when the pipeline RecordStep `MaxBodySize`
+   * cap fired at storage time. Mirrors `Flow.BodyTruncated` on the backend and
+   * is independent of any response-time query cap.
+   */
+  body_truncated?: boolean;
+  /**
+   * Response-time truncation flag: set when the MCP query `include_bodies` /
+   * `body_max_bytes` params suppressed or capped the body bytes returned to
+   * the caller. Distinct from `body_truncated`.
+   */
+  body_truncated_by_query?: boolean;
+  /** Pre-truncation wire-form byte length when body_truncated_by_query=true. */
+  body_original_size?: number;
+  /** Pre-truncation decoded-form byte length when body_truncated_by_query=true. */
+  body_decoded_original_size?: number;
   metadata?: Record<string, string>;
   timestamp: string;
 }
@@ -381,6 +397,12 @@ export interface VariantRequest {
   headers: Record<string, string[]>;
   body: string;
   body_encoding: string;
+  /**
+   * Record-time truncation flag for the original request body. Mirrors
+   * `Flow.BodyTruncated` on the backend. Optional because older recordings
+   * (pre-USK-965) may have omitted the field; render as `false` when missing.
+   */
+  body_truncated?: boolean;
   /** Body after Content-Encoding decode (USK-731). Empty when no codec applied. */
   body_decoded?: string;
   /** "text" | "base64" — transport encoding of body_decoded. */

--- a/web/src/pages/FlowDetail/FlowDetailHTTPMessage.tsx
+++ b/web/src/pages/FlowDetail/FlowDetailHTTPMessage.tsx
@@ -150,7 +150,7 @@ export function FlowDetailHTTPMessage({ flow }: FlowDetailHTTPMessageProps) {
                     key={`${flow.id}-original-request`}
                     body={flow.original_request.body}
                     encoding={flow.original_request.body_encoding}
-                    truncated={false}
+                    truncated={flow.original_request.body_truncated ?? false}
                     headers={flow.original_request.headers}
                     bodyDecoded={flow.original_request.body_decoded}
                     bodyDecodedEncoding={flow.original_request.body_decoded_encoding}

--- a/web/src/pages/FlowDetail/Http2Info.test.ts
+++ b/web/src/pages/FlowDetail/Http2Info.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { filterRegularHeaders, isPseudoHeader } from "./Http2Info.js";
+
+// ---------------------------------------------------------------------------
+// isPseudoHeader — case-insensitive pseudo-header detection
+// ---------------------------------------------------------------------------
+
+describe("isPseudoHeader", () => {
+  it("matches HTTP/2 request pseudo-header names", () => {
+    expect(isPseudoHeader(":method")).toBe(true);
+    expect(isPseudoHeader(":path")).toBe(true);
+    expect(isPseudoHeader(":authority")).toBe(true);
+    expect(isPseudoHeader(":scheme")).toBe(true);
+  });
+
+  it("matches HTTP/2 response pseudo-header names", () => {
+    expect(isPseudoHeader(":status")).toBe(true);
+  });
+
+  it("is case-insensitive (defensive against mixed-case wire input)", () => {
+    expect(isPseudoHeader(":METHOD")).toBe(true);
+    expect(isPseudoHeader(":Status")).toBe(true);
+  });
+
+  it("returns false for regular headers and non-h2 names", () => {
+    expect(isPseudoHeader("content-type")).toBe(false);
+    expect(isPseudoHeader("host")).toBe(false);
+    expect(isPseudoHeader(":unknown")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterRegularHeaders — Headers-tab projection for HTTP/2 (USK-965)
+// ---------------------------------------------------------------------------
+
+describe("filterRegularHeaders", () => {
+  it("passes null through unchanged", () => {
+    expect(filterRegularHeaders(null)).toBeNull();
+  });
+
+  it("strips pseudo-headers, keeping regular headers", () => {
+    const headers: Record<string, string[]> = {
+      ":method": ["GET"],
+      ":path": ["/api"],
+      "content-type": ["application/json"],
+      "x-custom": ["v1", "v2"],
+    };
+    const result = filterRegularHeaders(headers);
+    expect(result).toEqual({
+      "content-type": ["application/json"],
+      "x-custom": ["v1", "v2"],
+    });
+  });
+
+  it("returns an empty object when input contains only pseudo-headers (USK-965)", () => {
+    // Regression: HEAD-style response with just :status used to fall back to
+    // returning the unfiltered input, leaking :status into the Headers tab.
+    // The fix guarantees an empty map so HeadersTable shows the "no headers"
+    // state and Http2PseudoHeaders is the sole place that renders :status.
+    const headers: Record<string, string[]> = {
+      ":status": ["204"],
+    };
+    const result = filterRegularHeaders(headers);
+    expect(result).toEqual({});
+    expect(result).not.toEqual(headers);
+  });
+
+  it("returns an empty object for an empty input map", () => {
+    expect(filterRegularHeaders({})).toEqual({});
+  });
+});

--- a/web/src/pages/FlowDetail/Http2Info.tsx
+++ b/web/src/pages/FlowDetail/Http2Info.tsx
@@ -97,21 +97,25 @@ function extractPseudoHeaders(
   return result;
 }
 
-/** Filter out pseudo-headers from a header map, returning only regular headers. */
+/** Filter out pseudo-headers from a header map, returning only regular headers.
+ *
+ * If the input contains only pseudo-headers (e.g. HEAD response with just
+ * `:status`), the result is an empty object — NOT the unfiltered input. The
+ * pseudo-headers are rendered by `Http2PseudoHeaders`, so leaking them back
+ * into the regular Headers tab would double-display them. (USK-965)
+ */
 export function filterRegularHeaders(
   headers: Record<string, string[]> | null,
 ): Record<string, string[]> | null {
   if (!headers) return headers;
 
   const filtered: Record<string, string[]> = {};
-  let hasRegular = false;
   for (const [key, values] of Object.entries(headers)) {
     if (!isPseudoHeader(key)) {
       filtered[key] = values;
-      hasRegular = true;
     }
   }
-  return hasRegular ? filtered : headers;
+  return filtered;
 }
 
 /** Group messages by stream ID. Returns null if no stream_id metadata exists. */

--- a/web/src/pages/FlowDetail/MessageList.tsx
+++ b/web/src/pages/FlowDetail/MessageList.tsx
@@ -238,7 +238,10 @@ export function MessageList({
               key={expandedMessage.id}
               body={expandedMessage.body}
               encoding={expandedMessage.body_encoding}
-              truncated={false}
+              truncated={
+                (expandedMessage.body_truncated ?? false) ||
+                (expandedMessage.body_truncated_by_query ?? false)
+              }
               headers={expandedMessage.headers}
               bodyDecoded={expandedMessage.body_decoded}
               bodyDecodedEncoding={expandedMessage.body_decoded_encoding}


### PR DESCRIPTION
## Summary
- `filterRegularHeaders` returns the filtered map (which may be `{}`) instead of the unfiltered input when every header is a pseudo-header — prevents `:method` / `:status` from leaking into the Headers tab on HEAD-style responses where there are no regular headers to display.
- `MessageList` and `FlowDetailHTTPMessage` now propagate `body_truncated` / `body_truncated_by_query` from `MessageEntry` and `body_truncated` from the `original_request` variant instead of hardcoding `truncated={false}`.
- `MessageEntry` TS type gains the four query-side truncation fields the backend has been emitting (`body_truncated`, `body_truncated_by_query`, `body_original_size`, `body_decoded_original_size`).
- `VariantRequest` TS type gains an optional `body_truncated?: boolean` symmetric with `VariantResponse`.
- Backend `queryVariantRequest` gains `BodyTruncated`, populated in `buildOriginalRequest` from `Flow.BodyTruncated` on the original send message (same source `queryVariantResponse.BodyTruncated` already uses) — symmetric addition, no architectural reason to omit it on the request side. Confirmed with a new unit test (`TestQuery_Session_VariantOriginalRequest_BodyTruncated`).

### Backend symmetry decision
The original request truncation signal was simply missing from `queryVariantRequest` — `Flow.BodyTruncated` is already populated on every flow row regardless of direction, and `buildOriginalRequest` already reads from `originalMsg.*` for every other field. Adding `BodyTruncated` is a one-line symmetric fix with no storage / schema impact.

## Test plan
- [x] `TestQuery_Session_VariantOriginalRequest_BodyTruncated` confirms `Flow.BodyTruncated=true` on the original send message round-trips through `OriginalRequest.BodyTruncated` in the flow detail JSON.
- [x] HEAD-style response (pseudo-only headers) renders empty Headers tab — `filterRegularHeaders` now returns `{}` and `HeadersTable` shows the "no headers" state for empty maps. Verified by reading the component dispatch in `Http2Info.tsx` + `HeadersTable.tsx`.
- [x] `body_truncated_by_query=true` MessageEntry shows the truncation badge — `MessageList.tsx:241` now OR-combines both truncation flags into the `truncated` bool passed to `BodyViewer`.
- [x] Variant original-request body truncation renders correctly — `FlowDetailHTTPMessage.tsx:153` reads `flow.original_request.body_truncated ?? false`, which is now backed by the new `OriginalRequest.BodyTruncated` field on the wire.
- [x] `make lint` passes (gofmt + vet + staticcheck + ineffassign — clean).
- [x] WebUI `pnpm build` passes (TypeScript compile clean, no `// @ts-ignore` added).
- [x] WebUI `pnpm test --run` passes (235/235).
- [x] `go test ./internal/mcp/` passes (full mcp suite, including the new test).

Note: `make test` with `-race -timeout 4m` was observed to time out on the `internal/mcp` package on this worktree machine (`-race` brings the suite to ~466s here). The same timeout reproduces on `main` without this PR's changes — pre-existing environment-specific flake, not introduced by this PR. CI parallelism is faster than the local box.

Resolves USK-965
Linear: https://linear.app/usk6666/issue/USK-965

🤖 Generated with [Claude Code](https://claude.com/claude-code)