### PR TITLE
fix(webui/Resend): enforce json_path/regex mutex in BodyPatchEditor

### DIFF
--- a/web/src/pages/Resend/BodyPatchEditor.css
+++ b/web/src/pages/Resend/BodyPatchEditor.css
@@ -27,6 +27,34 @@
   border-radius: var(--radius-md);
 }
 
+.patch-editor-mode-row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.patch-editor-mode-select {
+  height: 28px;
+  padding: 0 var(--space-sm);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238b949e' d='M3 5l3 3 3-3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  padding-right: 20px;
+}
+
+.patch-editor-mode-select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.2);
+}
+
 .patch-editor-row {
   display: flex;
   gap: var(--space-sm);
@@ -63,6 +91,7 @@
   width: 28px;
   height: 28px;
   flex-shrink: 0;
+  margin-left: auto;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   color: var(--text-muted);
@@ -82,4 +111,15 @@
 .patch-editor-spacer {
   width: 28px;
   flex-shrink: 0;
+}
+
+/* Inline validation error for empty or conflicting patches (USK-973). */
+.patch-editor-error {
+  font-size: var(--font-size-xs);
+  color: var(--accent-danger);
+  padding-left: var(--space-xs);
+}
+
+.patch-editor-field[aria-invalid="true"] {
+  border-color: var(--accent-danger);
 }

--- a/web/src/pages/Resend/BodyPatchEditor.test.ts
+++ b/web/src/pages/Resend/BodyPatchEditor.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the BodyPatchEditor pure helpers (USK-973).
+ *
+ * The editor previously surfaced both `json_path + value` and
+ * `regex + replace` rows simultaneously, allowing the user to populate
+ * both modes on the same patch. The backend `validateBodyPatch`
+ * (`internal/mcp/body_patch.go`) rejects that shape with a hard error,
+ * so the UX gap caused a needless server round-trip for input that
+ * could never succeed. `detectBodyPatchMode` selects the rendering
+ * mode for an existing patch (defensive against legacy data) and
+ * `isBodyPatchValid` mirrors the backend's exactly-one-of contract so
+ * the parent's submit button can be disabled inline.
+ *
+ * The component itself is JSX-heavy; tests for it would pull in jsdom
+ * + RTL. Following the pattern of RawPatchEditor.test.ts, we verify
+ * the pure helpers here.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { BodyPatch } from "../../lib/mcp/types.js";
+import { detectBodyPatchMode, isBodyPatchValid } from "./BodyPatchEditor.js";
+
+describe("detectBodyPatchMode", () => {
+  it("returns json_path for an empty patch (default)", () => {
+    expect(detectBodyPatchMode({})).toBe("json_path");
+  });
+
+  it("returns json_path when only json_path is set", () => {
+    expect(detectBodyPatchMode({ json_path: "$.a" })).toBe("json_path");
+  });
+
+  it("returns json_path when only value is set", () => {
+    // No regex marker present — value alone is ambiguous; default to json_path.
+    expect(detectBodyPatchMode({ value: "x" })).toBe("json_path");
+  });
+
+  it("returns regex when only regex is set", () => {
+    expect(detectBodyPatchMode({ regex: "foo" })).toBe("regex");
+  });
+
+  it("returns regex when only replace is set", () => {
+    // Defense-only path: replace alone implies regex intent.
+    expect(detectBodyPatchMode({ replace: "bar" })).toBe("regex");
+  });
+
+  it("returns regex when both modes are set (regex wins)", () => {
+    // Defense-only path for legacy data. The editor's write path never
+    // produces this shape because handleModeChange clears the other-mode
+    // fields.
+    expect(
+      detectBodyPatchMode({ json_path: "$.a", regex: "foo" } as BodyPatch),
+    ).toBe("regex");
+  });
+
+  it("treats empty regex string as regex mode (presence over emptiness)", () => {
+    // The blank shape produced by switching into regex mode is
+    // `{ regex: "", replace: "" }`; detection must keep it in regex mode
+    // for the next render to show the regex fields, not flip back to
+    // json_path.
+    expect(detectBodyPatchMode({ regex: "", replace: "" })).toBe("regex");
+  });
+});
+
+describe("isBodyPatchValid", () => {
+  it("rejects fully empty patch", () => {
+    expect(isBodyPatchValid({})).toBe(false);
+  });
+
+  it("rejects patch with both modes set", () => {
+    expect(
+      isBodyPatchValid({ json_path: "$.a", regex: "foo" } as BodyPatch),
+    ).toBe(false);
+  });
+
+  it("rejects empty json_path string", () => {
+    expect(isBodyPatchValid({ json_path: "" })).toBe(false);
+  });
+
+  it("rejects whitespace-only json_path", () => {
+    expect(isBodyPatchValid({ json_path: "   " })).toBe(false);
+  });
+
+  it("rejects empty regex string", () => {
+    expect(isBodyPatchValid({ regex: "" })).toBe(false);
+  });
+
+  it("rejects whitespace-only regex", () => {
+    expect(isBodyPatchValid({ regex: "   " })).toBe(false);
+  });
+
+  it("rejects blank-mode-switch shape (regex+replace both empty)", () => {
+    // `handleModeChange` writes `{ regex: "", replace: "" }`; that row
+    // must be reported invalid so the Send button stays disabled until
+    // the user fills the pattern.
+    expect(isBodyPatchValid({ regex: "", replace: "" })).toBe(false);
+  });
+
+  it("accepts valid json_path patch", () => {
+    expect(isBodyPatchValid({ json_path: "$.user.name", value: "alice" })).toBe(
+      true,
+    );
+  });
+
+  it("accepts json_path patch without value (null is valid)", () => {
+    // The backend treats omitted/null `value` as a valid JSON null,
+    // matching the doc comment in body_patch.go's validateBodyPatch.
+    expect(isBodyPatchValid({ json_path: "$.a" })).toBe(true);
+  });
+
+  it("accepts valid regex patch", () => {
+    expect(isBodyPatchValid({ regex: "foo+", replace: "bar" })).toBe(true);
+  });
+
+  it("accepts regex patch with empty replace (matches strip)", () => {
+    // Empty replace is a meaningful operation (strip the matched text);
+    // only the pattern field is required.
+    expect(isBodyPatchValid({ regex: "foo+", replace: "" })).toBe(true);
+  });
+});

--- a/web/src/pages/Resend/BodyPatchEditor.tsx
+++ b/web/src/pages/Resend/BodyPatchEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { Button } from "../../components/ui/Button.js";
 import type { BodyPatch } from "../../lib/mcp/types.js";
 import "./BodyPatchEditor.css";
@@ -6,26 +6,100 @@ import "./BodyPatchEditor.css";
 export interface BodyPatchEditorProps {
   patches: BodyPatch[];
   onChange: (patches: BodyPatch[]) => void;
+  /**
+   * Called when the editor's validity changes. A patch is valid only when
+   * exactly one mode is populated (json_path xor regex). The backend
+   * `validateBodyPatch` (`internal/mcp/body_patch.go`) rejects the
+   * both-modes-set and neither-mode-set shapes with a hard error; parents
+   * use this signal to disable the submit button so the conflicting input
+   * is caught before the server round-trip (USK-973).
+   */
+  onValidityChange?: (valid: boolean) => void;
+}
+
+/** Patch mode for the editor entry. */
+export type BodyPatchMode = "json_path" | "regex";
+
+/**
+ * Infer which mode an existing BodyPatch entry uses.
+ *
+ * Priority: regex wins when both pattern fields are present. The
+ * editor's own write path never produces this shape (mode switching
+ * clears the other-mode fields), so the only way to reach it is
+ * legacy data or a flow-load before USK-973. The flow-load reset in
+ * `ResendPage` clears `bodyPatches` to `[]`, so this is defense-only.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function detectBodyPatchMode(patch: BodyPatch): BodyPatchMode {
+  if (patch.regex != null || patch.replace != null) return "regex";
+  return "json_path";
+}
+
+/**
+ * Determine whether a single BodyPatch is submittable.
+ *
+ * Mirrors the backend `validateBodyPatch` exactly-one-of contract:
+ * the patch must have a non-empty `json_path` xor a non-empty `regex`.
+ * Empty rows (both modes blank) and conflicting rows (both modes
+ * populated) are rejected here so the parent's submit button is
+ * disabled before the server round-trip.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function isBodyPatchValid(patch: BodyPatch): boolean {
+  const hasJSON = (patch.json_path ?? "").trim() !== "";
+  const hasRegex = (patch.regex ?? "").trim() !== "";
+  return hasJSON !== hasRegex;
 }
 
 /**
  * Editor for body patches (JSON path or regex-based partial body modification).
- * Each patch can specify a json_path + value or a regex + replace string.
+ * Each patch selects exactly one mode (json_path xor regex); mode switching
+ * clears the other-mode fields to keep the wire shape unambiguous.
  */
-export function BodyPatchEditor({ patches, onChange }: BodyPatchEditorProps) {
-  const handleFieldChange = useCallback(
-    (index: number, field: keyof BodyPatch, val: string) => {
+export function BodyPatchEditor({
+  patches,
+  onChange,
+  onValidityChange,
+}: BodyPatchEditorProps) {
+  const isValid = patches.every(isBodyPatchValid);
+
+  // Notify parent of validity transitions so the submit button can be
+  // disabled while any patch row is empty or has both modes populated
+  // (USK-973).
+  useEffect(() => {
+    onValidityChange?.(isValid);
+  }, [isValid, onValidityChange]);
+
+  const handleModeChange = useCallback(
+    (index: number, mode: BodyPatchMode) => {
+      const updated = [...patches];
+      // Reset all fields and set relevant ones for the new mode.
+      updated[index] = mode === "json_path" ? { json_path: "" } : { regex: "", replace: "" };
+      onChange(updated);
+    },
+    [patches, onChange],
+  );
+
+  const handleJSONPathChange = useCallback(
+    (index: number, val: string) => {
       const updated = [...patches];
       const patch = { ...updated[index] };
-      if (field === "value") {
-        // Try to parse as JSON, fall back to string.
-        try {
-          patch.value = JSON.parse(val);
-        } catch {
-          patch.value = val;
-        }
-      } else {
-        (patch as Record<string, unknown>)[field] = val || undefined;
+      patch.json_path = val;
+      updated[index] = patch;
+      onChange(updated);
+    },
+    [patches, onChange],
+  );
+
+  const handleValueChange = useCallback(
+    (index: number, val: string) => {
+      const updated = [...patches];
+      const patch = { ...updated[index] };
+      // Try to parse as JSON, fall back to string.
+      try {
+        patch.value = JSON.parse(val);
+      } catch {
+        patch.value = val;
       }
       updated[index] = patch;
       onChange(updated);
@@ -33,8 +107,19 @@ export function BodyPatchEditor({ patches, onChange }: BodyPatchEditorProps) {
     [patches, onChange],
   );
 
+  const handleRegexFieldChange = useCallback(
+    (index: number, field: "regex" | "replace", val: string) => {
+      const updated = [...patches];
+      const patch = { ...updated[index] };
+      patch[field] = val;
+      updated[index] = patch;
+      onChange(updated);
+    },
+    [patches, onChange],
+  );
+
   const handleAdd = useCallback(() => {
-    onChange([...patches, { json_path: "", replace: "" }]);
+    onChange([...patches, { json_path: "" }]);
   }, [patches, onChange]);
 
   const handleRemove = useCallback(
@@ -49,61 +134,104 @@ export function BodyPatchEditor({ patches, onChange }: BodyPatchEditorProps) {
     <div className="patch-editor">
       <div className="patch-editor-description">
         Modify parts of the request body using JSON path or regex patterns.
+        Choose a patch mode for each entry.
       </div>
       {patches.length === 0 && (
         <div className="patch-editor-empty">
           No body patches. Click "Add Patch" to add one.
         </div>
       )}
-      {patches.map((patch, index) => (
-        <div key={index} className="patch-editor-entry">
-          <div className="patch-editor-row">
-            <input
-              className="patch-editor-field"
-              type="text"
-              value={patch.json_path ?? ""}
-              onChange={(e) => handleFieldChange(index, "json_path", e.target.value)}
-              placeholder="$.path.to.field"
-              spellCheck={false}
-            />
-            <input
-              className="patch-editor-field"
-              type="text"
-              value={typeof patch.value === "string" ? patch.value : patch.value != null ? JSON.stringify(patch.value) : ""}
-              onChange={(e) => handleFieldChange(index, "value", e.target.value)}
-              placeholder="New value (JSON)"
-              spellCheck={false}
-            />
-            <button
-              className="patch-editor-remove"
-              onClick={() => handleRemove(index)}
-              title="Remove patch"
-              aria-label={`Remove patch ${index}`}
-            >
-              x
-            </button>
+      {patches.map((patch, index) => {
+        const mode = detectBodyPatchMode(patch);
+        const valid = isBodyPatchValid(patch);
+        return (
+          <div key={index} className="patch-editor-entry">
+            <div className="patch-editor-mode-row">
+              <select
+                className="patch-editor-mode-select"
+                value={mode}
+                onChange={(e) =>
+                  handleModeChange(index, e.target.value as BodyPatchMode)
+                }
+              >
+                <option value="json_path">JSON path + value</option>
+                <option value="regex">Regex + replace</option>
+              </select>
+              <button
+                className="patch-editor-remove"
+                onClick={() => handleRemove(index)}
+                title="Remove patch"
+                aria-label={`Remove patch ${index}`}
+              >
+                x
+              </button>
+            </div>
+            {mode === "json_path" && (
+              <div className="patch-editor-row">
+                <input
+                  className="patch-editor-field"
+                  type="text"
+                  value={patch.json_path ?? ""}
+                  onChange={(e) => handleJSONPathChange(index, e.target.value)}
+                  placeholder="$.path.to.field"
+                  spellCheck={false}
+                  aria-invalid={!valid}
+                />
+                <input
+                  className="patch-editor-field"
+                  type="text"
+                  value={
+                    typeof patch.value === "string"
+                      ? patch.value
+                      : patch.value != null
+                        ? JSON.stringify(patch.value)
+                        : ""
+                  }
+                  onChange={(e) => handleValueChange(index, e.target.value)}
+                  placeholder="New value (JSON)"
+                  spellCheck={false}
+                />
+              </div>
+            )}
+            {mode === "regex" && (
+              <div className="patch-editor-row">
+                <input
+                  className="patch-editor-field"
+                  type="text"
+                  value={patch.regex ?? ""}
+                  onChange={(e) =>
+                    handleRegexFieldChange(index, "regex", e.target.value)
+                  }
+                  placeholder="Regex pattern"
+                  spellCheck={false}
+                  aria-invalid={!valid}
+                />
+                <input
+                  className="patch-editor-field"
+                  type="text"
+                  value={patch.replace ?? ""}
+                  onChange={(e) =>
+                    handleRegexFieldChange(index, "replace", e.target.value)
+                  }
+                  placeholder="Replace string"
+                  spellCheck={false}
+                />
+              </div>
+            )}
+            {!valid && (
+              <div
+                className="patch-editor-error"
+                role="alert"
+                aria-label={`Validation error for patch ${index}`}
+              >
+                {mode === "json_path"
+                  ? "json_path is required"
+                  : "regex is required"}
+              </div>
+            )}
           </div>
-          <div className="patch-editor-row">
-            <input
-              className="patch-editor-field"
-              type="text"
-              value={patch.regex ?? ""}
-              onChange={(e) => handleFieldChange(index, "regex", e.target.value)}
-              placeholder="Regex pattern (optional)"
-              spellCheck={false}
-            />
-            <input
-              className="patch-editor-field"
-              type="text"
-              value={patch.replace ?? ""}
-              onChange={(e) => handleFieldChange(index, "replace", e.target.value)}
-              placeholder="Replace string (optional)"
-              spellCheck={false}
-            />
-            <div className="patch-editor-spacer" />
-          </div>
-        </div>
-      ))}
+        );
+      })}
       <Button variant="ghost" size="sm" onClick={handleAdd}>
         + Add Patch
       </Button>

--- a/web/src/pages/Resend/ResendPage.tsx
+++ b/web/src/pages/Resend/ResendPage.tsx
@@ -504,6 +504,12 @@ export function ResendPage() {
   const [headers, setHeaders] = useState<Array<{ key: string; value: string }>>([]);
   const [body, setBody] = useState("");
   const [bodyPatches, setBodyPatches] = useState<BodyPatch[]>([]);
+  // BodyPatchEditor validity gate (USK-973). The editor enforces the
+  // backend's exactly-one-of contract (json_path xor regex) and surfaces
+  // empty/conflicting rows; the Send button is disabled while any row
+  // fails, avoiding a needless server round-trip and the prior UX where
+  // both fields were addressable on the same row.
+  const [bodyPatchesValid, setBodyPatchesValid] = useState(true);
 
   // HTTP raw editor state.
   const [httpEditorMode, setHttpEditorMode] = useState<"structured" | "raw">("structured");
@@ -1502,7 +1508,11 @@ export function ResendPage() {
                     </div>
                   )}
                   {requestTab === "patches" && (
-                    <BodyPatchEditor patches={bodyPatches} onChange={setBodyPatches} />
+                    <BodyPatchEditor
+                      patches={bodyPatches}
+                      onChange={setBodyPatches}
+                      onValidityChange={setBodyPatchesValid}
+                    />
                   )}
                 </Tabs>
 
@@ -1538,7 +1548,12 @@ export function ResendPage() {
                   <Button
                     variant="primary"
                     onClick={() => handleHttpSend()}
-                    disabled={httpSending}
+                    disabled={httpSending || !bodyPatchesValid}
+                    title={
+                      !bodyPatchesValid
+                        ? "Fix body patch validation errors before sending"
+                        : undefined
+                    }
                   >
                     {httpSending ? "Sending..." : "Send"}
                   </Button>


### PR DESCRIPTION
## Summary
- Add a per-row `json_path` / `regex` mode `<select>` in `BodyPatchEditor`, mirroring the `RawPatchEditor` (USK-967) pattern.
- On mode switch, clear the other-mode fields to prevent silent contamination of the wire shape.
- Disable the Resend Send button while any body patch is empty or has both modes populated, via a new `onValidityChange` prop wired to `bodyPatchesValid` state in `ResendPage`.
- Export pure helpers `detectBodyPatchMode` and `isBodyPatchValid`; cover both with table-driven vitest cases in `BodyPatchEditor.test.ts` (node env, no DOM).

## Issue framing note
The Issue body describes the backend as "silently ignoring" one of the two modes when both fields are populated. The actual behavior is that the backend `validateBodyPatch` (`internal/mcp/body_patch.go`) returns a hard error. The defect this PR addresses is the UX gap that allowed the conflicting input + the needless server round-trip; the wire/data correctness was never at risk. The `BodyPatch` TS type and the Go struct are unchanged.

## Test plan
- [x] `cd web && npm run lint && npm run build && npm test` all pass (332 vitest cases, including the new `BodyPatchEditor.test.ts`)
- [x] `make build` passes (UI rebuild + `go vet` + `go build`)
- [ ] In the running app, BodyPatchEditor renders a mode `<select>` on every row; switching mode clears the other-mode fields.
- [ ] Adding an empty patch disables the Resend Send button; populating either mode re-enables it.
- [ ] Mode switching does not lose currently-active-mode field values.

Resolves USK-973
Linear: https://linear.app/usk6666/issue/USK-973/fixwebuiresendbodypatch-enforce-mutex-between-json-path-and-regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)