### PR TITLE
refactor(mcp/fuzz_http): macro hooks NIT polish (errors.Is ctx-cancel + test/doc gap)

### DIFF
--- a/internal/mcp/fuzz_http_helpers.go
+++ b/internal/mcp/fuzz_http_helpers.go
@@ -418,10 +418,25 @@ func buildJobHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) (
 // true when the loop reached the post-job firing path (natural
 // exhaustion or stop_on_5xx); it is false on ctx cancel. retErr
 // non-nil signals an unrecoverable abort and post-job MUST NOT fire.
+//
+// USK-979: ctx-cancel detection bubbles up through retErr wrapped with
+// %w so errors.Is(retErr, context.Canceled) / context.DeadlineExceeded
+// drives the post-job gate. The ctx-cancel error is consumed here (NOT
+// returned to the caller) so the run still reports success with a
+// stopped_reason — preserving the pre-refactor in-band cancel semantics
+// (Q23 / TestFuzzHTTP_FinalizesUnderCallerCancel).
 func (l *fuzzHTTPVariantLoop) runVariantLoop(ctx context.Context) (bool, string, error) {
 	for variantIdx := 0; variantIdx < l.plan.totalVariants; variantIdx++ {
 		stop, retErr := l.runOne(ctx, variantIdx)
 		if retErr != nil {
+			if errors.Is(retErr, context.Canceled) || errors.Is(retErr, context.DeadlineExceeded) {
+				// Q5: post-job does NOT fire on ctx cancel. Surface the
+				// cancel reason via stopped_reason for parity with the
+				// pre-USK-979 string-sentinel path; do NOT propagate as
+				// retErr so the caller still finalizes the fuzz_jobs
+				// row normally.
+				return false, fmt.Sprintf("ctx cancelled: %v", retErr), nil
+			}
 			// pre-iteration abort or other unrecoverable error. Per
 			// Q5: post-job does NOT fire on pre-iteration abort.
 			return false, "", retErr
@@ -429,9 +444,8 @@ func (l *fuzzHTTPVariantLoop) runVariantLoop(ctx context.Context) (bool, string,
 		if stop == "" {
 			continue
 		}
-		// stop_on_5xx and ctx cancel both reach here. Per Q5: post-job
-		// fires on stop_on_5xx but NOT on ctx cancel.
-		return !strings.HasPrefix(stop, "ctx cancelled:"), stop, nil
+		// stop_on_5xx reaches here. Per Q5: post-job fires on stop_on_5xx.
+		return true, stop, nil
 	}
 	return true, "", nil
 }
@@ -495,14 +509,17 @@ type fuzzHTTPVariantLoop struct {
 
 // runOne executes a single iteration of the variant loop. Returns
 // (stopReason, retErr): stopReason "" means continue; non-empty means
-// stop with that reason; retErr propagates an abort up the call stack.
-// The branching is by design: upstream resolution / pre macro / template
-// expansion each have their own short-circuit semantics, and a single
-// return type would conflate them.
+// stop with that reason (e.g., stop_on_5xx); retErr propagates an
+// abort up the call stack. ctx cancel is surfaced via retErr wrapped
+// with %w so the caller can distinguish via errors.Is(context.Canceled)
+// / errors.Is(context.DeadlineExceeded) instead of string-matching the
+// stop reason (USK-979). The branching is by design: upstream resolution
+// / pre macro / template expansion each have their own short-circuit
+// semantics, and a single return type would conflate them.
 func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (string, error) {
 	select {
 	case <-ctx.Done():
-		return fmt.Sprintf("ctx cancelled: %v", ctx.Err()), nil
+		return "", fmt.Errorf("variant %d: %w", variantIdx, ctx.Err())
 	default:
 	}
 

--- a/internal/mcp/fuzz_http_macro_integration_test.go
+++ b/internal/mcp/fuzz_http_macro_integration_test.go
@@ -1113,6 +1113,110 @@ func TestFuzzHTTPMacro_ScopeJobPreAbortOnErrorAbortsJob(t *testing.T) {
 	}
 }
 
+// TestFuzzHTTPMacro_ScopeJobPreContinueOnErrorProceeds covers pre=job +
+// on_error=continue + failing macro: every variant runs because the
+// continue policy proceeds with whatever jobKVStore captured, one
+// fuzz_macro_results row at index_num=-1 / status="error" records the
+// pre-job failure, and CompletedVariants == totalVariants. Sibling to
+// TestFuzzHTTPMacro_ScopeJobPreAbortOnErrorAbortsJob (USK-979 AC#2).
+func TestFuzzHTTPMacro_ScopeJobPreContinueOnErrorProceeds(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	// preServer returns 500 — required extract fails. With on_error=continue
+	// the variant loop must still proceed.
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/login", nil, nil)
+	defineMacroForTest(t, cs, "pre-required-job-continue", preFlowID, "", "", []map[string]any{
+		{
+			"name":      "session_token",
+			"from":      "response",
+			"source":    "body_json",
+			"json_path": "$.session_token",
+			"required":  true,
+		},
+	})
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	totalVariants := 3
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro":  map[string]any{"name": "pre-required-job-continue", "scope": "job", "on_error": "continue"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned unexpected error (on_error=continue must not abort): %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+
+	if out.CompletedVariants != totalVariants {
+		t.Errorf("CompletedVariants = %d, want %d (on_error=continue must run every variant)", out.CompletedVariants, totalVariants)
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); int(got) != totalVariants {
+		t.Errorf("fuzz server saw %d requests, want %d", got, totalVariants)
+	}
+	if out.StoppedReason != "" {
+		t.Errorf("StoppedReason = %q, want \"\" (continue must not set a stopped_reason)", out.StoppedReason)
+	}
+
+	fs := store.(flow.FuzzStore)
+	results, err := fs.ListFuzzMacroResults(context.Background(), out.FuzzID)
+	if err != nil {
+		t.Fatalf("ListFuzzMacroResults: %v", err)
+	}
+	// continue policy records the pre-job failure as one row at
+	// index_num=-1 / status="error". No post hook is configured, so this
+	// is the only fuzz_macro_results row expected.
+	if len(results) != 1 {
+		t.Fatalf("fuzz_macro_results rows = %d, want 1", len(results))
+	}
+	r := results[0]
+	if r.HookName != "pre" {
+		t.Errorf("hook_name = %q, want pre", r.HookName)
+	}
+	if r.IndexNum != -1 {
+		t.Errorf("index_num = %d, want -1 (job-scope sentinel)", r.IndexNum)
+	}
+	if r.Status != "error" {
+		t.Errorf("status = %q, want error (on_error=continue records the failure)", r.Status)
+	}
+}
+
 // TestFuzzHTTPMacro_ScopeJobIndexNumSentinel asserts that
 // ListFuzzMacroResults rows for job-scope hooks have IndexNum == -1
 // exactly (covers AC#5 of USK-961).

--- a/internal/mcp/resources/help_fuzz_http.md
+++ b/internal/mcp/resources/help_fuzz_http.md
@@ -72,7 +72,7 @@ The hook macro shares the per-iteration (or per-job) KV Store with the fuzz requ
 
 Mix-scope is supported — `pre_macro` and `post_macro` may pick their scope independently. The job-scope KV Store is merged into each iteration's per-variant store at iteration start; per-iteration reserved keys then overwrite any conflicting job keys ("iteration wins"). So `pre_macro { scope: "job" }` extracting `session_token` makes `§session_token§` resolvable in every variant's request templates.
 
-> `run_interval` is the underlying engine knob for `every_n` / `on_status` / etc. dispatch. It is rejected when `scope="job"` because the hook fires exactly once by construction (the call site, not `run_interval`, owns the single-fire guarantee).
+> `run_interval` is `scope="iteration"` only — the engine knob for `every_n` / `on_status` / etc. dispatch is meaningful only when the hook fires per-variant. `scope="job"` hooks fire exactly once by construction (the call site, not `run_interval`, owns the single-fire guarantee); once the `run_interval` field is publicly surfaced on the fuzz_http hook config, pairing it with `scope="job"` will be rejected at validation time.
 
 #### OnError semantics
 


### PR DESCRIPTION
## Summary
- Replace `strings.HasPrefix(stop, "ctx cancelled:")` at the `runOne` / `runVariantLoop` boundary with `errors.Is(retErr, context.Canceled)` / `errors.Is(retErr, context.DeadlineExceeded)`. `runOne` now surfaces ctx-cancel via wrapped `retErr` instead of a string-sentinel stop reason; `runVariantLoop` consumes the cancel error and re-emits the `"ctx cancelled: %v"` `stopped_reason` string for the response payload — observable behavior (Q23 / `TestFuzzHTTP_FinalizesUnderCallerCancel`) is preserved.
- Add `TestFuzzHTTPMacro_ScopeJobPreContinueOnErrorProceeds` mirroring the existing abort-path test (`TestFuzzHTTPMacro_ScopeJobPreAbortOnErrorAbortsJob`). Confirms `pre=job + on_error=continue + failing macro` runs every variant, sets no `stopped_reason`, and records a single `fuzz_macro_results` row at `index_num=-1 / status="error"`.
- Tighten `internal/mcp/resources/help_fuzz_http.md` `run_interval` note: `run_interval` is `scope="iteration"` only; pairing with `scope="job"` will be rejected at validation time once the field is publicly surfaced on the fuzz_http hook config.

## Test plan
- [x] `make build` passes
- [x] `make lint` passes
- [x] `go test -race -run TestFuzzHTTP ./internal/mcp/` passes (in-tree fuzz_http unit / non-e2e tests)
- [x] `go test -race -tags e2e -run TestFuzzHTTPMacro_ScopeJob ./internal/mcp/` passes including the new continue-path test
- [x] `go test -race ./internal/mcp/ ./internal/flow/` passes with extended timeout (`make test` default 4 min timed out on slow VM under `-v` load — unrelated to this change)

Resolves USK-979
Linear: https://linear.app/usk6666/issue/USK-979

🤖 Generated with [Claude Code](https://claude.com/claude-code)