### PR TITLE
fix(webui/Security): preserve zero as unlimited in RateLimits and Budget forms

### DIFF
--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -1445,7 +1445,12 @@ export interface SecurityTestTargetResult {
   tested_target: TestedTarget;
 }
 
-/** Rate limit configuration (mirrors Go proxy.RateLimitConfig). */
+/**
+ * Rate limit configuration (mirrors Go `connector.RateLimitConfig`).
+ *
+ * All fields use 0 = "no limit" as the unlimited sentinel. The wire never
+ * sends null/undefined for these fields; they are always present as numbers.
+ */
 export interface RateLimitConfig {
   max_requests_per_second: number;
   max_requests_per_host_per_second: number;
@@ -1465,7 +1470,13 @@ export interface SecurityGetRateLimitsResult {
   effective: RateLimitConfig;
 }
 
-/** Budget configuration (mirrors Go proxy.BudgetConfig). */
+/**
+ * Budget configuration (mirrors Go `connector.BudgetConfig`).
+ *
+ * `max_total_requests` uses 0 as the "no agent override" sentinel; `max_duration`
+ * uses "" or "0s" for the same meaning. The wire never sends null/undefined for
+ * these fields; they are always present as a number / string respectively.
+ */
 export interface BudgetConfig {
   max_total_requests: number;
   max_duration: string;

--- a/web/src/pages/Security/Budget.tsx
+++ b/web/src/pages/Security/Budget.tsx
@@ -67,11 +67,11 @@ export function Budget() {
   }, [status]);
 
   // Sync form state when data changes and not editing.
+  // Render numeric max_total_requests unconditionally so an explicit 0 (no agent
+  // override / policy applies) is faithfully shown rather than collapsing to "".
   useEffect(() => {
     if (data && !editing) {
-      setAgentMaxRequests(
-        data.agent.max_total_requests > 0 ? String(data.agent.max_total_requests) : "",
-      );
+      setAgentMaxRequests(String(data.agent.max_total_requests));
       setAgentMaxDuration(
         data.agent.max_duration !== "0s" && data.agent.max_duration !== ""
           ? data.agent.max_duration
@@ -124,9 +124,9 @@ export function Budget() {
   const handleCancel = useCallback(() => {
     setEditing(false);
     if (data) {
-      setAgentMaxRequests(
-        data.agent.max_total_requests > 0 ? String(data.agent.max_total_requests) : "",
-      );
+      // Symmetric with the sync effect above: render numeric max_total_requests
+      // unconditionally so an explicit 0 survives the cancel-revert path.
+      setAgentMaxRequests(String(data.agent.max_total_requests));
       setAgentMaxDuration(
         data.agent.max_duration !== "0s" && data.agent.max_duration !== ""
           ? data.agent.max_duration

--- a/web/src/pages/Security/RateLimits.tsx
+++ b/web/src/pages/Security/RateLimits.tsx
@@ -50,10 +50,13 @@ export function RateLimits() {
   }, [status, fetchRateLimits]);
 
   // Sync form state when data changes and not editing.
+  // Render numeric values unconditionally — backend RateLimitConfig is bi-state
+  // (number always present; 0 = no limit). Collapsing 0 to "" would hide an
+  // explicit "unlimited" setting and let the operator overwrite it unintentionally.
   useEffect(() => {
     if (data && !editing) {
-      setAgentRps(data.agent.max_requests_per_second > 0 ? String(data.agent.max_requests_per_second) : "");
-      setAgentHostRps(data.agent.max_requests_per_host_per_second > 0 ? String(data.agent.max_requests_per_host_per_second) : "");
+      setAgentRps(String(data.agent.max_requests_per_second));
+      setAgentHostRps(String(data.agent.max_requests_per_host_per_second));
     }
   }, [data, editing]);
 
@@ -92,8 +95,10 @@ export function RateLimits() {
   const handleCancel = useCallback(() => {
     setEditing(false);
     if (data) {
-      setAgentRps(data.agent.max_requests_per_second > 0 ? String(data.agent.max_requests_per_second) : "");
-      setAgentHostRps(data.agent.max_requests_per_host_per_second > 0 ? String(data.agent.max_requests_per_host_per_second) : "");
+      // Symmetric with the sync effect above: render numeric values unconditionally
+      // so an explicit 0 (unlimited) survives the cancel-revert path.
+      setAgentRps(String(data.agent.max_requests_per_second));
+      setAgentHostRps(String(data.agent.max_requests_per_host_per_second));
     }
   }, [data]);
 


### PR DESCRIPTION
## Summary
- `RateLimits.tsx`: form sync and cancel-revert paths no longer collapse an explicit `0 (unlimited)` to empty string; the input now faithfully shows the server's numeric value.
- `Budget.tsx`: same fix for the identical anti-pattern at L67-73 / L124-128 (orchestrator scope expansion — surfaced by the Phase 1.5 design review).
- `types.ts`: JSDoc clarifications on `RateLimitConfig` and `BudgetConfig` documenting the bi-state wire (0 = no limit / no-override sentinel; wire never sends null).

The wire is bi-state — backend `connector.RateLimitConfig.MaxRequestsPerSecond` is plain `float64` (no `*float64`, no `,omitempty`), and `connector.BudgetConfig.MaxTotalRequests` is plain `int64`. The Issue body's "null vs 0" framing was reframed to "show 0 faithfully" during design review.

## Test plan
- [x] `make lint` passes
- [x] `make build` passes (Vite + Go binary)
- [x] WebUI `pnpm test` — 16 files / 314 tests pass
- [x] `go test ./internal/mcp/webui/...` (the package that embeds `dist/`) passes
- [ ] Manual: server reports `agent.max_requests_per_second=0` → form shows `0` (not empty); save round-trips faithfully
- [ ] Manual: same check for `agent.max_total_requests=0` in Budget

> Note: `make test` showed pre-existing 4-minute timeouts in `internal/flow` and `internal/layer/grpcweb` under parallel load. These packages are unaffected by this TS-only change; CI will run them fresh.

Resolves USK-971
Linear: https://linear.app/usk6666/issue/USK-971

🤖 Generated with [Claude Code](https://claude.com/claude-code)