### PR TITLE
refactor(webui/Macros): mirror OnError and ExtractionSource as literal unions

### DIFF
--- a/web/src/lib/mcp/types.ts
+++ b/web/src/lib/mcp/types.ts
@@ -803,11 +803,34 @@ export interface MacrosResult {
  */
 export type ExtractionFrom = "request" | "response";
 
+/**
+ * Which part of the message a macro extraction rule reads from.
+ *
+ * Mirrors `ExtractionSource` in `internal/macro/types.go`. Closed set —
+ * extending the backend requires extending this union and the
+ * `EXTRACTION_SOURCE_OPTIONS` array in `MacroDetailPage.tsx`.
+ */
+export type ExtractionSource =
+  | "header"
+  | "body"
+  | "body_json"
+  | "status"
+  | "url";
+
+/**
+ * How the macro engine reacts when a step fails.
+ *
+ * Mirrors `OnError` in `internal/macro/types.go`. Closed set —
+ * extending the backend requires extending this union and the
+ * `ON_ERROR_OPTIONS` array in `MacroDetailPage.tsx`.
+ */
+export type OnError = "abort" | "skip" | "retry";
+
 /** Extraction rule in a macro step. */
 export interface ExtractionRule {
   name: string;
   from: ExtractionFrom;
-  source: string;
+  source: ExtractionSource;
   header_name?: string;
   regex?: string;
   group?: number;
@@ -835,7 +858,7 @@ export interface MacroStep {
   override_url?: string;
   override_headers?: Record<string, string>;
   override_body?: string | null;
-  on_error?: string;
+  on_error?: OnError;
   retry_count?: number;
   retry_delay_ms?: number;
   timeout_ms?: number;

--- a/web/src/pages/Macros/MacroDetailPage.tsx
+++ b/web/src/pages/Macros/MacroDetailPage.tsx
@@ -11,11 +11,13 @@ import { useMacro, useQuery } from "../../lib/mcp/hooks.js";
 import type {
   ExtractionFrom,
   ExtractionRule,
+  ExtractionSource,
   GuardCondition,
   MacroDefineResult,
   MacroRunResult,
   MacroStep,
   MacroStepResult,
+  OnError,
 } from "../../lib/mcp/types.js";
 import "./MacroDetailPage.css";
 
@@ -28,7 +30,7 @@ const TABS = [
   { id: "run", label: "Run & Results" },
 ];
 
-const ON_ERROR_OPTIONS = [
+const ON_ERROR_OPTIONS: readonly { value: OnError; label: string }[] = [
   { value: "abort", label: "Abort" },
   { value: "skip", label: "Skip" },
   { value: "retry", label: "Retry" },
@@ -39,7 +41,7 @@ const EXTRACTION_FROM_OPTIONS: readonly { value: ExtractionFrom; label: string }
   { value: "response", label: "Response" },
 ];
 
-const EXTRACTION_SOURCE_OPTIONS = [
+const EXTRACTION_SOURCE_OPTIONS: readonly { value: ExtractionSource; label: string }[] = [
   { value: "header", label: "Header" },
   { value: "body", label: "Body (regex)" },
   { value: "body_json", label: "Body (JSON Path)" },
@@ -67,7 +69,7 @@ interface StepFormEntry {
   overrideUrl: string;
   overrideHeaders: KVEntry[];
   overrideBody: string;
-  onError: string;
+  onError: OnError;
   retryCount: string;
   retryDelayMs: string;
   timeoutMs: string;
@@ -81,7 +83,7 @@ interface ExtractionFormEntry {
   key: string;
   name: string;
   from: ExtractionFrom;
-  source: string;
+  source: ExtractionSource;
   headerName: string;
   regex: string;
   group: string;
@@ -976,7 +978,7 @@ function StepEditor({
                 <select
                   className="macro-select"
                   value={step.onError}
-                  onChange={(e) => onUpdate({ onError: e.target.value })}
+                  onChange={(e) => onUpdate({ onError: e.target.value as OnError })}
                 >
                   {ON_ERROR_OPTIONS.map((o) => (
                     <option key={o.value} value={o.value}>
@@ -1071,7 +1073,7 @@ function StepEditor({
                       className="macro-select"
                       value={ext.source}
                       onChange={(e) =>
-                        updateExtraction(ext.key, { source: e.target.value })
+                        updateExtraction(ext.key, { source: e.target.value as ExtractionSource })
                       }
                     >
                       {EXTRACTION_SOURCE_OPTIONS.map((o) => (


### PR DESCRIPTION
## Summary
- Mirror `OnError` (`internal/macro/types.go:42-52`) as a TypeScript literal union in `web/src/lib/mcp/types.ts`; narrow `MacroStep.on_error` and `StepFormEntry.onError`; annotate `ON_ERROR_OPTIONS` so backend additions surface as compile errors.
- Mirror `ExtractionSource` (`internal/macro/types.go:54-68`) the same way; narrow `ExtractionRule.source` and `ExtractionFormEntry.source`; annotate `EXTRACTION_SOURCE_OPTIONS`.
- Add sound `as OnError` / `as ExtractionSource` casts on the `<select onChange>` handlers in `MacroDetailPage.tsx`.
- Follow the pattern established by USK-972 (PR #44) for `ExtractionFrom`.

## Test plan
- [x] `make build` (incl. `make build-ui` → `tsc`) passes — load-bearing for this refactor
- [x] `make lint` passes
- [x] `make test` passes (Go side unaffected)
- [ ] Manual smoke: open Macros page in WebUI, edit `on_error` and extraction `source` selects — values must persist and submit correctly

Resolves USK-978
Linear: https://linear.app/usk6666/issue/USK-978

🤖 Generated with [Claude Code](https://claude.com/claude-code)