### PR TITLE
fix(webui/Flows): reset pagination offset on filter change

### DIFF
--- a/web/src/pages/Flows/FlowsPage.tsx
+++ b/web/src/pages/Flows/FlowsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "../../components/ui/Badge.js";
 import { Button } from "../../components/ui/Button.js";
@@ -228,18 +228,11 @@ export function FlowsPage() {
   const flows = data?.flows ?? [];
   const total = data?.total ?? 0;
 
-  // Reset offset and selection when debounced text filters change
-  const prevTextFilterKey = useRef("");
-  useEffect(() => {
-    const key = JSON.stringify({ debouncedUrlPattern, debouncedBodyContains, debouncedTagFilter, debouncedHostFilter });
-    if (prevTextFilterKey.current && prevTextFilterKey.current !== key) {
-      setOffset(0);
-      setSelectedIds(new Set());
-    }
-    prevTextFilterKey.current = key;
-  }, [debouncedUrlPattern, debouncedBodyContains, debouncedTagFilter, debouncedHostFilter]);
-
-  // Reset offset when filter changes (used by non-debounced filter controls)
+  // Reset offset and selection on any filter change. Called synchronously
+  // from every filter setter so the next useQuery render sees offset=0
+  // alongside the new filter — avoids the 1-render race where a debounced
+  // filter committed first and offset reset arrived one render later, so
+  // the query briefly fired with new filter + stale offset (USK-964).
   const handleFilterChange = useCallback(() => {
     setOffset(0);
     setSelectedIds(new Set());
@@ -299,36 +292,40 @@ export function FlowsPage() {
     [handleFilterChange],
   );
 
-  // --- Host filter (debounced — offset/selection reset via effect) ---
+  // --- Host filter (debounced query, immediate offset reset) ---
   const handleHostFilterChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setHostFilter(e.target.value);
+      handleFilterChange();
     },
-    [],
+    [handleFilterChange],
   );
 
-  // --- URL pattern (debounced — offset/selection reset via effect) ---
+  // --- URL pattern (debounced query, immediate offset reset) ---
   const handleUrlChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setUrlPattern(e.target.value);
+      handleFilterChange();
     },
-    [],
+    [handleFilterChange],
   );
 
-  // --- Body contains (debounced — offset/selection reset via effect) ---
+  // --- Body contains (debounced query, immediate offset reset) ---
   const handleBodyContainsChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setBodyContains(e.target.value);
+      handleFilterChange();
     },
-    [],
+    [handleFilterChange],
   );
 
-  // --- Tag filter (debounced — offset/selection reset via effect) ---
+  // --- Tag filter (debounced query, immediate offset reset) ---
   const handleTagFilterChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setTagFilter(e.target.value);
+      handleFilterChange();
     },
-    [],
+    [handleFilterChange],
   );
 
   // --- Row click → navigate to detail ---


### PR DESCRIPTION
## Summary

Fixes a 1-render race in `FlowsPage` where changing a debounced text filter (host, URL pattern, body contains, tag) at a high page number briefly fetched the new filter with the stale offset before the reset arrived, sometimes producing a flash of an empty page.

The non-debounced filters (protocol radio, method, status, state, scheme, blocked-by) already reset `offset` to 0 synchronously via `handleFilterChange()` in their change handlers. The four debounced text filters were the holdout: they reset via a `useRef`/`useEffect` pair that fired *after* the render in which the new debounced filter committed, so `useQuery` saw new filter + old offset once before the reset re-rendered.

Fix: the four text-input `onChange` handlers now also call `handleFilterChange()` synchronously. The user types one keystroke, `offset` becomes 0 immediately, and the actual MCP query stays debounced (300 ms) and refires with `offset=0` once. Removed the now-unused `prevTextFilterKey` ref and the corresponding `useEffect`; dropped the `useRef` import.

After this change, every filter-state setter on the page resets `offset` and `selectedIds` in the same render, so the next `useQuery` call always sees the new filter alongside `offset=0`.

## Files changed

- `web/src/pages/Flows/FlowsPage.tsx` — only file touched

## Notes for reviewer

- **URL sync**: not in play. The page uses local `useState` for filters and pagination; there is no `useSearchParams` / URL-state sync, so the fix is purely in-component state. (Confirmed with `grep useSearchParams` across `web/src/pages/Flows/`.)
- **Filter setter audit**: every filter setter on the page now resets offset:
  - Radio/select handlers (`selectProtocol`, `handleMethodChange`, `handleStatusCodeChange`, `handleStateChange`, `handleSchemeChange`, `handleBlockedByChange`) — already called `handleFilterChange`, untouched.
  - Text input handlers (`handleHostFilterChange`, `handleUrlChange`, `handleBodyContainsChange`, `handleTagFilterChange`) — **now** call `handleFilterChange`.
  - Sort and page-size handlers also reset offset (pre-existing).
- **Test gap**: the WebUI test suite deliberately avoids RTL/jsdom (see the header comment in `web/src/pages/Resend/ResendPage.dispatch.test.tsx` — tests target pure-logic helpers, not component renders). The fix is interleaved with React hooks inside the component body; extracting a testable unit would require refactoring beyond this bug-fix scope. Manual verification is in the test plan below.

## Test plan

- [x] `make lint` — passes (no new findings on `FlowsPage.tsx`; pre-existing warnings unchanged)
- [x] `make build` — succeeds (UI + Go)
- [x] `pnpm test` (webui Vitest) — 235/235 pass
- [ ] Manual: navigate Flows to page 5, then:
  - change protocol filter — expect return to page 1 with filtered set
  - type into URL pattern — expect immediate return to page 1, debounced fetch fires at offset 0
  - type into host / body / tag — same as URL pattern

Resolves USK-964
Linear: https://linear.app/usk6666/issue/USK-964

Generated with [Claude Code](https://claude.com/claude-code)