### PR TITLE
fix(webui/Settings): confirm dialog before TcpForwards Add triggers proxy_start

### DIFF
--- a/web/src/pages/Settings/TcpForwards.tsx
+++ b/web/src/pages/Settings/TcpForwards.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { Badge, Button, Input, useToast } from "../../components/ui/index.js";
+import { Badge, Button, Input, useDialog, useToast } from "../../components/ui/index.js";
 import { useProxyControl } from "../../lib/mcp/hooks.js";
 import type { ConfigResult, ForwardConfig, ForwardProtocol } from "../../lib/mcp/types.js";
 
@@ -21,6 +21,7 @@ const PROTOCOL_OPTIONS = ["auto", "raw", "http", "http2", "grpc", "websocket", "
  */
 export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
   const { addToast } = useToast();
+  const { showDialog } = useDialog();
   const { start, loading } = useProxyControl();
 
   // Form state for adding a new mapping
@@ -83,6 +84,18 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
     // Build new forwards map: existing + new entry
     const newForwards: Record<string, ForwardConfig> = { ...forwards, [port]: newEntry };
 
+    const confirmed = await showDialog({
+      title: "Apply TCP Forward",
+      message:
+        "Applying TCP forward changes calls proxy_start, which resets all " +
+        "in-session settings on the listener (intercept rules, transform rules, " +
+        "capture scope, TLS fingerprint, connection limits) and may interrupt " +
+        "in-flight connections on that listener. Continue?",
+      variant: "confirm",
+      confirmLabel: "Apply",
+    });
+    if (!confirmed) return;
+
     try {
       await start({
         tcp_forwards: newForwards,
@@ -105,7 +118,7 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
         message: `Failed to add TCP forward: ${err instanceof Error ? err.message : String(err)}`,
       });
     }
-  }, [localPort, upstreamHost, upstreamPort, protocol, tlsEnabled, upstreamTlsEnabled, forwards, start, addToast, onRefresh]);
+  }, [localPort, upstreamHost, upstreamPort, protocol, tlsEnabled, upstreamTlsEnabled, forwards, start, addToast, onRefresh, showDialog]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -153,9 +166,12 @@ export function TcpForwards({ config, onRefresh }: TcpForwardsProps) {
             parsing applied based on the configured protocol hint.
           </p>
           <p className="settings-section-desc">
-            TCP forwards are configured when starting a new listener. Adding a forward
-            restarts the proxy with the updated mappings. To remove a forward, restart
-            the proxy with the desired configuration.
+            TCP forwards are listener start-time configuration. Adding a forward calls
+            proxy_start with the updated mapping set, which resets the listener's
+            in-session settings (intercept rules, transform rules, capture scope,
+            TLS fingerprint, connection limits) and may interrupt in-flight connections
+            on that listener. To remove a forward, restart the proxy with the desired
+            configuration.
           </p>
 
           {/* Add mapping form */}


### PR DESCRIPTION
## Summary
- Add a confirm dialog to `TcpForwards.tsx`'s `handleAdd` path before it calls the `proxy_start` MCP tool. The dialog describes the actual side effect — `proxy_start` resets in-session settings on the targeted listener (intercept rules, transform rules, capture scope, TLS fingerprint, connection limits) and may interrupt in-flight connections on that listener. Cancel is a true no-op (returns before `start`); Apply proceeds with the existing call path.
- Reuses the existing `useDialog` infrastructure (`web/src/components/ui/Dialog.tsx`) — same pattern as `TlsFingerprint.tsx` / `GrpcSchemas.tsx`. No new dependencies, no new files.
- Tighten the disclaimer paragraph on the same page to reflect the real semantics.

## Issue framing note
The Issue body describes the side effect as "restart drops other listeners' state". Per Phase 1.5 design review, the actual semantics are **listener-scoped** (not cross-listener), and on already-running listeners the call returns `ErrAlreadyRunning` without any state change. The dialog text in this PR reflects the real semantics rather than the inaccurate framing.

## Out of scope (follow-up candidates)
- Per-listener restart MCP tool / `configure`-tool extension for `tcp_forwards` (would let the UI narrow the impact without a full `proxy_start`).
- Remove-forward UI button (does not exist today; only Add is supported in the UI).
- `ErrAlreadyRunning` UX improvement (requires backend change so add-while-running is meaningful).

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm test` passes (314/314)
- [ ] Manual: in Settings → TcpForwards, fill in a forward → click Add. Dialog appears with the described text. Cancel — no MCP call (Network panel). Apply — the forward is applied as today.

Resolves USK-975
Linear: https://linear.app/usk6666/issue/USK-975/fixwebuisettingstcpforwards-warn-on-proxy-restart-impact-before

🤖 Generated with [Claude Code](https://claude.com/claude-code)