### PR TITLE
fix(webui/Resend): populate WS fin from loaded flow and validate raw patch offset

### DIFF
--- a/web/src/pages/Resend/RawPatchEditor.css
+++ b/web/src/pages/Resend/RawPatchEditor.css
@@ -111,3 +111,14 @@
   color: var(--accent-danger);
   background-color: rgba(248, 81, 73, 0.1);
 }
+
+/* Inline validation error for the offset field (USK-967). */
+.raw-patch-editor-error {
+  font-size: var(--font-size-xs);
+  color: var(--accent-danger);
+  padding-left: var(--space-xs);
+}
+
+.raw-patch-editor-field[aria-invalid="true"] {
+  border-color: var(--accent-danger);
+}

--- a/web/src/pages/Resend/RawPatchEditor.test.ts
+++ b/web/src/pages/Resend/RawPatchEditor.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the RawPatchEditor offset validation helper (USK-967).
+ *
+ * The editor previously coerced any non-numeric / empty / negative
+ * offset to 0 via `parseInt(val, 10)` + `?? 0`, which writes the
+ * patch at a wholly different position than the user intended —
+ * exactly the byte-level fuzz failure mode this editor exists to
+ * support. The pure `validateRawPatchOffset` helper is the gate that
+ * surfaces invalid input as a typed error string for inline display
+ * and disables the parent's submit button via onValidityChange.
+ *
+ * The component itself is JSX-heavy; tests for it would pull in
+ * jsdom + RTL. Following the pattern of grpcweb-display.test.ts, we
+ * verify the pure helper here.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRawPatchOffset } from "./RawPatchEditor.js";
+
+describe("validateRawPatchOffset", () => {
+  describe("invalid inputs", () => {
+    it("rejects empty string", () => {
+      expect(validateRawPatchOffset("")).not.toBeNull();
+    });
+
+    it("rejects whitespace-only string", () => {
+      expect(validateRawPatchOffset("   ")).not.toBeNull();
+    });
+
+    it('rejects non-numeric "abc"', () => {
+      const err = validateRawPatchOffset("abc");
+      expect(err).not.toBeNull();
+      expect(err).toMatch(/number/);
+    });
+
+    it("rejects negative integer", () => {
+      const err = validateRawPatchOffset("-1");
+      expect(err).not.toBeNull();
+      expect(err).toMatch(/non-negative/);
+    });
+
+    it("rejects fractional value", () => {
+      const err = validateRawPatchOffset("1.5");
+      expect(err).not.toBeNull();
+      expect(err).toMatch(/integer/);
+    });
+
+    it("rejects mixed input (1000abc)", () => {
+      // Number("1000abc") returns NaN; parseInt would have truncated to
+      // 1000 silently — verify the new validator rejects it cleanly.
+      expect(validateRawPatchOffset("1000abc")).not.toBeNull();
+    });
+
+    it("rejects Infinity", () => {
+      expect(validateRawPatchOffset("Infinity")).not.toBeNull();
+    });
+
+    it("rejects NaN literal", () => {
+      expect(validateRawPatchOffset("NaN")).not.toBeNull();
+    });
+  });
+
+  describe("valid inputs", () => {
+    it("accepts 0", () => {
+      expect(validateRawPatchOffset("0")).toBeNull();
+    });
+
+    it("accepts positive integer", () => {
+      expect(validateRawPatchOffset("42")).toBeNull();
+    });
+
+    it("accepts large integer", () => {
+      expect(validateRawPatchOffset("65536")).toBeNull();
+    });
+
+    it("accepts integer with surrounding whitespace", () => {
+      // Number() ignores leading/trailing whitespace; this mirrors what
+      // the editor sends after a user copy-paste with stray spaces.
+      expect(validateRawPatchOffset("  42  ")).toBeNull();
+    });
+  });
+});

--- a/web/src/pages/Resend/RawPatchEditor.tsx
+++ b/web/src/pages/Resend/RawPatchEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "../../components/ui/Button.js";
 import type { RawPatch } from "../../lib/mcp/types.js";
 import "./RawPatchEditor.css";
@@ -6,6 +6,34 @@ import "./RawPatchEditor.css";
 export interface RawPatchEditorProps {
   patches: RawPatch[];
   onChange: (patches: RawPatch[]) => void;
+  /**
+   * Called when the editor's validity changes. Validity is computed from
+   * the offset field of every `mode === "offset"` patch — non-numeric,
+   * empty, negative, or fractional offsets are invalid. Parent components
+   * use this to disable the submit button, preventing the prior silent
+   * NaN→0 coercion at submit time (USK-967).
+   */
+  onValidityChange?: (valid: boolean) => void;
+}
+
+/**
+ * Validate a raw offset string entry.
+ *
+ * Returns `null` when the input parses as a finite non-negative integer.
+ * Returns an error message otherwise. Empty strings, "abc", "-1", and
+ * "1.5" all surface as errors so the caller can render inline feedback
+ * and disable submit — silent coercion to 0 (the prior behaviour) would
+ * write the patch at a wholly different offset than the user intended,
+ * exactly the failure mode the byte-level fuzz workflow exists to avoid.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function validateRawPatchOffset(raw: string): string | null {
+  if (raw.trim() === "") return "offset is required";
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return "offset must be a number";
+  if (!Number.isInteger(parsed)) return "offset must be an integer";
+  if (parsed < 0) return "offset must be non-negative";
+  return null;
 }
 
 /** Patch mode for the editor entry. */
@@ -26,7 +54,44 @@ function detectMode(patch: RawPatch): PatchMode {
  * - Find/Replace (hex): find and replace by base64-encoded bytes
  * - Find/Replace (text): find and replace by plain text
  */
-export function RawPatchEditor({ patches, onChange }: RawPatchEditorProps) {
+export function RawPatchEditor({
+  patches,
+  onChange,
+  onValidityChange,
+}: RawPatchEditorProps) {
+  // Per-row raw offset input string (USK-967). Stored alongside the parsed
+  // patches so that an in-flight "abc" never silently coerces to 0 — the
+  // user's keystrokes are kept verbatim and the parent's submit gate
+  // observes the validation state.
+  const [offsetInputs, setOffsetInputs] = useState<Record<number, string>>({});
+
+  // Compute the per-row validation error for offset-mode patches. Other
+  // modes are unconditionally valid here (find/replace doesn't have the
+  // NaN→0 problem since the backend treats those fields as opaque strings).
+  const offsetErrors: Record<number, string | null> = {};
+  patches.forEach((patch, index) => {
+    const mode = detectMode(patch);
+    if (mode !== "offset") {
+      offsetErrors[index] = null;
+      return;
+    }
+    const raw = offsetInputs[index];
+    if (raw === undefined) {
+      // No edit yet — trust the parsed offset (typically 0 from "Add Patch").
+      offsetErrors[index] = patch.offset == null ? "offset is required" : null;
+      return;
+    }
+    offsetErrors[index] = validateRawPatchOffset(raw);
+  });
+
+  const isValid = Object.values(offsetErrors).every((e) => e == null);
+
+  // Notify parent of validity transitions so the submit button can be
+  // disabled while any offset row is invalid (USK-967).
+  useEffect(() => {
+    onValidityChange?.(isValid);
+  }, [isValid, onValidityChange]);
+
   const handleModeChange = useCallback(
     (index: number, mode: PatchMode) => {
       const updated = [...patches];
@@ -44,6 +109,33 @@ export function RawPatchEditor({ patches, onChange }: RawPatchEditorProps) {
       }
       updated[index] = blank;
       onChange(updated);
+      // Reset the per-row offset input string when leaving offset mode so
+      // a previously stored "abc" doesn't shadow a later switch back.
+      setOffsetInputs((prev) => {
+        const next = { ...prev };
+        delete next[index];
+        return next;
+      });
+    },
+    [patches, onChange],
+  );
+
+  const handleOffsetChange = useCallback(
+    (index: number, val: string) => {
+      setOffsetInputs((prev) => ({ ...prev, [index]: val }));
+      const updated = [...patches];
+      const patch = { ...updated[index] };
+      const err = validateRawPatchOffset(val);
+      if (err == null) {
+        patch.offset = Number(val);
+      } else {
+        // Mark the patch offset as null so the parent's submit-gate (which
+        // additionally disables when isValid is false) cannot accidentally
+        // see a stale numeric offset from a prior keystroke.
+        patch.offset = null;
+      }
+      updated[index] = patch;
+      onChange(updated);
     },
     [patches, onChange],
   );
@@ -52,12 +144,7 @@ export function RawPatchEditor({ patches, onChange }: RawPatchEditorProps) {
     (index: number, field: keyof RawPatch, val: string) => {
       const updated = [...patches];
       const patch = { ...updated[index] };
-      if (field === "offset") {
-        const num = parseInt(val, 10);
-        patch.offset = isNaN(num) ? null : num;
-      } else {
-        (patch as Record<string, unknown>)[field] = val || undefined;
-      }
+      (patch as Record<string, unknown>)[field] = val || undefined;
       updated[index] = patch;
       onChange(updated);
     },
@@ -72,6 +159,17 @@ export function RawPatchEditor({ patches, onChange }: RawPatchEditorProps) {
     (index: number) => {
       const updated = patches.filter((_, i) => i !== index);
       onChange(updated);
+      // Compact the offsetInputs keys so later entries don't inherit a
+      // stale validation state from a removed row.
+      setOffsetInputs((prev) => {
+        const next: Record<number, string> = {};
+        for (const [k, v] of Object.entries(prev)) {
+          const idx = Number(k);
+          if (idx < index) next[idx] = v;
+          else if (idx > index) next[idx - 1] = v;
+        }
+        return next;
+      });
     },
     [patches, onChange],
   );
@@ -110,24 +208,43 @@ export function RawPatchEditor({ patches, onChange }: RawPatchEditorProps) {
               </button>
             </div>
             {mode === "offset" && (
-              <div className="raw-patch-editor-row">
-                <input
-                  className="raw-patch-editor-field raw-patch-editor-field--offset"
-                  type="number"
-                  value={patch.offset ?? 0}
-                  onChange={(e) => handleFieldChange(index, "offset", e.target.value)}
-                  placeholder="Byte offset"
-                  title="Byte offset"
-                />
-                <input
-                  className="raw-patch-editor-field"
-                  type="text"
-                  value={patch.data_base64 ?? ""}
-                  onChange={(e) => handleFieldChange(index, "data_base64", e.target.value)}
-                  placeholder="Base64-encoded data"
-                  spellCheck={false}
-                />
-              </div>
+              <>
+                <div className="raw-patch-editor-row">
+                  <input
+                    className="raw-patch-editor-field raw-patch-editor-field--offset"
+                    type="text"
+                    inputMode="numeric"
+                    value={
+                      offsetInputs[index] !== undefined
+                        ? offsetInputs[index]
+                        : patch.offset != null
+                          ? String(patch.offset)
+                          : ""
+                    }
+                    onChange={(e) => handleOffsetChange(index, e.target.value)}
+                    placeholder="Byte offset"
+                    title="Byte offset (non-negative integer)"
+                    aria-invalid={offsetErrors[index] != null}
+                  />
+                  <input
+                    className="raw-patch-editor-field"
+                    type="text"
+                    value={patch.data_base64 ?? ""}
+                    onChange={(e) => handleFieldChange(index, "data_base64", e.target.value)}
+                    placeholder="Base64-encoded data"
+                    spellCheck={false}
+                  />
+                </div>
+                {offsetErrors[index] != null && (
+                  <div
+                    className="raw-patch-editor-error"
+                    role="alert"
+                    aria-label={`Offset error for patch ${index}`}
+                  >
+                    {offsetErrors[index]}
+                  </div>
+                )}
+              </>
             )}
             {mode === "find_replace_hex" && (
               <div className="raw-patch-editor-row">

--- a/web/src/pages/Resend/ResendPage.tsx
+++ b/web/src/pages/Resend/ResendPage.tsx
@@ -22,6 +22,7 @@ import type {
   ResendGRPCResult,
   ResendHTTPParams,
   ResendHTTPResult,
+  ResendRawBytePatch,
   ResendRawParams,
   ResendRawTypedResult,
   ResendWSResult,
@@ -262,6 +263,32 @@ function extractFlowPath(urlStr: string): string {
 }
 
 /**
+ * Extract the FIN bit from the first send-direction frame in a loaded
+ * WebSocket flow (USK-967).
+ *
+ * Frames are projected into `message_preview` with `metadata["ws_fin"]`
+ * (see `internal/pipeline/record_step.go:1231`). Returns `true` when the
+ * flow has no message_preview, no send-direction frame, or the metadata
+ * value is missing/unparseable — matching the historical default but
+ * preserving the wire-observed FIN=0 when one is recorded. Without this,
+ * a frame loaded with FIN=0 silently default-resends with FIN=1, which
+ * is a wire-faithfulness violation.
+ */
+function extractFlowFin(flow: FlowDetailResult): boolean {
+  const preview = flow.message_preview;
+  if (!preview || preview.length === 0) return true;
+  for (const msg of preview) {
+    if (msg.direction === "send") {
+      const raw = msg.metadata?.ws_fin;
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return true;
+    }
+  }
+  return true;
+}
+
+/**
  * Map a `Record<string, string[]>` headers map (the FlowDetailResult
  * wire shape) to the ordered `{key,value}` rows the HeaderEditor consumes.
  * Mirrors the inline conversion in the HTTP populate path.
@@ -488,6 +515,11 @@ export function ResendPage() {
   const [targetAddr, setTargetAddr] = useState("");
   const [useTls, setUseTls] = useState(false);
   const [rawPatches, setRawPatches] = useState<RawPatch[]>([]);
+  // RawPatchEditor validity gate (USK-967). The editor surfaces invalid
+  // offset entries (non-numeric / empty / negative / fractional) inline
+  // and toggles this flag via onValidityChange so the Send button is
+  // disabled before the prior silent NaN→0 coercion path is reached.
+  const [rawPatchesValid, setRawPatchesValid] = useState(true);
   const [tcpMode, setTcpMode] = useState<"resend_raw" | "tcp_replay">("resend_raw");
 
   // gRPC editor state — USK-936. Minimum-viable MVP exposes service /
@@ -722,14 +754,16 @@ export function ResendPage() {
         messagePayload: flow.request_body || "",
       });
     } else if (isWsFlow(flow)) {
-      // WebSocket flow: populate single-frame editor from the handshake URL.
+      // WebSocket flow: populate single-frame editor from the handshake URL
+      // and (USK-967) honour the first send-direction frame's FIN bit
+      // so a loaded FIN=0 frame doesn't silently default-resend with FIN=1.
       const path = extractFlowPath(flow.url || "");
       setWsState({
         targetAddr: flow.conn_info?.server_addr ?? "",
         scheme: extractUseTls(flow) ? "wss" : "ws",
         path,
         opcode: "text",
-        fin: true,
+        fin: extractFlowFin(flow),
         payload: "",
         bodyEncoding: "text",
         compressed: false,
@@ -743,6 +777,9 @@ export function ResendPage() {
       setTargetAddr(flow.conn_info?.server_addr ?? "");
       setUseTls(!!flow.conn_info?.tls_version);
       setRawPatches([]);
+      // Reset to valid for the empty-patches default; the editor will
+      // re-notify after the first edit (USK-967).
+      setRawPatchesValid(true);
       setTcpMode("resend_raw");
       setTcpRequestTab("messages");
     } else {
@@ -1037,23 +1074,52 @@ export function ResendPage() {
       return;
     }
 
-    const params: ResendRawParams = {
-      flow_id: activeFlowId,
-      target_addr: targetAddr.trim(),
-      use_tls: useTls || undefined,
-      patches:
-        rawPatches.length > 0
-          ? rawPatches.map((p) => ({
-              offset: p.offset ?? 0,
-              data: p.data_base64 ?? "",
-              data_encoding: "base64",
-            }))
-          : undefined,
-      tag: tag || undefined,
-    };
-
     setTcpResendRawSending(true);
     try {
+      // USK-967: the previous `p.offset ?? 0` fallback silently coerced an
+      // invalid offset (typically a NaN from a non-numeric editor input)
+      // to 0, which writes the patch at a wholly different position than
+      // the user intended — exactly the byte-level fuzz failure mode we
+      // exist to avoid. The submit button is gated on `rawPatchesValid`,
+      // so this path is unreachable when an offset row is invalid; the
+      // throw acts as a defense-in-depth assertion against a future
+      // regression in the validity wiring.
+      const offsetPatches: ResendRawBytePatch[] = [];
+      for (const p of rawPatches) {
+        const mode =
+          p.find_text != null || p.replace_text != null
+            ? "find_replace_text"
+            : p.find_base64 != null || p.replace_base64 != null
+              ? "find_replace_hex"
+              : "offset";
+        if (mode === "offset") {
+          if (
+            p.offset == null ||
+            !Number.isInteger(p.offset) ||
+            p.offset < 0
+          ) {
+            throw new Error(
+              "resend_raw: invalid offset reached submit; RawPatchEditor validity gate failed",
+            );
+          }
+          offsetPatches.push({
+            offset: p.offset,
+            data: p.data_base64 ?? "",
+            data_encoding: "base64",
+          });
+        }
+        // Note: find/replace modes are not part of ResendRawParams.patches
+        // (the typed schema is offset-only). They are preserved in state
+        // for future use but skipped here — matching the prior behaviour.
+      }
+      const params: ResendRawParams = {
+        flow_id: activeFlowId,
+        target_addr: targetAddr.trim(),
+        use_tls: useTls || undefined,
+        patches: offsetPatches.length > 0 ? offsetPatches : undefined,
+        tag: tag || undefined,
+      };
+
       const typedResult: ResendRawTypedResult = await client.resendRaw(params);
       const adapted: TcpResendResult = {
         new_flow_id: typedResult.stream_id,
@@ -1859,7 +1925,11 @@ export function ResendPage() {
                   <TcpMessageList messages={tcpMessages} />
                 )}
                 {tcpRequestTab === "raw_patches" && (
-                  <RawPatchEditor patches={rawPatches} onChange={setRawPatches} />
+                  <RawPatchEditor
+                    patches={rawPatches}
+                    onChange={setRawPatches}
+                    onValidityChange={setRawPatchesValid}
+                  />
                 )}
               </Tabs>
             )}
@@ -1883,7 +1953,16 @@ export function ResendPage() {
                   <Button
                     variant="primary"
                     onClick={() => handleResendRaw()}
-                    disabled={tcpResendRawSending || !targetAddr.trim()}
+                    disabled={
+                      tcpResendRawSending ||
+                      !targetAddr.trim() ||
+                      !rawPatchesValid
+                    }
+                    title={
+                      !rawPatchesValid
+                        ? "Fix raw patch validation errors before sending"
+                        : undefined
+                    }
                   >
                     {tcpResendRawSending ? "Sending..." : "Send Raw"}
                   </Button>


### PR DESCRIPTION
## Summary

- **WS resend**: `fin` initial state derived from the loaded flow's first send-direction frame metadata (`ws_fin`), no longer hardcoded to `true`. The `WsRequestEditor` checkbox was already controlled — the fix is on the populate path so a frame loaded with `FIN=0` round-trips faithfully instead of silently flipping to `FIN=1`.
- **RawPatchEditor**: non-numeric / empty / negative / fractional offset surfaces an inline error (`aria-invalid` + red text), the parent's "Send Raw" button is disabled while invalid via a new `onValidityChange` callback prop. Pure helper `validateRawPatchOffset` extracted for unit testing.
- Removed silent `?? 0` fallback at submit (replaced with disabled-gate + defense-in-depth `throw` inside the existing try/catch so a future regression surfaces as a toast rather than an off-by-N-byte patch).
- Added 12 unit tests for `validateRawPatchOffset` covering the bug class (`"abc"`, `""`, `"-1"`, `"1.5"`, `"1000abc"`, `"Infinity"`, `"NaN"`) and the happy path (`"0"`, integers, surrounding whitespace).

## Decisions

1. **Initial fin state** — kept `boolean` type and initialise from loaded flow (default `true` for brand-new sends, set from `flow.message_preview[*].metadata.ws_fin` on load). No tri-state — the user mental model stays binary.
2. **`?? 0` removal** — replaced with disabled-button + assertion-throw, both small. The throw is now inside the try block so unexpected gate failures produce a user-visible toast instead of an uncaught promise rejection.
3. **Offset validation** — `Number()` + `Number.isFinite` + `Number.isInteger` + non-negative check. Rejects `"abc"`, `""`, `"-1"`, `"1.5"`, and `"1000abc"` (which `parseInt` would have silently truncated to `1000`).

## Test plan

- [x] FIN=0 WS frame round-trip: `extractFlowFin()` reads `flow.message_preview[*].metadata.ws_fin === "false"` → editor populates with `fin: false` → `WsRequestEditor` shows unchecked checkbox → `buildResendWsParams` forwards `fin: false` to `resend_ws` (see `web/src/pages/Resend/typedDispatch.ts:116`).
- [x] `parseInt("abc")` rejection: `validateRawPatchOffset("abc")` returns `"offset must be a number"`. Editor renders inline error with `role="alert"`, marks input `aria-invalid="true"`, calls `onValidityChange(false)`, parent disables Send Raw with a tooltip.
- [x] `make build` passes (TypeScript compile clean, 461 modules transformed).
- [x] `pnpm test` passes (12 files, 247 tests including 12 new ones for `validateRawPatchOffset`).
- [x] `make lint` passes (no new gofmt/vet/staticcheck violations).

Resolves USK-967
Linear: https://linear.app/usk6666/issue/USK-967

🤖 Generated with [Claude Code](https://claude.com/claude-code)