### PR TITLE
feat(mcp/fuzz_http,macro): add scope="job" + mix-scope to fuzz_http macro hooks (USK-961)

### DIFF
--- a/internal/flow/fuzz_store.go
+++ b/internal/flow/fuzz_store.go
@@ -65,7 +65,14 @@ type FuzzResult struct {
 type FuzzMacroResult struct {
 	// FuzzID is the parent fuzz_jobs row id.
 	FuzzID string
-	// IndexNum is the 0-based variant index within the job.
+	// IndexNum is the 0-based variant index within the job for
+	// per-iteration (scope="iteration") hook rows. For scope="job"
+	// hook rows (USK-961 — pre-job / post-job hooks that fire exactly
+	// once outside the variant loop) IndexNum is -1, the documented
+	// sentinel. The underlying schemaV17 column is INTEGER NOT NULL,
+	// so -1 is a legal value (NULL is not) and the (fuzz_id,
+	// index_num, hook_name) primary key remains unique without a
+	// schema migration.
 	IndexNum int
 	// HookName is "pre" or "post".
 	HookName string

--- a/internal/flow/schema.go
+++ b/internal/flow/schema.go
@@ -462,6 +462,16 @@ CREATE INDEX IF NOT EXISTS idx_flows_stream_id_timestamp ON flows(stream_id, tim
 // recordMacroStepSession; status is one of "ok", "skipped", "error";
 // status_code carries the macro's last HTTP step status when available.
 //
+// index_num is the 0-based variant index for scope="iteration" rows.
+// USK-961 introduces scope="job" hooks (pre-job / post-job that fire
+// once outside the variant loop); those rows use index_num=-1 as the
+// documented sentinel so the (fuzz_id, index_num, hook_name) primary
+// key stays unique without a schema migration. The column is INTEGER
+// NOT NULL, so -1 is a legal value (NULL is not). There are no
+// external consumers of this table today; the sentinel is consumed
+// only by the test path and the `query` MCP tool surfaces does not
+// include fuzz_macro_results.
+//
 // idx_fuzz_macro_results_fuzz_id mirrors the fuzz_results companion index
 // so query-by-fuzz_id reads run as predicate scans.
 const schemaV17 = `

--- a/internal/mcp/fuzz_http.go
+++ b/internal/mcp/fuzz_http.go
@@ -86,28 +86,45 @@ type fuzzHTTPInput struct {
 
 	UpstreamProxy *UpstreamProxyConfig `json:"upstream_proxy,omitempty" jsonschema:"optional upstream proxy override applied per variant. url_template is re-expanded once per variant against §__iteration§ (variant index) and §__nonce§ (per-variant UUID), and the parsed URL tunnels the variant's dial via HTTP CONNECT or SOCKS5. Used for residential proxy IP rotation: each variant exits from a distinct upstream IP"`
 
-	// PreMacro / PostMacro: per-iteration macro hooks (USK-960). Use a
-	// shared per-variant KV Store so reserved keys §__iteration§ /
-	// §__nonce§ are visible to both macros, extracts from pre flow into
-	// the fuzz body's §var§ expansion, and reserved __response_status /
-	// __response_body / __response_headers__<lower(name)>__ keys land in
-	// the same store before post fires.
-	PreMacro  *fuzzHTTPMacroConfig `json:"pre_macro,omitempty" jsonschema:"per-iteration pre macro hook executed before each variant's send. scope=iteration (job deferred to USK-961). on_error: skip|abort|continue (default skip)"`
-	PostMacro *fuzzHTTPMacroConfig `json:"post_macro,omitempty" jsonschema:"per-iteration post macro hook executed after each variant's response. scope=iteration (job deferred to USK-961). on_error: skip|abort|continue (default skip). pass_response is forced on so __response_status / __response_body / __response_headers__<lower(name)>__ are visible to the macro's template expansion"`
+	// PreMacro / PostMacro: pre/post macro hooks (USK-960 per-iteration,
+	// USK-961 per-job + mix-scope). scope="iteration" (default) shares a
+	// per-variant KV Store with the variant's pipeline so reserved keys
+	// §__iteration§ / §__nonce§, pre extracts, and (for post) reserved
+	// __response_* keys are visible to template expansion. scope="job"
+	// runs the hook exactly once outside the variant loop against a
+	// job-scoped KV Store that is merged into each iteration's store
+	// before per-iteration reserved keys are seeded — so pre=job extracts
+	// flow into every variant's request templating. mix-scope (pre and
+	// post with independent scope) is supported.
+	PreMacro  *fuzzHTTPMacroConfig `json:"pre_macro,omitempty" jsonschema:"pre macro hook executed before a variant's send. scope=iteration (default; fires once per variant) | job (fires once before the variant loop; extracts shared with every variant). on_error: skip|abort|continue (default skip). For scope=job, skip returns a successful job result with completed_variants=0 and stopped_reason set"`
+	PostMacro *fuzzHTTPMacroConfig `json:"post_macro,omitempty" jsonschema:"post macro hook executed after a variant's response. scope=iteration (default; fires once per variant against __response_* reserved keys) | job (fires once after the variant loop completes; no __response_* keys, since there is no single response). on_error: skip|abort|continue (default skip). For scope=iteration, pass_response is forced on so __response_status / __response_body / __response_headers__<lower(name)>__ are visible to the macro's template expansion"`
 }
 
-// fuzzHTTPMacroConfig is the per-iteration pre/post macro hook configuration
-// for fuzz_http (USK-960). Wire-compatible scaffold for future per-job
-// scope (USK-961); scope="job" is accepted at the schema boundary but
-// rejected at validation so forward-compat clients can speak the field
-// without runtime support landing yet.
+// fuzzHTTPMacroConfig is the pre/post macro hook configuration for
+// fuzz_http (USK-960 per-iteration, USK-961 per-job + mix-scope).
+//
+// scope="iteration" (default) fires once per variant; the per-iteration
+// KV Store is allocated fresh in the variant loop with reserved keys
+// §__iteration§ / §__nonce§ seeded and (for post) reserved __response_*
+// keys injected before the macro runs.
+//
+// scope="job" fires exactly once outside the variant loop against a
+// separate job-scoped KV Store that is merged into each iteration's
+// store before per-iteration reserved keys are seeded — so pre=job
+// extracts flow into every variant's request templating, and post=job
+// summarises after the loop completes. Reserved keys (§__iteration§,
+// §__nonce§, __response_*) are NOT visible to job-scope macros (the
+// loop has not started for pre-job, and is over with discarded per-
+// iteration kvStores for post-job). run_interval is rejected when
+// scope="job" (single-fire by construction).
 type fuzzHTTPMacroConfig struct {
 	// Name is the stored macro name (defined via macro.define).
 	Name string `json:"name" jsonschema:"REQUIRED stored macro name"`
 
-	// Scope: "iteration" (MVP) or "job" (deferred to USK-961). Empty
-	// defaults to "iteration".
-	Scope string `json:"scope,omitempty" jsonschema:"iteration (default) | job (deferred to USK-961; rejected at validation today)"`
+	// Scope: "iteration" (default) or "job". Mix-scope is supported —
+	// pre and post may independently select their scope. Empty defaults
+	// to "iteration".
+	Scope string `json:"scope,omitempty" jsonschema:"iteration (default; fires once per variant) | job (fires once outside the variant loop; KV Store is shared across the whole job and merged into each iteration's per-variant store)"`
 
 	// OnError selects the iteration's behaviour when the hook errors.
 	//   "skip"     (default) — record the iteration as skipped, do not send

--- a/internal/mcp/fuzz_http_helpers.go
+++ b/internal/mcp/fuzz_http_helpers.go
@@ -133,9 +133,7 @@ func validateFuzzHTTPInput(input *fuzzHTTPInput) error {
 }
 
 // validateFuzzHTTPMacroConfig validates one pre/post macro hook config.
-// scope="iteration" (default) is accepted; scope="job" is rejected at
-// validation with a deferred-to-USK-961 message (the field is parsed so
-// forward-compat clients can speak it without runtime support).
+// scope="iteration" (default) and scope="job" are both accepted (USK-961).
 //
 // macro-name lookup is intentionally deferred to runtime — checking the
 // stored macros table here would require an extra DB roundtrip for every
@@ -154,11 +152,9 @@ func validateFuzzHTTPMacroConfig(label string, cfg *fuzzHTTPMacroConfig) error {
 		scope = "iteration"
 	}
 	switch scope {
-	case "iteration":
-	case "job":
-		return fmt.Errorf("%s: scope=%q is deferred to follow-up: USK-961", label, scope)
+	case "iteration", "job":
 	default:
-		return fmt.Errorf("%s: invalid scope %q (must be iteration; job is deferred to USK-961)", label, scope)
+		return fmt.Errorf("%s: invalid scope %q (must be iteration or job)", label, scope)
 	}
 	switch cfg.OnError {
 	case "", "skip", "abort", "continue":
@@ -299,7 +295,51 @@ func (s *Server) buildFuzzHTTPPlan(ctx context.Context, input *fuzzHTTPInput) (*
 // populated for both successful and error variants. Store-write
 // failures are non-fatal (slog.Warn + continue) — the wire data is on
 // disk via RecordStep and remains the source of truth.
+//
+// USK-961: scope="job" hooks fire exactly once outside the variant
+// loop against a separate job-scoped kvStore that is merged into each
+// iteration's per-variant store. pre-job runs between loop-state setup
+// and the for-variant loop; post-job runs after the loop body exits
+// (including the stop_on_5xx terminal path, but NOT on ctx cancel or
+// pre-job abort).
 func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *fuzzHTTPMacroConfig) ([]fuzzHTTPVariantRow, int, string, error) {
+	loop := buildFuzzHTTPVariantLoop(s, plan, timeout, stopOn5xx, tag, fuzzID, upstreamProxy, preMacro, postMacro)
+
+	// USK-961 pre-job: fire once before the variant loop. Abort short-
+	// circuits the whole job; skip returns success with stopped_reason;
+	// continue records the error and proceeds with whatever jobKVStore
+	// captured.
+	if isJobScope(preMacro) {
+		jobAction, stopReason, retErr := loop.runPreJobMacro(ctx)
+		if retErr != nil {
+			return loop.rows, loop.completed, "", retErr
+		}
+		if jobAction == fuzzHTTPPreJobSkipAll {
+			return loop.rows, loop.completed, stopReason, nil
+		}
+	}
+
+	completedNormally, earlyStopReason, retErr := loop.runVariantLoop(ctx)
+	if retErr != nil {
+		return loop.rows, loop.completed, "", retErr
+	}
+
+	// USK-961 post-job: fire after the variant loop exits. Q5 rule —
+	// post-job fires on natural exhaustion or stop_on_5xx exit, but NOT
+	// on ctx cancel. completedNormally captures "we reached the
+	// post-job firing path through a non-cancel exit".
+	if completedNormally && isJobScope(postMacro) {
+		loop.runPostJobMacro(ctx)
+	}
+
+	return loop.rows, loop.completed, earlyStopReason, nil
+}
+
+// buildFuzzHTTPVariantLoop assembles the per-run state container shared
+// by all variants. Split out of runFuzzHTTPVariants to keep that function
+// below the gocyclo threshold; the construction logic is mechanical and
+// has no branch fan-out outside the hook-config assembly.
+func buildFuzzHTTPVariantLoop(s *Server, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *fuzzHTTPMacroConfig) *fuzzHTTPVariantLoop {
 	loop := &fuzzHTTPVariantLoop{
 		s:             s,
 		plan:          plan,
@@ -326,44 +366,102 @@ func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, ti
 	}
 	loop.rateLimitHost = rateLimitHost
 
-	// hookExecutor is constructed once and reused across iterations so
-	// pre_macro state ("once", "every_n", "on_error") tracks across the
-	// whole fuzz run. The hookExecutor's PreMacro / PostMacro fields are
-	// the engine-facing form: build a hooksInput from the fuzzHTTPMacro
-	// config and force pass_response=true on the post hook so __response_*
-	// reserved keys land in the shared kvStore before the post macro fires.
-	if preMacro != nil || postMacro != nil {
-		hooks := &hooksInput{}
-		if preMacro != nil {
-			hooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
-		}
-		if postMacro != nil {
-			hooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always", PassResponse: true}
-		}
-		loop.hookExec = newHookExecutor(s, hooks, &hookState{})
-	} else {
-		loop.hookExec = newHookExecutor(s, nil, &hookState{})
-	}
+	loop.hookExec = buildIterationHookExecutor(s, preMacro, postMacro)
+	loop.jobHookExec, loop.jobKVStore = buildJobHookExecutor(s, preMacro, postMacro)
 
 	loop.rows = make([]fuzzHTTPVariantRow, 0, plan.totalVariants)
 	loop.indices = make([]int, len(plan.positions))
 
-	for variantIdx := 0; variantIdx < plan.totalVariants; variantIdx++ {
-		stop, retErr := loop.runOne(ctx, variantIdx)
-		if retErr != nil {
-			return loop.rows, loop.completed, "", retErr
-		}
-		if stop != "" {
-			return loop.rows, loop.completed, stop, nil
-		}
+	return loop
+}
+
+// buildIterationHookExecutor returns the hookExecutor used by the
+// per-iteration call sites. It is always non-nil so the gating logic in
+// runOne can dispatch via the executor; when no hook is configured, the
+// executor is a no-op shell. Iteration-scope passes RunInterval="always"
+// (which is also the default in shouldRunPreMacro / shouldRunPostMacro).
+func buildIterationHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) *hookExecutor {
+	if preMacro == nil && postMacro == nil {
+		return newHookExecutor(s, nil, &hookState{})
 	}
-	return loop.rows, loop.completed, "", nil
+	hooks := &hooksInput{}
+	if preMacro != nil {
+		hooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
+	}
+	if postMacro != nil {
+		hooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always", PassResponse: true}
+	}
+	return newHookExecutor(s, hooks, &hookState{})
+}
+
+// buildJobHookExecutor returns (jobHookExec, jobKVStore) for the
+// scope="job" call sites, or (nil, nil) when neither hook is job-scoped.
+// Distinct from buildIterationHookExecutor so the hookState.preMacroExecuted
+// state is not flipped by the job-side single-fire call. Post-job leaves
+// PassResponse off (no per-iteration response is available — Q21).
+func buildJobHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) (*hookExecutor, map[string]string) {
+	if !isJobScope(preMacro) && !isJobScope(postMacro) {
+		return nil, nil
+	}
+	jobHooks := &hooksInput{}
+	if isJobScope(preMacro) {
+		jobHooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
+	}
+	if isJobScope(postMacro) {
+		jobHooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always"}
+	}
+	return newHookExecutor(s, jobHooks, &hookState{}), make(map[string]string)
+}
+
+// runVariantLoop drives the variant loop body and returns
+// (completedNormally, earlyStopReason, retErr). completedNormally is
+// true when the loop reached the post-job firing path (natural
+// exhaustion or stop_on_5xx); it is false on ctx cancel. retErr
+// non-nil signals an unrecoverable abort and post-job MUST NOT fire.
+func (l *fuzzHTTPVariantLoop) runVariantLoop(ctx context.Context) (bool, string, error) {
+	for variantIdx := 0; variantIdx < l.plan.totalVariants; variantIdx++ {
+		stop, retErr := l.runOne(ctx, variantIdx)
+		if retErr != nil {
+			// pre-iteration abort or other unrecoverable error. Per
+			// Q5: post-job does NOT fire on pre-iteration abort.
+			return false, "", retErr
+		}
+		if stop == "" {
+			continue
+		}
+		// stop_on_5xx and ctx cancel both reach here. Per Q5: post-job
+		// fires on stop_on_5xx but NOT on ctx cancel.
+		return !strings.HasPrefix(stop, "ctx cancelled:"), stop, nil
+	}
+	return true, "", nil
+}
+
+// isJobScope reports whether cfg is configured as scope="job". Nil is
+// always false. Empty scope defaults to "iteration".
+func isJobScope(cfg *fuzzHTTPMacroConfig) bool {
+	return cfg != nil && cfg.Scope == "job"
+}
+
+// isIterationScope reports whether cfg is configured as scope="iteration"
+// (or empty, which defaults to iteration). Nil is always false.
+func isIterationScope(cfg *fuzzHTTPMacroConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Scope == "" || cfg.Scope == "iteration"
 }
 
 // fuzzHTTPVariantLoop bundles the per-run state shared across iterations
 // so the inner loop body (runOne) is a method on a small struct instead
 // of an 11-argument free function. The split keeps cyclomatic complexity
 // per method below the project threshold without changing semantics.
+//
+// USK-961 adds jobKVStore + jobHookExec for scope="job" hooks. The two
+// kvStores (per-iteration + job) are deliberately separate: per-iteration
+// reserved keys (§__iteration§ / §__nonce§ / __response_*) overwrite any
+// conflicting keys from the job store at iteration start ("iteration
+// wins" — matches the existing "caller wins" precedent in
+// executePreMacro / executePostMacro's vars-merge dance).
 type fuzzHTTPVariantLoop struct {
 	s             *Server
 	plan          *fuzzHTTPPlan
@@ -378,6 +476,16 @@ type fuzzHTTPVariantLoop struct {
 	pipe          *pipeline.Pipeline
 	dial          session.DialFunc
 	hookExec      *hookExecutor
+	// jobHookExec is the executor for scope="job" hooks. Distinct from
+	// hookExec so the iteration-side hookState.preMacroExecuted state is
+	// not flipped by the job-side single-fire call. Nil when no hook is
+	// scope="job".
+	jobHookExec *hookExecutor
+	// jobKVStore is the kvStore shared across all variants for scope="job"
+	// hooks. pre-job extracts land here; iteration runs copy this into a
+	// fresh per-iteration kvStore before seeding reserved keys; post-job
+	// reads back what pre-job wrote. Nil when no hook is scope="job".
+	jobKVStore    map[string]string
 	rateLimitHost string
 
 	rows      []fuzzHTTPVariantRow
@@ -403,27 +511,19 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		return "", fmt.Errorf("variant %d: decode payloads: %w", variantIdx, err)
 	}
 
-	// Per-iteration kvStore — canonical state container for this variant.
-	// Seeded with §__iteration§ / §__nonce§ via ResolveForIterationWithKV
-	// (or SeedIterationKV when no upstream rotation is configured).
-	kvStore := make(map[string]string)
-	connector.SeedIterationKV(kvStore, variantIdx)
-
-	iterCtx, ipErr := l.upstreamProxy.ResolveForIterationWithKV(ctx, variantIdx, kvStore)
-	if ipErr != nil {
-		l.recordVariantError(ctx, variantIdx, payloads, ipErr.Error())
-		nextIndices(l.indices, l.plan.positions)
-		return "", nil
-	}
-
-	preState, retErr := l.runPreMacro(ctx, iterCtx, variantIdx, payloads, kvStore)
+	prep, stopReason, retErr := l.prepareIteration(ctx, variantIdx, payloads)
 	if retErr != nil {
 		return "", retErr
 	}
-	if preState == fuzzHTTPPreSkipped {
+	if stopReason != "" {
+		return stopReason, nil
+	}
+	if prep.skipped {
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
 	}
+	iterCtx := prep.iterCtx
+	kvStore := prep.kvStore
 
 	if err := l.s.waitRateLimit(ctx, l.rateLimitHost); err != nil {
 		return fmt.Sprintf("rate limit: %v", err), nil
@@ -468,10 +568,12 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	l.s.saveFuzzHTTPResult(ctx, l.fuzzID, variantIdx, row, payloads)
 
 	// pre_macro outcome is guaranteed != fuzzHTTPPreSkipped here (the
-	// skip branch above already short-circuited via continue/return).
-	// Gate post_macro purely on postMacro being configured.
-	_ = preState
-	if l.postMacro != nil {
+	// skip branch above already short-circuited in prepareIteration via
+	// the prep.skipped path).
+	// USK-961: gate post-iteration on scope="iteration" (or empty —
+	// defaults to iteration). scope="job" post runs once after the
+	// variant loop completes.
+	if isIterationScope(l.postMacro) {
 		l.runPostMacro(ctx, iterCtx, variantIdx, row, kvStore)
 	}
 
@@ -481,6 +583,64 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		return fmt.Sprintf("stop_on_5xx: variant %d returned %d", variantIdx, statusCode), nil
 	}
 	return "", nil
+}
+
+// fuzzHTTPIterationPrep holds the per-iteration state produced by
+// prepareIteration: the kvStore (merged from jobKVStore + reserved
+// iteration keys), the iteration-scoped context (carrying upstream-proxy
+// rotation), and the skipped flag set when pre-iteration's on_error=skip
+// short-circuited the variant.
+type fuzzHTTPIterationPrep struct {
+	kvStore map[string]string
+	iterCtx context.Context //nolint:containedctx // iterCtx is plumbed downstream as the per-variant ctx; carrying it on a value struct keeps the prepareIteration signature tractable
+	skipped bool
+}
+
+// prepareIteration handles the per-variant kvStore setup, upstream-proxy
+// resolution, and pre-iteration hook dispatch. Returns
+// (prep, stopReason, retErr): stopReason "" + retErr nil means continue
+// with prep; stopReason non-empty signals a non-fatal early stop
+// (e.g. ctx cancel); retErr non-nil aborts the run; prep.skipped means
+// the iteration was short-circuited and the caller should advance
+// indices and continue to the next variant.
+//
+// Split out of runOne to keep that function below the gocyclo threshold.
+func (l *fuzzHTTPVariantLoop) prepareIteration(ctx context.Context, variantIdx int, payloads map[string]string) (fuzzHTTPIterationPrep, string, error) {
+	// Per-iteration kvStore — canonical state container for this variant.
+	// USK-961 mix-scope path: copy job-scope extracts into the iteration
+	// store BEFORE seeding reserved keys, so pre=job extracts flow into
+	// every variant's template expansion AND per-iteration reserved keys
+	// (§__iteration§, §__nonce§) overwrite any conflicting job-store keys
+	// ("iteration wins" — matches the "caller wins" precedent in
+	// executePreMacro). Seeded with §__iteration§ / §__nonce§ via
+	// ResolveForIterationWithKV (or SeedIterationKV when no upstream
+	// rotation is configured).
+	kvStore := make(map[string]string)
+	for k, v := range l.jobKVStore {
+		kvStore[k] = v
+	}
+	connector.SeedIterationKV(kvStore, variantIdx)
+
+	iterCtx, ipErr := l.upstreamProxy.ResolveForIterationWithKV(ctx, variantIdx, kvStore)
+	if ipErr != nil {
+		l.recordVariantError(ctx, variantIdx, payloads, ipErr.Error())
+		return fuzzHTTPIterationPrep{skipped: true}, "", nil
+	}
+
+	// USK-961: pre-iteration only fires when pre is configured at
+	// scope="iteration" (empty defaults to iteration). When pre is
+	// scope="job", the executor was invoked once outside the loop.
+	if !isIterationScope(l.preMacro) {
+		return fuzzHTTPIterationPrep{kvStore: kvStore, iterCtx: iterCtx}, "", nil
+	}
+	preState, retErr := l.runPreMacro(ctx, iterCtx, variantIdx, payloads, kvStore)
+	if retErr != nil {
+		return fuzzHTTPIterationPrep{}, "", retErr
+	}
+	if preState == fuzzHTTPPreSkipped {
+		return fuzzHTTPIterationPrep{skipped: true}, "", nil
+	}
+	return fuzzHTTPIterationPrep{kvStore: kvStore, iterCtx: iterCtx}, "", nil
 }
 
 // fuzzHTTPPreMacroOutcome marks whether the variant loop should proceed
@@ -552,6 +712,101 @@ func (l *fuzzHTTPVariantLoop) runPostMacro(ctx context.Context, iterCtx context.
 	}
 	l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, variantIdx, "post", "", "ok", responseStatus, "")
 }
+
+// fuzzHTTPJobPreOutcome marks the pre-job hook's effect on the
+// surrounding job loop.
+type fuzzHTTPJobPreOutcome int
+
+const (
+	// fuzzHTTPPreJobOK = pre-job ran successfully (or under
+	// on_error=continue): proceed with the variant loop.
+	fuzzHTTPPreJobOK fuzzHTTPJobPreOutcome = iota
+	// fuzzHTTPPreJobSkipAll = pre-job failed under on_error=skip: skip
+	// the entire job. fuzz_http returns a successful result with
+	// CompletedVariants=0 and stopped_reason set (U1 user-confirmed).
+	fuzzHTTPPreJobSkipAll
+)
+
+// runPreJobMacro fires the pre_macro hook ONCE outside the variant loop
+// (scope="job"). Behavior on failure follows the OnError policy:
+//
+//   - abort: return a wrapped error that aborts the whole job before any
+//     variant runs (caller propagates as retErr).
+//   - continue: log warn, record a fuzz_macro_results row at
+//     index_num=-1, status="error"; proceed with whatever jobKVStore
+//     captured.
+//   - skip: record a fuzz_macro_results row at index_num=-1,
+//     status="skipped"; return fuzzHTTPPreJobSkipAll so the caller
+//     short-circuits the whole job with a stopped_reason (U1).
+//
+// fuzz_macro_results.index_num=-1 is the documented sentinel for
+// job-scope hook rows (see FuzzMacroResult.IndexNum doc comment).
+func (l *fuzzHTTPVariantLoop) runPreJobMacro(ctx context.Context) (fuzzHTTPJobPreOutcome, string, error) {
+	if l.jobHookExec == nil || l.preMacro == nil || !isJobScope(l.preMacro) {
+		return fuzzHTTPPreJobOK, "", nil
+	}
+	_, hookErr := l.jobHookExec.executePreMacro(ctx, l.jobKVStore)
+	if hookErr == nil {
+		l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "pre", "", "ok", 0, "")
+		return fuzzHTTPPreJobOK, "", nil
+	}
+	policy := l.preMacro.OnError
+	if policy == "" {
+		policy = "skip"
+	}
+	switch policy {
+	case "abort":
+		l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "pre", "", "error", 0, hookErr.Error())
+		return fuzzHTTPPreJobOK, "", fmt.Errorf("pre_macro hook abort (scope=job): %w", hookErr)
+	case "continue":
+		slog.WarnContext(ctx, "fuzz_http: pre_macro hook error (scope=job, on_error=continue)",
+			"fuzz_id", l.fuzzID, "error", hookErr)
+		l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "pre", "", "error", 0, hookErr.Error())
+		return fuzzHTTPPreJobOK, "", nil
+	default: // skip — short-circuit the whole job with stopped_reason (U1)
+		l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "pre", "", "skipped", 0, hookErr.Error())
+		stopReason := fmt.Sprintf("pre_macro hook skipped (scope=job, on_error=skip): %v", hookErr)
+		return fuzzHTTPPreJobSkipAll, stopReason, nil
+	}
+}
+
+// runPostJobMacro fires the post_macro hook ONCE after the variant loop
+// completes (scope="job"). Q5 rule: post-job fires on natural
+// exhaustion or stop_on_5xx, but NOT on ctx cancel (the caller gates
+// the call on completedNormally). Q21: post-job sees only the
+// jobKVStore — per-iteration response keys (__response_*) are NOT
+// available because each iteration's kvStore was discarded.
+//
+// Failures NEVER abort the run (the loop already completed); record a
+// fuzz_macro_results row at index_num=-1 and return. Matches
+// per-iteration post precedent (post failures don't escalate to retErr).
+func (l *fuzzHTTPVariantLoop) runPostJobMacro(ctx context.Context) {
+	if l.jobHookExec == nil || l.postMacro == nil || !isJobScope(l.postMacro) {
+		return
+	}
+	// Post-job has no per-iteration response to inject. Pass zero values
+	// for status / body / headers so executePostMacro's PassResponse
+	// branch is a no-op (we deliberately leave PassResponse=false in the
+	// jobHookExec.hooks.PostMacro config — but defensively pass zero
+	// values anyway so a future enable wouldn't leak stale data).
+	hookErr := l.jobHookExec.executePostMacro(ctx, 0, nil, nil, l.jobKVStore)
+	if hookErr != nil {
+		slog.WarnContext(ctx, "fuzz_http: post_macro hook error (scope=job)",
+			"fuzz_id", l.fuzzID, "error", hookErr)
+		l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "post", "", "error", 0, hookErr.Error())
+		return
+	}
+	l.s.saveFuzzMacroHookResult(ctx, l.fuzzID, jobScopeIndexNumSentinel, "post", "", "ok", 0, "")
+}
+
+// jobScopeIndexNumSentinel is the fuzz_macro_results.index_num value
+// recorded for scope="job" hook outcomes. Per-iteration rows use the
+// 0-based variant index; job-scope rows use -1 so the row keys
+// (fuzz_id, index_num, hook_name) remain unique without a schema
+// migration (USK-961 Q7). The schema column is INTEGER NOT NULL — -1
+// is a legal value, NULL is not. There are no external consumers of
+// fuzz_macro_results today, so the sentinel is structurally invisible.
+const jobScopeIndexNumSentinel = -1
 
 // recordVariantError appends a synthetic error-row to the variant rows
 // (no upstream send happened) and persists the matching fuzz_results

--- a/internal/mcp/fuzz_http_macro_integration_test.go
+++ b/internal/mcp/fuzz_http_macro_integration_test.go
@@ -668,52 +668,619 @@ func TestFuzzHTTPMacro_OnErrorContinue_UnresolvedDiagInPositionPayload(t *testin
 }
 
 // ---------------------------------------------------------------------------
-// AC#4 — scope="job" deferral: validation reject with USK-961 message.
+// USK-961 — scope="job" + mix-scope tests.
 // ---------------------------------------------------------------------------
 
-func TestFuzzHTTPMacro_ScopeJobRejectedAsDeferredToUSK961(t *testing.T) {
+// TestFuzzHTTPMacro_ScopeJobPreSharesKVAcrossVariants covers AC#1 +
+// AC#2 of USK-961: pre=job login once → fuzz N variants share the
+// extracted token via templated header; post=iteration audits each.
+// Asserts pre-job fires exactly once (fuzz_macro_results row at
+// index_num=-1, hook_name="pre"); post-iteration fires N times.
+func TestFuzzHTTPMacro_ScopeJobPreSharesKVAcrossVariants(t *testing.T) {
 	cs, store := setupFuzzHTTPMacroSession(t)
 
-	// We don't need a working pre macro target — validation rejects
-	// before runtime. Define a minimal macro so the runtime path would
-	// otherwise succeed.
-	dummyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// preServer issues the same session_token every call so we can
+	// assert every variant sees the same value.
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		fmt.Fprint(w, `{"session_token":"job-tok-shared"}`)
+	}))
+	t.Cleanup(preServer.Close)
+
+	// postServer records the URL query so we can assert the post macro's
+	// OverrideURL expanded against per-iteration kvStore + the inherited
+	// pre-job extract.
+	var postRecords atomic.Pointer[[]map[string]string]
+	postServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := map[string]string{"query": r.URL.RawQuery}
+		for {
+			old := postRecords.Load()
+			var cur []map[string]string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, rec)
+			if postRecords.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(postServer.Close)
+
+	// fuzzServer records the X-Token header so we can confirm every
+	// variant carried the pre-job extracted token.
+	var fuzzTokens atomic.Pointer[[]string]
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("X-Token")
+		for {
+			old := fuzzTokens.Load()
+			var cur []string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, tok)
+			if fuzzTokens.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(dummyServer.Close)
-	flowID := recordMacroFlow(t, store, "POST", dummyServer.URL+"/x", nil, nil)
-	defineMacroForTest(t, cs, "noop-macro", flowID, "", "", nil)
+	t.Cleanup(fuzzServer.Close)
 
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	postFlowID := recordMacroFlow(t, store, "POST", postServer.URL+"/audit", nil, nil)
+
+	defineMacroForTest(t, cs, "pre-job-login", preFlowID, "", "", []map[string]any{
+		{
+			"name":      "session_token",
+			"from":      "response",
+			"source":    "body_json",
+			"json_path": "$.session_token",
+			"required":  true,
+		},
+	})
+	// post-iteration audits each variant's status. References §session_token§
+	// to confirm job-store extracts are merged into per-iteration kvStore.
+	overrideURL := postServer.URL + "/audit?iter=§__iteration§&token=§session_token§"
+	defineMacroForTest(t, cs, "post-iter-audit", postFlowID, overrideURL, "audit", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
 	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
 		Name: "fuzz_http",
 		Arguments: map[string]any{
 			"method":    "GET",
 			"scheme":    "http",
-			"authority": "127.0.0.1:1",
-			"path":      "/x",
+			"authority": authority,
+			"path":      "/probe",
 			"headers": []map[string]any{
-				{"name": "Host", "value": "127.0.0.1:1"},
+				{"name": "Host", "value": authority},
+				{"name": "X-Token", "value": "§session_token§"},
 			},
 			"positions": []map[string]any{
-				{"path": "path", "payloads": []string{"/a"}},
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
 			},
-			"timeout_ms": 1000,
-			"pre_macro":  map[string]any{"name": "noop-macro", "scope": "job"},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-job-login", "scope": "job"},
+			"post_macro": map[string]any{"name": "post-iter-audit", "scope": "iteration"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.CompletedVariants != 3 {
+		t.Fatalf("CompletedVariants = %d, want 3", out.CompletedVariants)
+	}
+
+	// AC: pre-job called exactly once.
+	if got := atomic.LoadInt32(&preCalls); got != 1 {
+		t.Errorf("pre macro called %d times, want 1 (scope=job)", got)
+	}
+
+	// AC: every variant carried the shared token.
+	tokens := *fuzzTokens.Load()
+	if len(tokens) != 3 {
+		t.Fatalf("fuzz received %d requests, want 3", len(tokens))
+	}
+	for i, tok := range tokens {
+		if tok != "job-tok-shared" {
+			t.Errorf("variant %d X-Token = %q, want job-tok-shared", i, tok)
+		}
+	}
+
+	// AC: post-iteration called 3 times. The OverrideURL referenced
+	// §session_token§ so post-iteration confirms the job-store extract
+	// is merged into each iteration's kvStore.
+	if postRecords.Load() == nil {
+		t.Fatal("post server received no requests")
+	}
+	pRecs := *postRecords.Load()
+	if len(pRecs) != 3 {
+		t.Fatalf("post server received %d requests, want 3", len(pRecs))
+	}
+	for i, rec := range pRecs {
+		if !strings.Contains(rec["query"], "token=job-tok-shared") {
+			t.Errorf("post-iter[%d] query = %q, want to contain token=job-tok-shared", i, rec["query"])
+		}
+	}
+
+	// AC: fuzz_macro_results — 1 pre row (index_num=-1, hook="pre") + 3
+	// post rows (index_num=0..2, hook="post"), all "ok".
+	fs := store.(flow.FuzzStore)
+	results, err := fs.ListFuzzMacroResults(context.Background(), out.FuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 4", len(results))
+	}
+	preRows, postRows := 0, 0
+	for _, r := range results {
+		if r.Status != "ok" {
+			t.Errorf("row hook=%s idx=%d status=%q, want ok (err=%q)", r.HookName, r.IndexNum, r.Status, r.Error)
+		}
+		switch r.HookName {
+		case "pre":
+			preRows++
+			if r.IndexNum != -1 {
+				t.Errorf("pre row index_num = %d, want -1 (job-scope sentinel)", r.IndexNum)
+			}
+		case "post":
+			postRows++
+			if r.IndexNum < 0 || r.IndexNum >= 3 {
+				t.Errorf("post row index_num = %d, want 0..2", r.IndexNum)
+			}
+		}
+	}
+	if preRows != 1 {
+		t.Errorf("pre rows = %d, want 1", preRows)
+	}
+	if postRows != 3 {
+		t.Errorf("post rows = %d, want 3", postRows)
+	}
+}
+
+// TestFuzzHTTPMacro_ScopeJobPostFiresOnceAfterLoop covers the mix-scope
+// pre=iteration + post=job case. Asserts post-job fires exactly once
+// after the last variant, with index_num=-1. Also asserts post-job's
+// kvStore does NOT contain __response_* keys (Q4 / Q21).
+func TestFuzzHTTPMacro_ScopeJobPostFiresOnceAfterLoop(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	// preServer rotates a per-iteration token.
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&preCalls, 1)
+		fmt.Fprintf(w, `{"per_iter_token":"tok-%d"}`, n)
+	}))
+	t.Cleanup(preServer.Close)
+
+	// postServer records the URL query so we can assert the post-job
+	// template did NOT see any __response_* keys (they should be left
+	// literal because the kvStore for post-job is the job kvStore, not
+	// the discarded per-iteration store).
+	var postRecords atomic.Pointer[[]map[string]string]
+	postServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := map[string]string{"query": r.URL.RawQuery}
+		for {
+			old := postRecords.Load()
+			var cur []map[string]string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, rec)
+			if postRecords.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(postServer.Close)
+
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	postFlowID := recordMacroFlow(t, store, "POST", postServer.URL+"/summary", nil, nil)
+
+	defineMacroForTest(t, cs, "pre-iter-rotate", preFlowID, "", "", []map[string]any{
+		{
+			"name":      "per_iter_token",
+			"from":      "response",
+			"source":    "body_json",
+			"json_path": "$.per_iter_token",
+			"required":  true,
+		},
+	})
+	// Post-job's OverrideURL references __response_status — for post-job
+	// scope this key should NOT be in the kvStore, so the template
+	// resolves to the literal "§__response_status§".
+	overrideURL := postServer.URL + "/summary?rs=§__response_status§"
+	defineMacroForTest(t, cs, "post-job-summary", postFlowID, overrideURL, "summary", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-iter-rotate", "scope": "iteration"},
+			"post_macro": map[string]any{"name": "post-job-summary", "scope": "job"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != 2 {
+		t.Fatalf("CompletedVariants = %d, want 2", out.CompletedVariants)
+	}
+
+	// AC: pre-iteration called twice; post-job called once.
+	if got := atomic.LoadInt32(&preCalls); got != 2 {
+		t.Errorf("pre called %d times, want 2 (scope=iteration)", got)
+	}
+	if postRecords.Load() == nil {
+		t.Fatal("post server received no requests")
+	}
+	pRecs := *postRecords.Load()
+	if len(pRecs) != 1 {
+		t.Fatalf("post server received %d requests, want 1 (scope=job)", len(pRecs))
+	}
+
+	// AC: post-job kvStore did NOT carry __response_status — the
+	// template is left literal because the variable was never set.
+	if !strings.Contains(pRecs[0]["query"], "rs=%C2%A7__response_status%C2%A7") &&
+		!strings.Contains(pRecs[0]["query"], "rs=§__response_status§") {
+		t.Errorf("post-job query = %q, want literal §__response_status§ (post-job must not see __response_* keys)", pRecs[0]["query"])
+	}
+
+	// AC: fuzz_macro_results — 2 pre rows (index_num=0,1) + 1 post row
+	// (index_num=-1), all ok.
+	fs := store.(flow.FuzzStore)
+	results, err := fs.ListFuzzMacroResults(context.Background(), out.FuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 3", len(results))
+	}
+	preRows, postRows := 0, 0
+	for _, r := range results {
+		switch r.HookName {
+		case "pre":
+			preRows++
+			if r.IndexNum < 0 || r.IndexNum >= 2 {
+				t.Errorf("pre row index_num = %d, want 0..1", r.IndexNum)
+			}
+		case "post":
+			postRows++
+			if r.IndexNum != -1 {
+				t.Errorf("post row index_num = %d, want -1 (job-scope sentinel)", r.IndexNum)
+			}
+		}
+	}
+	if preRows != 2 {
+		t.Errorf("pre rows = %d, want 2", preRows)
+	}
+	if postRows != 1 {
+		t.Errorf("post rows = %d, want 1", postRows)
+	}
+}
+
+// TestFuzzHTTPMacro_ScopeJobPreAbortOnErrorAbortsJob covers pre=job +
+// on_error=abort + failing macro: zero variants run; caller-side error
+// contains "pre_macro hook abort (scope=job)"; one fuzz_macro_results
+// row at index_num=-1, status="error".
+func TestFuzzHTTPMacro_ScopeJobPreAbortOnErrorAbortsJob(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	// preServer returns 500 — required extract fails — abort policy.
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	defineMacroForTest(t, cs, "pre-required-job-abort", preFlowID, "", "", []map[string]any{
+		{
+			"name":      "session_token",
+			"from":      "response",
+			"source":    "body_json",
+			"json_path": "$.session_token",
+			"required":  true,
+		},
+	})
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-required-job-abort", "scope": "job", "on_error": "abort"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("CallTool fuzz_http: %v", err)
 	}
 	if !res.IsError {
-		t.Fatal("expected IsError for scope=job, got success")
+		t.Fatal("expected IsError for pre=job + on_error=abort, got success")
 	}
+
 	var msg strings.Builder
 	for _, c := range res.Content {
 		if tc, ok := c.(*gomcp.TextContent); ok {
 			msg.WriteString(tc.Text)
 		}
 	}
-	if !strings.Contains(msg.String(), "USK-961") {
-		t.Errorf("error message = %q, want to contain USK-961", msg.String())
+	if !strings.Contains(msg.String(), "pre_macro hook abort (scope=job)") {
+		t.Errorf("error = %q, want to contain 'pre_macro hook abort (scope=job)'", msg.String())
+	}
+
+	if got := atomic.LoadInt32(&fuzzCalls); got != 0 {
+		t.Errorf("fuzz server saw %d requests, want 0 (pre-job abort must short-circuit before any variant)", got)
+	}
+
+	// Look up the fuzz_id from the fuzz_jobs table — we need it to
+	// query fuzz_macro_results. The pre_macro hook saved a row with
+	// fuzzID set, so we list all macro results and find the matching
+	// one. (Alternative: use a deterministic fuzz_id, but the tool
+	// generates one internally.)
+	fs := store.(flow.FuzzStore)
+	jobs, err := fs.ListFuzzJobs(context.Background(), flow.FuzzJobListOptions{})
+	if err != nil {
+		t.Fatalf("ListFuzzJobs: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatal("no fuzz_jobs row recorded; pre-job abort must still create the job row")
+	}
+	// Take the most recent job.
+	fuzzID := jobs[0].ID
+	results, err := fs.ListFuzzMacroResults(context.Background(), fuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 1", len(results))
+	}
+	r := results[0]
+	if r.HookName != "pre" {
+		t.Errorf("hook_name = %q, want pre", r.HookName)
+	}
+	if r.IndexNum != -1 {
+		t.Errorf("index_num = %d, want -1 (job-scope sentinel)", r.IndexNum)
+	}
+	if r.Status != "error" {
+		t.Errorf("status = %q, want error (on_error=abort + failure)", r.Status)
+	}
+}
+
+// TestFuzzHTTPMacro_ScopeJobIndexNumSentinel asserts that
+// ListFuzzMacroResults rows for job-scope hooks have IndexNum == -1
+// exactly (covers AC#5 of USK-961).
+func TestFuzzHTTPMacro_ScopeJobIndexNumSentinel(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"k":"v"}`)
+	}))
+	t.Cleanup(preServer.Close)
+	postServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(postServer.Close)
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	postFlowID := recordMacroFlow(t, store, "POST", postServer.URL+"/sum", nil, nil)
+	defineMacroForTest(t, cs, "pre-noop-job", preFlowID, "", "", nil)
+	defineMacroForTest(t, cs, "post-noop-job", postFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-noop-job", "scope": "job"},
+			"post_macro": map[string]any{"name": "post-noop-job", "scope": "job"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+
+	fs := store.(flow.FuzzStore)
+	results, err := fs.ListFuzzMacroResults(context.Background(), out.FuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	// Both job-scope hooks must produce exactly one row each at
+	// index_num=-1.
+	if len(results) != 2 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 2", len(results))
+	}
+	for _, r := range results {
+		if r.IndexNum != -1 {
+			t.Errorf("hook=%s index_num = %d, want -1 (job-scope sentinel)", r.HookName, r.IndexNum)
+		}
+		if r.Status != "ok" {
+			t.Errorf("hook=%s status = %q, want ok", r.HookName, r.Status)
+		}
+	}
+}
+
+// TestFuzzHTTPMacro_ScopeJobPreSkipOnErrorReturnsStoppedReason covers
+// U1 (user-confirmed): pre=job + on_error=skip + failing macro returns
+// success with CompletedVariants=0 and stopped_reason set. One
+// fuzz_macro_results row at index_num=-1, status="skipped".
+func TestFuzzHTTPMacro_ScopeJobPreSkipOnErrorReturnsStoppedReason(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	defineMacroForTest(t, cs, "pre-required-job-skip", preFlowID, "", "", []map[string]any{
+		{
+			"name":      "session_token",
+			"from":      "response",
+			"source":    "body_json",
+			"json_path": "$.session_token",
+			"required":  true,
+		},
+	})
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-required-job-skip", "scope": "job", "on_error": "skip"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned unexpected error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+
+	if out.CompletedVariants != 0 {
+		t.Errorf("CompletedVariants = %d, want 0 (pre-job skip must short-circuit before any variant)", out.CompletedVariants)
+	}
+	if !strings.Contains(out.StoppedReason, "pre_macro hook skipped (scope=job, on_error=skip)") {
+		t.Errorf("StoppedReason = %q, want to contain 'pre_macro hook skipped (scope=job, on_error=skip)'", out.StoppedReason)
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); got != 0 {
+		t.Errorf("fuzz server saw %d requests, want 0", got)
+	}
+
+	fs := store.(flow.FuzzStore)
+	results, err := fs.ListFuzzMacroResults(context.Background(), out.FuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 1", len(results))
+	}
+	r := results[0]
+	if r.HookName != "pre" || r.IndexNum != -1 || r.Status != "skipped" {
+		t.Errorf("row = {hook=%q, index_num=%d, status=%q}, want {hook=pre, index_num=-1, status=skipped}",
+			r.HookName, r.IndexNum, r.Status)
 	}
 }

--- a/internal/mcp/resources/help_fuzz_http.md
+++ b/internal/mcp/resources/help_fuzz_http.md
@@ -53,6 +53,42 @@ When `true`, abort the remaining variants once any variant returns a 5xx respons
 ### timeout_ms (integer, optional)
 Per-VARIANT timeout in milliseconds. Default `30000`.
 
+### pre_macro / post_macro (object, optional)
+
+Pre and post macro hooks dispatched around variants by name. Both fields take the same shape (USK-960, USK-961):
+
+- **name** (string, REQUIRED): the stored macro name (defined via the `macro` tool's `define_macro` action).
+- **scope** (string, optional): `"iteration"` (default) or `"job"`. See "Macro hook scopes" below.
+- **on_error** (string, optional): `"skip"` (default) | `"abort"` | `"continue"`. See "OnError semantics" below.
+
+The hook macro shares the per-iteration (or per-job) KV Store with the fuzz request — `§var§` templates in the request inherit pre-macro extracts, and post-macros (scope=iteration only) receive `__response_status` / `__response_body` / `__response_headers__<lower(name)>__` reserved keys.
+
+#### Macro hook scopes
+
+| Scope | Pre fires | Post fires | KV Store lifetime | `__response_*` keys | `§__iteration§` / `§__nonce§` |
+|-------|-----------|------------|-------------------|---------------------|-------------------------------|
+| `iteration` (default) | Before each variant's send | After each variant's response | Fresh per variant | Visible to post | Seeded each iteration |
+| `job` | Once before the variant loop | Once after the variant loop (incl. `stop_on_5xx` exit) | Shared across the whole job | NOT visible | NOT seeded |
+
+Mix-scope is supported — `pre_macro` and `post_macro` may pick their scope independently. The job-scope KV Store is merged into each iteration's per-variant store at iteration start; per-iteration reserved keys then overwrite any conflicting job keys ("iteration wins"). So `pre_macro { scope: "job" }` extracting `session_token` makes `§session_token§` resolvable in every variant's request templates.
+
+> `run_interval` is the underlying engine knob for `every_n` / `on_status` / etc. dispatch. It is rejected when `scope="job"` because the hook fires exactly once by construction (the call site, not `run_interval`, owns the single-fire guarantee).
+
+#### OnError semantics
+
+| OnError | pre / scope=iteration | pre / scope=job | post / either scope |
+|---------|----------------------|-----------------|--------------------|
+| `skip` (default) | Skip the variant: don't send, don't run post. Record `fuzz_macro_results.status="skipped"`. | Skip the entire job — `completed_variants=0`, `stopped_reason="pre_macro hook skipped (scope=job, on_error=skip): ..."`. | Record `fuzz_macro_results.status="error"`. Never aborts the run. |
+| `abort` | Abort the whole fuzz run with an error. | Abort the whole job before any variant runs. | Record `fuzz_macro_results.status="error"`. Never aborts (post-job runs after the loop has completed; nothing left to abort). |
+| `continue` | Log warn + record error row, proceed with whatever the kvStore captured; templates may carry unresolved `§var§` literals (surfaced in `fuzz_results.error`). | Log warn + record error row, proceed with variant loop. | Same as `skip` for post. |
+
+#### fuzz_macro_results schema notes
+
+The `fuzz_macro_results` table (one row per hook invocation) keys on `(fuzz_id, index_num, hook_name)`:
+
+- **`index_num`** is the 0-based variant index for `scope="iteration"` rows.
+- **`index_num = -1`** is the sentinel for `scope="job"` rows — pre-job and post-job each emit a single row at `index_num=-1`. This avoids a schema migration. There are no external consumers (the `query` MCP tool does not surface `fuzz_macro_results` today); the sentinel is consumed only by internal tooling.
+
 ## Result fields
 
 - `fuzz_id` (string, UUID) — primary key of the `fuzz_jobs` row created for this run. Chain with `query { resource: "fuzz_results", filter: { fuzz_id: "...", outliers_only: true } }` to surface outlier variants without re-running the fuzz job (USK-827 + USK-278).
@@ -150,3 +186,23 @@ Variant Streams are stamped `origin = "fuzz"`, so `query { resource: "flows", fi
   ]
 }
 ```
+
+### Mix-scope macro hooks: login once, fuzz N, summarise once
+```json
+{
+  "method": "GET",
+  "scheme": "https",
+  "authority": "api.target.com",
+  "path": "/v1/profile",
+  "headers": [
+    {"name": "Host", "value": "api.target.com"},
+    {"name": "Authorization", "value": "Bearer §session_token§"}
+  ],
+  "positions": [
+    {"path": "headers[1].value", "payloads": ["Bearer §session_token§", "Bearer §session_token§ "]}
+  ],
+  "pre_macro":  {"name": "login-once", "scope": "job"},
+  "post_macro": {"name": "audit-summary", "scope": "job"}
+}
+```
+`pre_macro` (scope=job) runs once before the variant loop, extracts `session_token` into the job-scoped KV Store; every variant then sees `§session_token§` in the templated `Authorization` header. `post_macro` (scope=job) runs once after the loop completes — it can summarise the run via its own template against the job-scoped KV Store.

--- a/internal/mcp/resources/schema_fuzz_http.json
+++ b/internal/mcp/resources/schema_fuzz_http.json
@@ -119,6 +119,50 @@
     "stop_on_5xx": {
       "type": "boolean",
       "description": "When true, abort the remaining variants once any variant returns a 5xx response."
+    },
+    "pre_macro": {
+      "type": "object",
+      "description": "Pre macro hook executed before a variant's send (scope=iteration) or before the variant loop starts (scope=job). The hook macro shares the KV Store with the fuzz request so extracts flow into §var§ template expansion. For scope=job + on_error=skip, the whole job short-circuits with completed_variants=0 and stopped_reason set.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Stored macro name (defined via the macro tool's define_macro action)."
+        },
+        "scope": {
+          "type": "string",
+          "description": "iteration (default; fires once per variant) | job (fires once outside the variant loop; KV Store is shared across the whole job).",
+          "enum": ["iteration", "job"]
+        },
+        "on_error": {
+          "type": "string",
+          "description": "skip (default; iteration scope skips the variant, job scope skips the whole job) | abort (aborts the whole fuzz run) | continue (record the error and proceed).",
+          "enum": ["skip", "abort", "continue"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "post_macro": {
+      "type": "object",
+      "description": "Post macro hook executed after a variant's response (scope=iteration) or after the variant loop completes (scope=job). For scope=iteration, pass_response is forced on so __response_status / __response_body / __response_headers__<lower(name)>__ reserved keys are visible to the macro's template expansion. For scope=job, no per-iteration response is injected (the loop is over). Fires on natural exhaustion or stop_on_5xx exit, but NOT on ctx cancel.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Stored macro name (defined via the macro tool's define_macro action)."
+        },
+        "scope": {
+          "type": "string",
+          "description": "iteration (default; fires once per variant) | job (fires once after the variant loop completes).",
+          "enum": ["iteration", "job"]
+        },
+        "on_error": {
+          "type": "string",
+          "description": "skip (default; log warn + record error row) | abort (post failures never abort the run; behaviour matches skip for post) | continue (same as skip).",
+          "enum": ["skip", "abort", "continue"]
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

- Loosen validation: `pre_macro.scope` / `post_macro.scope` now accept `"job"` (previously rejected with `USK-961` deferral error).
- New job-scope semantics: pre-job fires once before the variant loop, post-job fires once after the loop, kvStore is shared across the whole job.
- Mix-scope works: any combination of `pre.scope` and `post.scope` ∈ {iteration, job}. jobKVStore is merged into per-iteration kvStore at iteration start; reserved iteration keys overwrite any conflicting job keys ("iteration wins").
- `fuzz_macro_results.index_num = -1` is the sentinel for job-scope rows (documented in `FuzzMacroResult.IndexNum`, `schema.go` table comment, and `help_fuzz_http.md`); avoids a schema migration since there are no external consumers of `fuzz_macro_results` today.
- Documentation: `help_fuzz_http.md` + `schema_fuzz_http.json` gain a new "Macro hooks" section covering both scopes, mix-scope, `__response_*` availability rule, and post-job-on-stop_on_5xx behaviour. (USK-960 had left these stale.)
- Deleted `TestFuzzHTTPMacro_ScopeJobRejectedAsDeferredToUSK961`. Added 5 new e2e tests covering: pre-job-shares-kv, post-job-fires-once, pre-job-abort, pre-job-skip-stopped-reason (U1), index_num=-1 sentinel.

## Design decisions

Followed the `/orchestrate` Phase 1.5 design review (2026-05-22). Key resolved choices:

- **Two-store kvStore layout** (jobKVStore + per-iteration kvStore), merged at iteration start with iteration reserved keys winning conflicts.
- **Sentinel `index_num=-1`** over a schemaV18 migration (no external consumers today).
- **`on_error=skip` for pre-job** returns success with `stopped_reason` (mirrors `stop_on_5xx` precedent; user-confirmed U1).
- **post-job fires on `stop_on_5xx`** but NOT on ctx cancel or pre-iteration abort (matches `finalizeFuzzHTTPJob`'s status rule).
- **Two hookExecutor instances** (iteration + job) so the `preMacroExecuted` state-flip on the job-side doesn't trip per-iteration sibling dispatch.

## Test plan

- [x] `make lint` passes
- [x] `make build` succeeds
- [x] `make test` passes (fast tier; full flow tests take ~7m with race; mcp tests ~9m)
- [x] All USK-960 e2e tests still pass (4/4 green under `-tags e2e`)
- [x] All 5 new USK-961 e2e tests pass (5/5 green under `-tags e2e`)
- [x] Spot-checked `fuzz_macro_results` rows in the integration tests carry `index_num=-1` for job-scope hooks and `index_num=0..N-1` for iteration-scope hooks

Resolves USK-961
Linear: https://linear.app/usk6666/issue/USK-961

🤖 Generated with [Claude Code](https://claude.com/claude-code)