### PR TITLE
fix(webui/export): filter HTTP/2 pseudo-headers in curl and HAR exports

### DIFF
--- a/web/src/lib/export/curl.test.ts
+++ b/web/src/lib/export/curl.test.ts
@@ -233,4 +233,74 @@ describe("generateCurl", () => {
     expect(result).toContain("curl");
     expect(result).not.toContain("-X");
   });
+
+  // ---------------------------------------------------------------------------
+  // HTTP/2 pseudo-headers
+  //
+  // `-H ':method: GET'` is invalid in curl (curl rejects leading-colon names
+  // and the shell would need awkward escaping anyway). The information they
+  // carry — method, scheme, authority, path — is already encoded in the
+  // method flag + URL we emit above, so the export must filter them.
+  // ---------------------------------------------------------------------------
+
+  it("filters HTTP/2 request pseudo-headers", () => {
+    const result = generateCurl(
+      makeFlow({
+        protocol: "HTTP/2",
+        method: "GET",
+        url: "https://example.com/api",
+        request_headers: {
+          ":method": ["GET"],
+          ":path": ["/api"],
+          ":authority": ["example.com"],
+          ":scheme": ["https"],
+          "user-agent": ["test-agent/1.0"],
+        },
+      })
+    );
+    expect(result).not.toContain(":method");
+    expect(result).not.toContain(":path");
+    expect(result).not.toContain(":authority");
+    expect(result).not.toContain(":scheme");
+    expect(result).not.toContain("-H ':");
+    expect(result).toContain("-H 'user-agent: test-agent/1.0'");
+    expect(result).toContain("'https://example.com/api'");
+  });
+
+  it("filters HTTP/2 pseudo-headers regardless of casing", () => {
+    const result = generateCurl(
+      makeFlow({
+        protocol: "HTTP/2",
+        method: "POST",
+        url: "https://example.com/upload",
+        request_body: "hello",
+        request_headers: {
+          ":METHOD": ["POST"],
+          ":Path": ["/upload"],
+          "Content-Type": ["text/plain"],
+        },
+      })
+    );
+    expect(result).not.toContain(":METHOD");
+    expect(result).not.toContain(":Path");
+    expect(result).toContain("-H 'Content-Type: text/plain'");
+  });
+
+  it("preserves the method and URL when pseudo-headers are present", () => {
+    const result = generateCurl(
+      makeFlow({
+        protocol: "HTTP/2",
+        method: "DELETE",
+        url: "https://example.com/items/42",
+        request_headers: {
+          ":method": ["DELETE"],
+          ":path": ["/items/42"],
+          ":authority": ["example.com"],
+          ":scheme": ["https"],
+        },
+      })
+    );
+    expect(result).toContain("-X 'DELETE'");
+    expect(result).toContain("'https://example.com/items/42'");
+  });
 });

--- a/web/src/lib/export/curl.ts
+++ b/web/src/lib/export/curl.ts
@@ -5,6 +5,7 @@
  * terminals, scripts, or other tooling common in vulnerability assessments.
  */
 
+import { isPseudoHeader } from "../http2/pseudoHeaders.js";
 import type { FlowDetailResult } from "../mcp/types.js";
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,10 @@ export function generateCurl(flow: FlowDetailResult): string {
   const headers = flow.request_headers ?? {};
   for (const [name, values] of Object.entries(headers)) {
     if (IMPLICIT_HEADERS.has(name.toLowerCase())) continue;
+    // HTTP/2 pseudo-headers (`:method`, `:path`, ...) cannot be passed via
+    // curl's `-H` flag; their semantic content is already carried in the
+    // request-line (method + URL) built above.
+    if (isPseudoHeader(name)) continue;
 
     for (const v of values) {
       parts.push("-H '" + shellEscape(name + ": " + v) + "'");

--- a/web/src/lib/export/har.test.ts
+++ b/web/src/lib/export/har.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { buildHar } from "./har";
+import type { FlowDetailResult } from "../mcp/types";
+
+/**
+ * Helper to create a minimal FlowDetailResult for testing.
+ * Only the fields used by buildHar are required.
+ */
+function makeFlow(
+  overrides: Partial<FlowDetailResult> = {},
+): FlowDetailResult {
+  return {
+    id: "test-id",
+    conn_id: "conn-1",
+    protocol: "HTTP/1.x",
+    flow_type: "http",
+    state: "complete",
+    method: "GET",
+    url: "http://example.com/",
+    request_headers: null,
+    request_body: "",
+    request_body_encoding: "",
+    response_status_code: 200,
+    response_headers: null,
+    response_body: "",
+    response_body_encoding: "",
+    request_body_truncated: false,
+    response_body_truncated: false,
+    timestamp: "2025-01-01T00:00:00Z",
+    duration_ms: 100,
+    message_count: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Baseline HTTP/1.x
+// ---------------------------------------------------------------------------
+
+describe("buildHar", () => {
+  it("builds a minimal HAR for a GET / 200 flow", () => {
+    const har = buildHar(makeFlow());
+    expect(har.log.version).toBe("1.2");
+    expect(har.log.entries).toHaveLength(1);
+
+    const entry = har.log.entries[0];
+    expect(entry.request.method).toBe("GET");
+    expect(entry.request.url).toBe("http://example.com/");
+    expect(entry.request.httpVersion).toBe("HTTP/1.1");
+    expect(entry.response.status).toBe(200);
+    expect(entry.response.httpVersion).toBe("HTTP/1.1");
+  });
+
+  it("emits regular HTTP/1.x request headers", () => {
+    const har = buildHar(
+      makeFlow({
+        request_headers: {
+          Accept: ["application/json"],
+          "X-Custom": ["a", "b"],
+        },
+      }),
+    );
+    const headers = har.log.entries[0].request.headers;
+    expect(headers).toEqual([
+      { name: "Accept", value: "application/json" },
+      { name: "X-Custom", value: "a" },
+      { name: "X-Custom", value: "b" },
+    ]);
+  });
+
+  it("emits regular HTTP/1.x response headers", () => {
+    const har = buildHar(
+      makeFlow({
+        response_headers: {
+          "Content-Type": ["text/html"],
+          "Set-Cookie": ["a=1", "b=2"],
+        },
+      }),
+    );
+    const headers = har.log.entries[0].response.headers;
+    expect(headers).toEqual([
+      { name: "Content-Type", value: "text/html" },
+      { name: "Set-Cookie", value: "a=1" },
+      { name: "Set-Cookie", value: "b=2" },
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP/2 pseudo-headers
+  //
+  // HAR 1.2 §6.2.4 / §6.2.6 forbid pseudo-headers from request.headers[] and
+  // response.headers[]. Strict HAR validators reject entries containing them.
+  // The semantic content is already represented in request.method /
+  // request.url / response.status.
+  // -------------------------------------------------------------------------
+
+  it("strips request pseudo-headers from HTTP/2 request.headers[]", () => {
+    const har = buildHar(
+      makeFlow({
+        protocol: "HTTP/2",
+        method: "POST",
+        url: "https://example.com/api",
+        request_headers: {
+          ":method": ["POST"],
+          ":path": ["/api"],
+          ":authority": ["example.com"],
+          ":scheme": ["https"],
+          "content-type": ["application/json"],
+          "user-agent": ["test-agent/1.0"],
+        },
+      }),
+    );
+    const headers = har.log.entries[0].request.headers;
+    const names = headers.map((h) => h.name);
+    expect(names).not.toContain(":method");
+    expect(names).not.toContain(":path");
+    expect(names).not.toContain(":authority");
+    expect(names).not.toContain(":scheme");
+    expect(names).toContain("content-type");
+    expect(names).toContain("user-agent");
+  });
+
+  it("strips :status from HTTP/2 response.headers[]", () => {
+    const har = buildHar(
+      makeFlow({
+        protocol: "HTTP/2",
+        response_status_code: 200,
+        response_headers: {
+          ":status": ["200"],
+          "content-type": ["application/json"],
+          "content-length": ["42"],
+        },
+      }),
+    );
+    const headers = har.log.entries[0].response.headers;
+    const names = headers.map((h) => h.name);
+    expect(names).not.toContain(":status");
+    expect(names).toContain("content-type");
+    expect(names).toContain("content-length");
+  });
+
+  it("strips pseudo-headers regardless of casing", () => {
+    const har = buildHar(
+      makeFlow({
+        protocol: "HTTP/2",
+        request_headers: {
+          ":METHOD": ["GET"],
+          ":Path": ["/api"],
+        },
+        response_headers: {
+          ":STATUS": ["200"],
+        },
+      }),
+    );
+    expect(har.log.entries[0].request.headers).toEqual([]);
+    expect(har.log.entries[0].response.headers).toEqual([]);
+  });
+
+  it("populates request.method / request.url / response.status from top-level fields even when pseudo-headers are filtered", () => {
+    const har = buildHar(
+      makeFlow({
+        protocol: "HTTP/2",
+        method: "DELETE",
+        url: "https://example.com/items/42",
+        response_status_code: 204,
+        request_headers: {
+          ":method": ["DELETE"],
+          ":path": ["/items/42"],
+          ":authority": ["example.com"],
+          ":scheme": ["https"],
+        },
+        response_headers: {
+          ":status": ["204"],
+        },
+      }),
+    );
+    const entry = har.log.entries[0];
+    expect(entry.request.method).toBe("DELETE");
+    expect(entry.request.url).toBe("https://example.com/items/42");
+    expect(entry.request.httpVersion).toBe("h2");
+    expect(entry.response.status).toBe(204);
+    expect(entry.response.httpVersion).toBe("h2");
+  });
+
+  // -------------------------------------------------------------------------
+  // Bodies / postData / content
+  // -------------------------------------------------------------------------
+
+  it("includes request body in postData", () => {
+    const har = buildHar(
+      makeFlow({
+        method: "POST",
+        request_body: '{"a":1}',
+        request_headers: { "Content-Type": ["application/json"] },
+      }),
+    );
+    const req = har.log.entries[0].request;
+    expect(req.postData).toEqual({
+      mimeType: "application/json",
+      text: '{"a":1}',
+    });
+    expect(req.bodySize).toBe('{"a":1}'.length);
+  });
+
+  it("preserves base64 request body verbatim", () => {
+    const har = buildHar(
+      makeFlow({
+        method: "POST",
+        request_body: "AAEC",
+        request_body_encoding: "base64",
+      }),
+    );
+    expect(har.log.entries[0].request.postData?.text).toBe("AAEC");
+  });
+
+  it("marks base64 response body with encoding", () => {
+    const har = buildHar(
+      makeFlow({
+        response_body: "AAEC",
+        response_body_encoding: "base64",
+      }),
+    );
+    const content = har.log.entries[0].response.content;
+    expect(content.text).toBe("AAEC");
+    expect(content.encoding).toBe("base64");
+  });
+
+  // -------------------------------------------------------------------------
+  // Query string + redirect URL
+  // -------------------------------------------------------------------------
+
+  it("extracts query string from the URL", () => {
+    const har = buildHar(makeFlow({ url: "http://example.com/?a=1&b=two" }));
+    expect(har.log.entries[0].request.queryString).toEqual([
+      { name: "a", value: "1" },
+      { name: "b", value: "two" },
+    ]);
+  });
+
+  it("populates redirectURL from Location header", () => {
+    const har = buildHar(
+      makeFlow({
+        response_status_code: 302,
+        response_headers: { Location: ["https://example.com/next"] },
+      }),
+    );
+    expect(har.log.entries[0].response.redirectURL).toBe(
+      "https://example.com/next",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Null guards
+  // -------------------------------------------------------------------------
+
+  it("handles null request_headers and response_headers", () => {
+    const har = buildHar(
+      makeFlow({ request_headers: null, response_headers: null }),
+    );
+    expect(har.log.entries[0].request.headers).toEqual([]);
+    expect(har.log.entries[0].response.headers).toEqual([]);
+  });
+});

--- a/web/src/lib/export/har.ts
+++ b/web/src/lib/export/har.ts
@@ -7,6 +7,7 @@
  * available via the MCP query tool — no backend changes are required.
  */
 
+import { isPseudoHeader } from "../http2/pseudoHeaders.js";
 import type { FlowDetailResult, FlowEntry } from "../mcp/types.js";
 
 // ---------------------------------------------------------------------------
@@ -261,6 +262,12 @@ function mapHttpVersion(protocol: string): string {
 
 /**
  * Flatten the multi-value headers map into a flat array of {name, value} pairs.
+ *
+ * HAR 1.2 §6.2.4 / §6.2.6 forbid HTTP/2 pseudo-headers (`:method`, `:path`,
+ * `:authority`, `:scheme`, `:status`) from appearing in `request.headers[]`
+ * or `response.headers[]` — their semantic content is already carried in
+ * `request.method` / `request.url` / `response.status`. Strict HAR
+ * validators reject entries that violate this, so we filter at the sink.
  */
 function flattenHeaders(
   headers?: Record<string, string[]> | null,
@@ -268,6 +275,7 @@ function flattenHeaders(
   if (!headers) return [];
   const result: HarHeader[] = [];
   for (const [name, values] of Object.entries(headers)) {
+    if (isPseudoHeader(name)) continue;
     for (const value of values) {
       result.push({ name, value });
     }

--- a/web/src/lib/http2/pseudoHeaders.ts
+++ b/web/src/lib/http2/pseudoHeaders.ts
@@ -1,0 +1,33 @@
+/**
+ * HTTP/2 pseudo-header constants and helpers (RFC 9113 §8.3).
+ *
+ * Pseudo-headers (`:method`, `:path`, `:authority`, `:scheme`, `:status`) are
+ * a protocol-format concept distinct from regular headers — they carry
+ * request-line / status-line information in HTTP/2's HEADERS frames. Tools
+ * that consume HTTP-shaped output (curl, HAR validators) reject them when
+ * they appear as ordinary headers, so export sinks must filter them.
+ *
+ * This module is the single source of truth for that set.
+ */
+
+/** HTTP/2 request pseudo-header names. */
+export const REQUEST_PSEUDO_HEADERS = [
+  ":method",
+  ":path",
+  ":authority",
+  ":scheme",
+];
+
+/** HTTP/2 response pseudo-header names. */
+export const RESPONSE_PSEUDO_HEADERS = [":status"];
+
+/** All HTTP/2 pseudo-header names. */
+export const ALL_PSEUDO_HEADERS = new Set<string>([
+  ...REQUEST_PSEUDO_HEADERS,
+  ...RESPONSE_PSEUDO_HEADERS,
+]);
+
+/** Check if a header name is an HTTP/2 pseudo-header (case-insensitive). */
+export function isPseudoHeader(name: string): boolean {
+  return ALL_PSEUDO_HEADERS.has(name.toLowerCase());
+}

--- a/web/src/pages/FlowDetail/Http2Info.tsx
+++ b/web/src/pages/FlowDetail/Http2Info.tsx
@@ -10,8 +10,18 @@
  */
 
 import { Badge } from "../../components/ui/Badge.js";
+import {
+  REQUEST_PSEUDO_HEADERS,
+  RESPONSE_PSEUDO_HEADERS,
+  isPseudoHeader,
+} from "../../lib/http2/pseudoHeaders.js";
 import type { FlowDetailResult, MessageEntry } from "../../lib/mcp/types.js";
 import "./FlowDetailPage.css";
+
+// Re-export for backward compatibility with existing consumers
+// (FlowDetailHTTPMessage.tsx). The source of truth lives in
+// `lib/http2/pseudoHeaders.ts`.
+export { isPseudoHeader };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,22 +39,6 @@ export interface Http2PseudoHeadersProps {
 export interface Http2StreamGroupProps {
   messages: MessageEntry[];
 }
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** HTTP/2 request pseudo-header names. */
-const REQUEST_PSEUDO_HEADERS = [":method", ":path", ":authority", ":scheme"];
-
-/** HTTP/2 response pseudo-header names. */
-const RESPONSE_PSEUDO_HEADERS = [":status"];
-
-/** All HTTP/2 pseudo-header names. */
-const ALL_PSEUDO_HEADERS = new Set([
-  ...REQUEST_PSEUDO_HEADERS,
-  ...RESPONSE_PSEUDO_HEADERS,
-]);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,11 +64,6 @@ function isH2TLS(flow: FlowDetailResult): boolean {
 /** Extract stream ID from a message's metadata. */
 function getStreamId(msg: MessageEntry): string | undefined {
   return msg.metadata?.stream_id;
-}
-
-/** Check if a header name is an HTTP/2 pseudo-header. */
-export function isPseudoHeader(name: string): boolean {
-  return ALL_PSEUDO_HEADERS.has(name.toLowerCase());
 }
 
 /** Extract pseudo-headers from a header map. */


### PR DESCRIPTION
## Summary
- Extract HTTP/2 pseudo-header constants + `isPseudoHeader` helper into shared module `web/src/lib/http2/pseudoHeaders.ts` (single source of truth)
- Filter `:method` / `:path` / `:authority` / `:scheme` / `:status` in `curl.ts` header-emission loop
- Filter the same set in `har.ts` `flattenHeaders` (applies uniformly to request and response sides)
- New `web/src/lib/export/har.test.ts` (HAR exporter was previously untested)
- Extend `curl.test.ts` with HTTP/2 pseudo-header cases (filter, case-insensitivity, method/URL preservation)
- `Http2Info.tsx` re-exports `isPseudoHeader` so `FlowDetailHTTPMessage.tsx` keeps compiling unchanged

## Why
HTTP/2 flows captured by the proxy carry pseudo-headers in `request_headers` / `response_headers`. The two export sinks emit them as ordinary headers, which produces broken artifacts:
- `-H ':method: GET'` is rejected by curl (leading colon is invalid in HTTP header field-names).
- HAR 1.2 §6.2.4 / §6.2.6 forbid pseudo-headers in `request.headers[]` / `response.headers[]`; strict HAR validators reject such entries.

Both sinks already carry the semantic content elsewhere (`flow.method` + `flow.url` for curl; `request.method` / `request.url` / `response.status` for HAR), so the fix is strictly sink-side filtering. The underlying recorded headers are not mutated — only the export representation changes (MITM Principle #3, RFC-001).

## Test plan
- [x] `make test-ui` — 251 tests pass (12 files), includes 13 new `har.test.ts` and 3 new HTTP/2 cases in `curl.test.ts`
- [x] `make build` — Vite + `tsc -b` clean, `go vet` + `go build` clean
- [x] `make lint` — passes (gofmt + go vet + staticcheck + ineffassign + gocyclo)
- [x] `make test` — Go test suite passes (no Go data-path code touched)
- [x] WebUI ESLint: error count unchanged (4 pre-existing errors in unrelated files); warning count unchanged
- [x] curl export of HTTP/2 GET/POST flow contains no `-H ':...'` flags
- [x] HAR export of HTTP/2 GET/POST flow contains no pseudo-headers in `request.headers[]` / `response.headers[]`
- [x] HTTP/1.x export unchanged (regression check via existing curl tests + new HAR baseline tests)

## Context
Defense-in-depth fix following USK-965 (commit `8a2b3ae2`), which fixed the display-side `filterRegularHeaders` to always strip pseudo-headers. The export sinks (curl, HAR) had the same gap.

Resolves USK-962
Linear: https://linear.app/usk6666/issue/USK-962

🤖 Generated with [Claude Code](https://claude.com/claude-code)