### PR TITLE
feat(mcp/query): expose intercept_queue config and prefill InterceptRules form

### DIFF
--- a/internal/mcp/query_config_resource_test.go
+++ b/internal/mcp/query_config_resource_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
 	"github.com/usk6666/yorishiro-proxy/internal/testutil"
 )
 
@@ -236,6 +238,139 @@ func TestQuery_Config_ProtocolCaps_OmittedWhenZero(t *testing.T) {
 		if _, present := raw[key]; present {
 			t.Errorf("expected JSON key %q to be OMITTED for zero value, raw[%q]=%v", key, key, raw[key])
 		}
+	}
+}
+
+// TestQuery_Config_InterceptQueue_Populated is the USK-977 regression for
+// the "intercept queue config missing from query config" gap deferred from
+// USK-969 (PR #43). When the server is wired with a HoldQueue (the
+// production wiring path), query("config") must echo the intercept_queue
+// settings so the WebUI InterceptRules tab can prefill its form on initial
+// mount.
+func TestQuery_Config_InterceptQueue_Populated(t *testing.T) {
+	t.Parallel()
+
+	// Wire a HoldQueue with explicit non-default values so the round-trip
+	// is observably distinct from the NewHoldQueue defaults.
+	const wantTimeoutMs int64 = 45_000
+	const wantBehavior = common.TimeoutAutoDrop
+
+	hold := common.NewHoldQueue()
+	hold.SetTimeout(time.Duration(wantTimeoutMs) * time.Millisecond)
+	hold.SetTimeoutBehavior(wantBehavior)
+
+	ctx := context.Background()
+	ca := newTestCA(t)
+	store := newTestStore(t)
+	s := newServer(ctx, ca, store, nil, WithHoldQueue(hold))
+
+	ct, st := gomcp.NewInMemoryTransports()
+	ss, err := s.server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { ss.Close() })
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test", Version: "v0.0.1"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	result := callQuery(t, cs, queryInput{Resource: "config"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	// Round-trip through queryConfigResult to verify Go-typed values.
+	var out queryConfigResult
+	unmarshalQueryResult(t, result, &out)
+	if out.InterceptQueue == nil {
+		t.Fatalf("InterceptQueue = nil, want non-nil (holdQueue is wired)")
+	}
+	if out.InterceptQueue.TimeoutMs != wantTimeoutMs {
+		t.Errorf("InterceptQueue.TimeoutMs = %d, want %d", out.InterceptQueue.TimeoutMs, wantTimeoutMs)
+	}
+	if out.InterceptQueue.TimeoutBehavior != string(wantBehavior) {
+		t.Errorf("InterceptQueue.TimeoutBehavior = %q, want %q", out.InterceptQueue.TimeoutBehavior, string(wantBehavior))
+	}
+	switch out.InterceptQueue.TimeoutBehavior {
+	case "auto_release", "auto_drop":
+		// OK — one of the two canonical values.
+	default:
+		t.Errorf("InterceptQueue.TimeoutBehavior = %q, want one of {auto_release, auto_drop}", out.InterceptQueue.TimeoutBehavior)
+	}
+
+	// Round-trip through a generic map to verify the snake_case JSON key
+	// is present in the wire payload (omitempty did not skip it).
+	if len(result.Content) == 0 {
+		t.Fatal("result.Content is empty")
+	}
+	textPart, ok := result.Content[0].(*gomcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(textPart.Text), &raw); err != nil {
+		t.Fatalf("unmarshal raw JSON: %v", err)
+	}
+	if _, present := raw["intercept_queue"]; !present {
+		t.Errorf("expected JSON key %q to be present, raw=%v", "intercept_queue", raw)
+	}
+}
+
+// TestQuery_Config_InterceptQueue_OmittedWhenNil confirms the
+// `omitempty` JSON tag drops `intercept_queue` from the wire payload
+// when the proxy has not been started (holdQueue == nil). The shape
+// stays stable for WebUI clients that key off presence.
+func TestQuery_Config_InterceptQueue_OmittedWhenNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ca := newTestCA(t)
+	store := newTestStore(t)
+	// No WithHoldQueue option — pipeline.holdQueue stays nil.
+	s := newServer(ctx, ca, store, nil)
+
+	ct, st := gomcp.NewInMemoryTransports()
+	ss, err := s.server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { ss.Close() })
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test", Version: "v0.0.1"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	result := callQuery(t, cs, queryInput{Resource: "config"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	var out queryConfigResult
+	unmarshalQueryResult(t, result, &out)
+	if out.InterceptQueue != nil {
+		t.Errorf("InterceptQueue = %+v, want nil (holdQueue not wired)", out.InterceptQueue)
+	}
+
+	if len(result.Content) == 0 {
+		t.Fatal("result.Content is empty")
+	}
+	textPart, ok := result.Content[0].(*gomcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(textPart.Text), &raw); err != nil {
+		t.Fatalf("unmarshal raw JSON: %v", err)
+	}
+	if _, present := raw["intercept_queue"]; present {
+		t.Errorf("expected JSON key %q to be OMITTED when holdQueue is nil, raw[%q]=%v", "intercept_queue", "intercept_queue", raw["intercept_queue"])
 	}
 }
 

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -2306,6 +2306,11 @@ type queryConfigResult struct {
 	// echoed here — that surface is owned by the `security` MCP tool
 	// (different lifecycle and audit semantics).
 	CaptureScope *queryCaptureScopeResult `json:"capture_scope"`
+	// InterceptQueue echoes the current intercept HoldQueue settings
+	// (USK-977). Reuses the configure-side response struct so the wire
+	// shape matches `configure({intercept_queue: ...})` byte-for-byte.
+	// Omitted when s.pipeline.holdQueue is nil (proxy not yet started).
+	InterceptQueue *configureInterceptQueueResult `json:"intercept_queue,omitempty"`
 }
 
 // queryCaptureScopeResult is the JSON shape returned for the
@@ -2412,6 +2417,14 @@ func (s *Server) handleQueryConfig() (*gomcp.CallToolResult, *queryConfigResult,
 
 	result.TLSFingerprint = s.currentTLSFingerprint()
 	result.CaptureScope = s.currentCaptureScope()
+
+	// USK-977: surface intercept_queue config so the WebUI InterceptRules
+	// tab can prefill its form. Nil-guard mirrors configureInterceptQueue
+	// (configure_tool.go) — holdQueue may be nil if the proxy has not
+	// started yet.
+	if s.pipeline.holdQueue != nil {
+		result.InterceptQueue = s.interceptQueueResult()
+	}
 
 	return nil, result, nil
 }

--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -675,6 +675,21 @@ export interface ConfigResult {
   peek_timeout_ms: number;
   request_timeout_ms: number;
   tls_fingerprint: string;
+  /**
+   * Current intercept HoldQueue settings (USK-977). Mirrors the
+   * `ConfigureResult.intercept_queue` shape byte-for-byte so callers can
+   * reuse the same render path. Omitted when the proxy has not yet
+   * initialized the queue (server start race).
+   */
+  intercept_queue?: {
+    timeout_ms: number;
+    timeout_behavior: string;
+    queued_items: number;
+    protocol_overrides?: Record<
+      string,
+      { timeout_ms: number; timeout_behavior: string }
+    >;
+  };
 }
 
 /** Response for query resource="ca_cert". */

--- a/web/src/pages/Settings/InterceptRules.tsx
+++ b/web/src/pages/Settings/InterceptRules.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button, Input, useToast } from "../../components/ui/index.js";
 import { useConfigure } from "../../lib/mcp/hooks.js";
 import type { ConfigResult, InterceptRule } from "../../lib/mcp/types.js";
@@ -17,7 +17,7 @@ const TIMEOUT_BEHAVIOR_OPTIONS = ["auto_release", "auto_drop"] as const;
  * Note: The config query does not return individual rule details.
  * We manage rules via the configure tool's intercept_rules section.
  */
-export function InterceptRules({ config: _config, onRefresh }: InterceptRulesProps) {
+export function InterceptRules({ config, onRefresh }: InterceptRulesProps) {
   const { addToast } = useToast();
   const { configure, loading: configureLoading } = useConfigure();
 
@@ -37,6 +37,20 @@ export function InterceptRules({ config: _config, onRefresh }: InterceptRulesPro
   // Intercept queue settings
   const [queueTimeoutMs, setQueueTimeoutMs] = useState("");
   const [queueTimeoutBehavior, setQueueTimeoutBehavior] = useState<"auto_release" | "auto_drop">("auto_release");
+
+  // USK-977: prefill queue settings from the latest config snapshot on
+  // initial mount and whenever the backend echoes a fresh value (e.g.
+  // after onRefresh()). The TS type for timeout_behavior is the loose
+  // `string` (mirrors ConfigureResult); narrow at runtime to defend
+  // against an unexpected backend value corrupting the form state.
+  useEffect(() => {
+    const q = config.intercept_queue;
+    if (!q) return;
+    setQueueTimeoutMs(String(q.timeout_ms));
+    if (q.timeout_behavior === "auto_release" || q.timeout_behavior === "auto_drop") {
+      setQueueTimeoutBehavior(q.timeout_behavior);
+    }
+  }, [config.intercept_queue]);
 
   const resetForm = () => {
     setRuleId("");


### PR DESCRIPTION
## Summary
- Extend `queryConfigResult` with an `intercept_queue` field that reuses the existing `configureInterceptQueueResult` struct and `s.interceptQueueResult()` helper, with a nil-guard on `s.pipeline.holdQueue` matching the configure-side pattern.
- WebUI: add the matching optional field to `ConfigResult` in types.ts (mirrors `ConfigureResult.intercept_queue` shape). Rename `_config`→`config` in InterceptRules (USK-969 left it underscored as unused) and add a `useEffect` that syncs `queueTimeoutMs` + `queueTimeoutBehavior` from `config.intercept_queue` whenever it changes, so a page reload after save restores the form state.

## Test plan
- [x] `make lint` passes
- [x] `make build` passes (Go + WebUI)
- [x] `make test` passes
- [x] `query_config_resource_test.go` extended to assert `intercept_queue` round-trips with non-nil TimeoutMs and a valid TimeoutBehavior, plus a sibling `OmittedWhenNil` test for the proxy-not-yet-started path.

Resolves USK-977
Linear: https://linear.app/usk6666/issue/USK-977

🤖 Generated with [Claude Code](https://claude.com/claude-code)