### PR TITLE
refactor(webui/Macros): source ExtractionFrom from typed literal union

### DIFF
--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -794,10 +794,19 @@ export interface MacrosResult {
   count: number;
 }
 
+/**
+ * Where in the message to extract a value from in a macro step.
+ *
+ * Mirrors `ExtractionFrom` in `internal/macro/types.go`. Closed set —
+ * extending the backend requires extending this union and the
+ * `EXTRACTION_FROM_OPTIONS` array in `MacroDetailPage.tsx`.
+ */
+export type ExtractionFrom = "request" | "response";
+
 /** Extraction rule in a macro step. */
 export interface ExtractionRule {
   name: string;
-  from: string;
+  from: ExtractionFrom;
   source: string;
   header_name?: string;
   regex?: string;

--- a/web/src/pages/Macros/MacroDetailPage.tsx
+++ b/web/src/pages/Macros/MacroDetailPage.tsx
@@ -9,6 +9,7 @@ import { Tabs } from "../../components/ui/Tabs.js";
 import { useToast } from "../../components/ui/Toast.js";
 import { useMacro, useQuery } from "../../lib/mcp/hooks.js";
 import type {
+  ExtractionFrom,
   ExtractionRule,
   GuardCondition,
   MacroDefineResult,
@@ -33,7 +34,7 @@ const ON_ERROR_OPTIONS = [
   { value: "retry", label: "Retry" },
 ];
 
-const EXTRACTION_FROM_OPTIONS = [
+const EXTRACTION_FROM_OPTIONS: readonly { value: ExtractionFrom; label: string }[] = [
   { value: "request", label: "Request" },
   { value: "response", label: "Response" },
 ];
@@ -79,7 +80,7 @@ interface StepFormEntry {
 interface ExtractionFormEntry {
   key: string;
   name: string;
-  from: string;
+  from: ExtractionFrom;
   source: string;
   headerName: string;
   regex: string;
@@ -1052,7 +1053,9 @@ function StepEditor({
                       className="macro-select"
                       value={ext.from}
                       onChange={(e) =>
-                        updateExtraction(ext.key, { from: e.target.value })
+                        updateExtraction(ext.key, {
+                          from: e.target.value as ExtractionFrom,
+                        })
                       }
                     >
                       {EXTRACTION_FROM_OPTIONS.map((o) => (


### PR DESCRIPTION
## Summary
- Add `export type ExtractionFrom = "request" | "response"` to `web/src/lib/mcp/types.ts`, mirroring `internal/macro.ExtractionFrom`.
- Narrow `ExtractionRule.from` and `ExtractionFormEntry.from` from `string` to `ExtractionFrom`.
- Annotate `EXTRACTION_FROM_OPTIONS` with the literal-union element type so an unrepresented backend value would surface as a TypeScript error.
- Cast `e.target.value` to `ExtractionFrom` at the sole `<select>` write-site in `MacroDetailPage.tsx` (the option set is constrained by the same array).
- Scope held strictly to `from` — `OnError` and `ExtractionSource` have the same refactor opportunity and will be filed separately if desired.

## Test plan
- [x] `make build` — tsc + Vite pass
- [x] `make lint` — passes (gofmt / vet / staticcheck / ineffassign / gocyclo)
- [x] Web tests (`pnpm test`) — 16 files / 314 tests pass
- [x] `tsc -b` — clean

Resolves USK-972
Linear: https://linear.app/usk6666/issue/USK-972

Generated with [Claude Code](https://claude.com/claude-code)