### PR TITLE
perf(webui): pause polling on hidden tab and adapt to intercept queue state

### DIFF
--- a/web/src/lib/mcp/hooks.test.ts
+++ b/web/src/lib/mcp/hooks.test.ts
@@ -31,7 +31,7 @@
  * invariant — keeping the webui test surface dependency-free.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { McpClient } from "./client.js";
 
 // ---------------------------------------------------------------------------
@@ -229,6 +229,7 @@ const {
   useSecurity,
   useConfigure,
   useProxyControl,
+  useQuery,
 } = await import("./hooks.js");
 
 // ---------------------------------------------------------------------------
@@ -677,5 +678,170 @@ describe("useProxyControl — start/stop identity stability", () => {
 
     expect(outs[1]!.start).not.toBe(outs[0]!.start);
     expect(outs[1]!.stop).not.toBe(outs[0]!.stop);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useQuery — pauseWhenHidden + Page Visibility (USK-974)
+// ---------------------------------------------------------------------------
+//
+// Vitest's default test environment is node with no `document` global, so
+// the production `usePageVisible()` helper short-circuits on the
+// `typeof document === "undefined"` guard. To exercise the visibility-aware
+// polling code path we install a minimal `document` stub on `globalThis` in
+// `beforeEach` and tear it down in `afterEach` so no state leaks between
+// tests. The stub exposes the bits the helper actually touches:
+// `visibilityState` (read by the seed + the listener) and
+// `addEventListener` / `removeEventListener` for `visibilitychange`. Timers
+// are mocked with `vi.useFakeTimers()` so `setInterval` callbacks are
+// driven deterministically via `vi.advanceTimersByTimeAsync(ms)`.
+
+/** Shape of the `document` stub installed by the suite below. */
+interface DocStub {
+  visibilityState: "visible" | "hidden";
+  addEventListener: (type: string, handler: () => void) => void;
+  removeEventListener: (type: string, handler: () => void) => void;
+  /** Manually fire all `visibilitychange` listeners (test helper). */
+  fireVisibilityChange: () => void;
+}
+
+function makeDocStub(initial: "visible" | "hidden"): DocStub {
+  const listeners = new Set<() => void>();
+  return {
+    visibilityState: initial,
+    addEventListener(type, handler) {
+      if (type === "visibilitychange") listeners.add(handler);
+    },
+    removeEventListener(type, handler) {
+      if (type === "visibilitychange") listeners.delete(handler);
+    },
+    fireVisibilityChange() {
+      for (const h of listeners) h();
+    },
+  };
+}
+
+describe("useQuery — pauseWhenHidden + Page Visibility", () => {
+  let doc: DocStub;
+  let originalDocument: PropertyDescriptor | undefined;
+  let querySpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Snapshot any pre-existing `document` (none in node, but be defensive
+    // in case a future test setup adds jsdom) so we can restore it later.
+    originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    doc = makeDocStub("visible");
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      writable: true,
+      value: doc,
+    });
+
+    // Mock timers so `setInterval` is driven deterministically.
+    vi.useFakeTimers();
+
+    // Fresh client + query spy per test. The hook awaits the returned
+    // promise; resolving with `null` keeps the success path simple.
+    querySpy = vi.fn().mockResolvedValue(null);
+    ctx.client = { query: querySpy } as unknown as McpClient;
+    ctx.status = "connected";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalDocument) {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    } else {
+      delete (globalThis as Record<string, unknown>).document;
+    }
+  });
+
+  it("does not arm the polling interval while the page is hidden (pauseWhenHidden=true)", async () => {
+    doc.visibilityState = "hidden";
+
+    driveHook(
+      () =>
+        useQuery("macros", {
+          pollInterval: 1000,
+          pauseWhenHidden: true,
+        }),
+      1,
+    );
+
+    // The initial fetch effect still runs — only the periodic timer is
+    // gated by visibility. Drain microtasks for the first fetch.
+    await vi.advanceTimersByTimeAsync(0);
+    const initialCalls = querySpy.mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    // Advance well past several poll cycles. No interval should be armed,
+    // so the call count must not grow.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(querySpy.mock.calls.length).toBe(initialCalls);
+  });
+
+  it("fires one immediate refetch on hidden → visible and re-arms the interval", async () => {
+    doc.visibilityState = "hidden";
+
+    // Initial render with the page hidden.
+    let outs = driveHook(
+      () =>
+        useQuery("macros", {
+          pollInterval: 1000,
+          pauseWhenHidden: true,
+        }),
+      1,
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterInitial = querySpy.mock.calls.length;
+
+    // Flip to visible, fire the listener, then re-render to let the
+    // updated `pageVisible` state propagate through the hook's effects.
+    doc.visibilityState = "visible";
+    doc.fireVisibilityChange();
+
+    outs = driveHook(
+      () =>
+        useQuery("macros", {
+          pollInterval: 1000,
+          pauseWhenHidden: true,
+        }),
+      1,
+    );
+    expect(outs[0]).toBeDefined();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The transition must have triggered exactly one immediate fetch on
+    // top of any baseline calls observed while hidden.
+    const callsAfterTransition = querySpy.mock.calls.length;
+    expect(callsAfterTransition).toBeGreaterThan(callsAfterInitial);
+
+    // Subsequent timer advances must now produce additional fetches via
+    // the re-armed `setInterval`. Advance by ~3 intervals and require at
+    // least one further call to land.
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(querySpy.mock.calls.length).toBeGreaterThan(callsAfterTransition);
+  });
+
+  it("arms the polling interval normally when pauseWhenHidden is omitted (regression guard)", async () => {
+    doc.visibilityState = "hidden";
+
+    driveHook(
+      () =>
+        useQuery("macros", {
+          pollInterval: 1000,
+        }),
+      1,
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const initialCalls = querySpy.mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    // With the default `pauseWhenHidden: false`, the interval must arm
+    // regardless of visibility — confirms the new option is fully opt-in.
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(querySpy.mock.calls.length).toBeGreaterThan(initialCalls);
   });
 });

--- a/web/src/lib/mcp/hooks.ts
+++ b/web/src/lib/mcp/hooks.ts
@@ -184,6 +184,15 @@ export interface UseQueryOptions {
   pollInterval?: number;
   /** When false, the query is not executed. Defaults to true. */
   enabled?: boolean;
+  /**
+   * When true, the polling timer is suspended while the document is hidden
+   * (`document.visibilityState === "hidden"`). On the `hidden → visible`
+   * transition, the hook fires one immediate refetch and then re-arms the
+   * interval. The initial fetch and dependency-driven refetches are not
+   * gated by visibility — only the periodic timer. Defaults to false for
+   * backwards compatibility with existing callers.
+   */
+  pauseWhenHidden?: boolean;
   /** Additional filter parameters. */
   filter?: QueryFilter;
   /** Flow or macro ID (for resource="flow", "messages", "macro"). */
@@ -198,6 +207,36 @@ export interface UseQueryOptions {
   limit?: number;
   /** Pagination offset. */
   offset?: number;
+}
+
+// ---------------------------------------------------------------------------
+// usePageVisible — private helper backing the `pauseWhenHidden` useQuery
+// option. Mirrors the Page Visibility API as a boolean React state, with
+// SSR-safe guards so node-environment tests (and any future SSR) can import
+// `hooks.ts` without a real `document`.
+// ---------------------------------------------------------------------------
+
+function usePageVisible(): boolean {
+  const [visible, setVisible] = useState<boolean>(() => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState !== "hidden";
+  });
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const handler = () => {
+      setVisible(document.visibilityState !== "hidden");
+    };
+    // Seed once on mount so a render that occurred while hidden picks up
+    // the current state even if no `visibilitychange` event has fired.
+    handler();
+    document.addEventListener("visibilitychange", handler);
+    return () => {
+      document.removeEventListener("visibilitychange", handler);
+    };
+  }, []);
+
+  return visible;
 }
 
 /** Return type for useQuery. */
@@ -239,6 +278,8 @@ export function useQuery<R extends QueryResource>(
 
   const enabled = options.enabled !== false;
   const pollInterval = options.pollInterval;
+  const pauseWhenHidden = options.pauseWhenHidden === true;
+  const pageVisible = usePageVisible();
 
   // Stable JSON key over the request-shaping fields. Order matters and
   // must stay in lock-step with the query call below so consumers get
@@ -319,10 +360,31 @@ export function useQuery<R extends QueryResource>(
     fetchData();
   }, [enabled, status, fetchData]);
 
-  // Polling.
+  // Track whether the previous polling-effect run paused due to hidden
+  // visibility, so the next run that observes `pageVisible === true` can
+  // fire one immediate refetch on the hidden → visible transition. The
+  // ref is intentionally outside `pauseWhenHidden` gating: when the option
+  // is disabled, the flag is never set, so no spurious refetch fires.
+  const wasPausedHiddenRef = useRef(false);
+
+  // Polling. When `pauseWhenHidden` is on and the page is hidden, the
+  // periodic timer is not armed — the effect simply returns without
+  // scheduling anything. When the page returns to visible, the effect
+  // re-runs (because `pageVisible` is a dep), fires one immediate
+  // `fetchData()` to refresh stale data, then arms the interval as usual.
   useEffect(() => {
     if (!enabled || !pollInterval || pollInterval <= 0 || status !== "connected") {
       return;
+    }
+
+    if (pauseWhenHidden && !pageVisible) {
+      wasPausedHiddenRef.current = true;
+      return;
+    }
+
+    if (pauseWhenHidden && wasPausedHiddenRef.current) {
+      wasPausedHiddenRef.current = false;
+      fetchData();
     }
 
     const timer = setInterval(() => {
@@ -330,7 +392,7 @@ export function useQuery<R extends QueryResource>(
     }, pollInterval);
 
     return () => clearInterval(timer);
-  }, [enabled, status, fetchData, pollInterval]);
+  }, [enabled, status, fetchData, pollInterval, pauseWhenHidden, pageVisible]);
 
   return { data, loading, error, refetch: fetchData };
 }

--- a/web/src/pages/Intercept/InterceptPage.tsx
+++ b/web/src/pages/Intercept/InterceptPage.tsx
@@ -18,6 +18,14 @@ const TABS = [
   { id: "rules", label: "Rules" },
 ];
 
+// Adaptive polling thresholds for the intercept queue (USK-974). When the
+// queue holds at least one entry, poll aggressively so newly-arriving items
+// and post-action queue updates feel responsive. When the queue is empty,
+// fall back to 5s to reduce idle load. The Issue body explicitly accepts up
+// to 5s latency for the first item to surface in the idle state.
+const INTERCEPT_POLL_ACTIVE_MS = 1000;
+const INTERCEPT_POLL_IDLE_MS = 5000;
+
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
 const HTTP_STATUS_CODES = [
@@ -55,14 +63,27 @@ export function InterceptPage() {
   const { addToast } = useToast();
   const { interceptAction, loading: executeLoading } = useInterceptAction();
 
-  // Poll intercept queue every second
+  // Adaptive polling state derived from the previously-rendered queue
+  // depth. Stored as a boolean so the timer is only re-armed on the
+  // empty ↔ non-empty transition, not on every poll that mutates queue
+  // contents at fixed length. The polling `useEffect` inside `useQuery`
+  // re-arms whenever `pollInterval` changes, so once the first non-empty
+  // result lands the next render swaps from idle (5s) to active (1s)
+  // cadence and back (USK-974). `pauseWhenHidden` additionally suspends
+  // the timer entirely while the tab is in the background.
+  const [queueHasItems, setQueueHasItems] = useState<boolean>(false);
+  const queuePollInterval = queueHasItems
+    ? INTERCEPT_POLL_ACTIVE_MS
+    : INTERCEPT_POLL_IDLE_MS;
+
   const {
     data: queueData,
     loading: queueLoading,
     error: queueError,
     refetch: refetchQueue,
   } = useQuery<"intercept_queue">("intercept_queue", {
-    pollInterval: 1000,
+    pollInterval: queuePollInterval,
+    pauseWhenHidden: true,
   });
 
   // Fetch config for intercept rules summary
@@ -72,6 +93,17 @@ export function InterceptPage() {
   } = useQuery<"config">("config");
 
   const queue: InterceptQueueResult = queueData ?? { items: [], count: 0 };
+
+  // Mirror the live queue's emptiness into state so the adaptive
+  // `pollInterval` computed above sees the latest value on the next
+  // render. Only the empty ↔ non-empty boolean is tracked so the polling
+  // `useEffect` does not tear down and re-arm its timer for fixed-length
+  // mutations (e.g., one entry replaced by another) — the interval stays
+  // stable in the active cadence until the queue actually drains.
+  useEffect(() => {
+    const next = queue.items.length > 0;
+    setQueueHasItems((prev) => (prev === next ? prev : next));
+  }, [queue.items.length]);
 
   // Clear selectedId when the selected entry is no longer in the queue
   useEffect(() => {

--- a/web/src/pages/Macros/MacrosPage.tsx
+++ b/web/src/pages/Macros/MacrosPage.tsx
@@ -39,8 +39,11 @@ export function MacrosPage() {
   const { macro: macroAction, loading: actionLoading } = useMacro();
 
   // --- Query macros list ---
+  // `pauseWhenHidden` halts the 5s poll while the tab is in the background
+  // (USK-974); a single refetch fires on the hidden → visible transition.
   const { data, loading, error, refetch } = useQuery("macros", {
     pollInterval: 5000,
+    pauseWhenHidden: true,
   });
 
   const macros = data?.macros ?? [];


### PR DESCRIPTION
## Summary
- Add a `pauseWhenHidden?: boolean` option to the `useQuery` hook (default `false`, backwards-compatible). When enabled, the polling timer pauses while `document.visibilityState === "hidden"` and fires one immediate refetch on transition back to `"visible"`.
- `MacrosPage` opts in to `pauseWhenHidden: true` so the 5s `macros` poll halts in background tabs.
- `InterceptPage` opts in to `pauseWhenHidden: true` AND switches its `pollInterval` from a fixed 1s to `queue.items.length > 0 ? 1s : 5s`, dropping idle-queue load to 12 RPM.
- Page Visibility API only (no new dependencies). SSR-safe (`typeof document !== "undefined"` guards). No behavior change for other `useQuery` consumers.

## Test plan
- [ ] `cd web && pnpm run lint && pnpm run build && pnpm test` all pass (including the three new cases in `hooks.test.ts`)
- [ ] `make build` and `make test` pass
- [ ] Manual: open Macros, switch tabs, watch Network panel — `query macros` calls cease. Switch back — one immediate fetch fires, then 5s cadence resumes.
- [ ] Manual: open Intercept with 0 items — Network panel shows 5s cadence. Add a held item via a request — cadence switches to 1s. Drop / forward the last item — back to 5s.

Resolves USK-974
Linear: https://linear.app/usk6666/issue/USK-974/perfwebui-adaptive-polling-for-macros-list-and-intercept-queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)