### PR TITLE
fix(webui/mcp): harden callTool fallback and export missing hooks

### DIFF
--- a/web/src/lib/mcp/client.test.ts
+++ b/web/src/lib/mcp/client.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for McpClient.callTool's content-block parsing contract (USK-966).
+ *
+ * yorishiro-proxy's MCP tools return a single JSON-text ContentBlock. If the
+ * server returns no content, an empty content array, or a non-text first
+ * block, that is a contract violation. callTool MUST throw an explicit error
+ * with the tool name — the previous behaviour silently cast the raw
+ * `ToolResult` to `T`, which propagated to callers and triggered
+ * `JSON.parse("")` crashes or property-undefined surprises downstream.
+ */
+
+import { describe, expect, it } from "vitest";
+import { McpClient } from "./client.js";
+
+/**
+ * Build an McpClient and inject a fake underlying MCP SDK client that
+ * returns the supplied `ToolResult` payload from `callTool`. Bypasses the
+ * real transport / handshake — we only exercise the result-parsing path.
+ */
+function clientReturning(result: unknown): McpClient {
+  const c = new McpClient({ url: "/mcp" });
+  // Cast to a record so we can poke at the private fields exercised by
+  // callTool's guard. `callTool` only checks `this.client` truthiness and
+  // `this._status === "connected"`; nothing else from the SDK is touched in
+  // the parsing path.
+  const internal = c as unknown as {
+    client: { callTool: (req: unknown) => Promise<unknown> } | null;
+    _status: string;
+  };
+  internal.client = {
+    callTool: async () => result,
+  };
+  internal._status = "connected";
+  return c;
+}
+
+describe("McpClient.callTool", () => {
+  it("parses a single JSON-text content block", async () => {
+    const c = clientReturning({
+      content: [{ type: "text", text: JSON.stringify({ ok: true }) }],
+    });
+    const out = await c.callTool<{ ok: boolean }>("some_tool", {});
+    expect(out).toEqual({ ok: true });
+  });
+
+  it("throws when content array is missing", async () => {
+    const c = clientReturning({});
+    await expect(c.callTool("some_tool", {})).rejects.toThrow(
+      "MCP tool 'some_tool' returned no parseable content",
+    );
+  });
+
+  it("throws when content array is empty", async () => {
+    const c = clientReturning({ content: [] });
+    await expect(c.callTool("some_tool", {})).rejects.toThrow(
+      "MCP tool 'some_tool' returned no parseable content",
+    );
+  });
+
+  it("throws when first content block is not a text block", async () => {
+    const c = clientReturning({
+      content: [{ type: "image", data: "...", mimeType: "image/png" }],
+    });
+    await expect(c.callTool("some_tool", {})).rejects.toThrow(
+      "MCP tool 'some_tool' returned no parseable content",
+    );
+  });
+
+  it("propagates isError content text as the error message", async () => {
+    const c = clientReturning({
+      isError: true,
+      content: [{ type: "text", text: "tool blew up" }],
+    });
+    await expect(c.callTool("some_tool", {})).rejects.toThrow("tool blew up");
+  });
+});

--- a/web/src/lib/mcp/client.ts
+++ b/web/src/lib/mcp/client.ts
@@ -217,6 +217,14 @@ export class McpClient {
     }
 
     // Parse the structured result from the content.
+    //
+    // yorishiro-proxy's MCP tools return a single JSON-text ContentBlock as
+    // their contract. If the content array is missing, empty, or its first
+    // block is not a text block, that is a contract violation by the server
+    // — surface it as an explicit error instead of silently casting the raw
+    // ToolResult to `T`, which used to propagate to callers and trigger
+    // downstream `JSON.parse("")` crashes or property-undefined surprises
+    // (USK-966).
     if (
       result.content &&
       Array.isArray(result.content) &&
@@ -228,7 +236,9 @@ export class McpClient {
       }
     }
 
-    return result as unknown as T;
+    throw new Error(
+      `MCP tool '${name}' returned no parseable content`,
+    );
   }
 
   // -----------------------------------------------------------------------

--- a/web/src/lib/mcp/index.ts
+++ b/web/src/lib/mcp/index.ts
@@ -31,10 +31,10 @@ export type { McpContextValue, McpProviderProps } from "./context.js";
 
 // Hooks
 export {
-  useConfigure, useInterceptAction, useMacro, useManage, useMcpClient, useProxyControl, useQuery, useSecurity
+  useConfigure, useGrpcSchema, useGrpcSchemaList, useInterceptAction, useMacro, useManage, useMcpClient, usePluginIntrospect, useProxyControl, useQuery, useSecurity
 } from "./hooks.js";
 export type {
-  UseConfigureResult, UseInterceptActionResult, UseMacroResult, UseManageResult, UseMcpClientResult, UseProxyControlResult, UseQueryOptions,
+  UseConfigureResult, UseGrpcSchemaListResult, UseGrpcSchemaResult, UseInterceptActionResult, UseMacroResult, UseManageResult, UseMcpClientResult, UsePluginIntrospectResult, UseProxyControlResult, UseQueryOptions,
   UseQueryResult, UseSecurityResult
 } from "./hooks.js";
 


### PR DESCRIPTION
## Summary
- `callTool()` now throws a descriptive Error (`"MCP tool '<name>' returned no parseable content"`) when the MCP server returns empty or non-text content, instead of silently casting the raw `ToolResult` to `T` and triggering downstream `JSON.parse` crashes or property-undefined surprises.
- `index.ts` re-exports `usePluginIntrospect`, `useGrpcSchema`, `useGrpcSchemaList` and their `Use*Result` types so `import { ... } from "@/lib/mcp"` resolves them correctly (they were exported from `hooks.ts` but never re-exported from the barrel).
- Added `web/src/lib/mcp/client.test.ts` covering the parse path: valid JSON-text block, missing/empty content, non-text first block, and `isError` propagation.

## Why throw instead of `Promise<T | null>`
Every existing caller of `callTool<T>` (all inside `client.ts`'s typed wrappers) treats the return value as the typed result and immediately accesses fields. Switching to `Promise<T | null>` would force every hook and React-Query caller to handle `null` everywhere. An empty/non-text content response from yorishiro-proxy's own MCP server is a contract violation — throwing is the right signal, and React Query's `useQuery` surfaces it via `error` natively.

## Test plan
- [x] `make test-ui` — 12 files / 240 tests pass (includes the 5 new `callTool` cases)
- [x] `make build` — TypeScript compiles clean; vite + go build succeed
- [x] `make lint` — gofmt / vet / staticcheck / ineffassign / gocyclo all clean
- [x] `go test ./internal/mcp/` — passes (initial `make test` flaked on a 4m sqlite timeout; rerun with 8m timeout passes — unrelated to this WebUI change)
- [x] Grep confirms no caller of `callTool` outside `client.ts` relied on the previous silent-cast behavior

Resolves USK-966
Linear: https://linear.app/usk6666/issue/USK-966

🤖 Generated with [Claude Code](https://claude.com/claude-code)