### PR TITLE
feat(webui/Security): clarify Safety Filter Input vs Output semantics

### DIFF
--- a/web/src/pages/Security/SafetyFilter.tsx
+++ b/web/src/pages/Security/SafetyFilter.tsx
@@ -129,6 +129,9 @@ export function SafetyFilter() {
           <Badge variant="info">{data.input_rules.length}</Badge>
         </div>
         <div className="security-card-body">
+          <p className="security-section-desc">
+            Blocks Send-direction payloads on the live wire before they reach the upstream server. Recommended presets: <code>destructive-sql</code>, <code>destructive-os-command</code>.
+          </p>
           <SafetyFilterRuleTable rules={data.input_rules} />
         </div>
       </div>
@@ -139,6 +142,9 @@ export function SafetyFilter() {
           <Badge variant="info">{data.output_rules.length}</Badge>
         </div>
         <div className="security-card-body">
+          <p className="security-section-desc">
+            Masks sensitive bytes only when an MCP tool returns a recorded flow to the AI agent. The wire copy delivered to the DB, browser, and next hop is never modified. Recommended presets: <code>credit-card</code>, <code>japan-my-number</code>.
+          </p>
           <SafetyFilterRuleTable rules={data.output_rules} showReplacement />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add per-card explanatory paragraphs to `SafetyFilter.tsx` distinguishing Input Filter (Send-direction wire block) from Output Filter (MCP-boundary mask).
- Reuses existing `.security-section-desc` CSS class. No new components or styles.

## Test plan
- [ ] `make build` — UI rebuilds, embed succeeds
- [ ] `make lint` — passes
- [ ] `make test` — passes
- [ ] Open WebUI `/security` page, confirm both filter cards display the new descriptions

Resolves USK-970
Linear: https://linear.app/usk6666/issue/USK-970

🤖 Generated with [Claude Code](https://claude.com/claude-code)