### PR TITLE
feat(mcp/fuzz_http): per-hook vars overrides + run_interval field (USK-981)

### DIFF
--- a/internal/mcp/fuzz_http.go
+++ b/internal/mcp/fuzz_http.go
@@ -36,6 +36,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -136,6 +137,55 @@ type fuzzHTTPMacroConfig struct {
 	//                unresolved §var§ literals — recorded in
 	//                fuzz_results.error).
 	OnError string `json:"on_error,omitempty" jsonschema:"skip (default) | abort | continue"`
+
+	// Vars is a static map of kvStore overrides injected before the macro
+	// runs. Keys with the reserved prefix ("__") are silently dropped at
+	// injection time (matches internal/job/job.go:mergeKVStore precedent)
+	// so a Vars entry cannot shadow runtime-populated reserved keys such
+	// as __iteration / __nonce / __response_* (USK-981 Q2).
+	//
+	// scope="iteration": Vars is injected into every variant's per-
+	// iteration kvStore after the job-store copy and before
+	// SeedIterationKV — so the operator's static overrides are visible to
+	// §var§ template expansion on the variant request but cannot shadow
+	// per-iteration reserved keys.
+	//
+	// scope="job": Vars is injected once into the job kvStore at job
+	// start. The job-store is then naturally merged into every per-
+	// iteration kvStore via the existing copy at iteration setup.
+	Vars map[string]string `json:"vars,omitempty" jsonschema:"static kvStore overrides injected before the macro runs. Keys with the '__' reserved prefix are silently dropped (USK-981)"`
+
+	// RunInterval gates when the hook fires across iterations. Only valid
+	// for scope="iteration" — scope="job" hooks fire exactly once by
+	// construction and the validator rejects scope="job" + non-empty
+	// RunInterval (USK-961 Q10).
+	//
+	// pre_macro legal values: "always" (default) | "once" | "every_n" |
+	// "on_error". post_macro legal values: "always" (default) |
+	// "on_status" | "on_match". Pre and post have disjoint legal sets;
+	// validation runs per-direction via the underlying hooks.go
+	// validators (USK-981 Q7).
+	RunInterval string `json:"run_interval,omitempty" jsonschema:"hook firing cadence (scope=iteration only). pre_macro: always (default) | once | every_n | on_error. post_macro: always (default) | on_status | on_match. Rejected when scope='job'"`
+
+	// N is the interval count for RunInterval="every_n". Required when
+	// RunInterval="every_n"; ignored otherwise.
+	N int `json:"n,omitempty" jsonschema:"iteration cadence for RunInterval='every_n' (>= 1)"`
+
+	// StatusCodes is the list of response status codes that gate
+	// post_macro firing for RunInterval="on_status". Required when
+	// RunInterval="on_status"; ignored otherwise. post_macro only.
+	StatusCodes []int `json:"status_codes,omitempty" jsonschema:"response status codes for post_macro RunInterval='on_status'"`
+
+	// MatchPattern is the regex pattern matched against the response body
+	// for post_macro RunInterval="on_match". Required when
+	// RunInterval="on_match"; ignored otherwise. post_macro only.
+	MatchPattern string `json:"match_pattern,omitempty" jsonschema:"response body regex pattern for post_macro RunInterval='on_match'"`
+
+	// compiledPattern is the pre-compiled MatchPattern, set during
+	// validation so the hook executor reuses it across iterations rather
+	// than recompiling. Not serialised — internal to the validator/
+	// executor handoff. Matches the precedent on hookConfig.compiledPattern.
+	compiledPattern *regexp.Regexp `json:"-"`
 }
 
 // fuzzHTTPPosition describes one fuzz position. Path is a typed

--- a/internal/mcp/fuzz_http_helpers.go
+++ b/internal/mcp/fuzz_http_helpers.go
@@ -123,10 +123,10 @@ func validateFuzzHTTPInput(input *fuzzHTTPInput) error {
 			return fmt.Errorf("positions cartesian product exceeds %d variants (computed at position %d); reduce payload counts or split into multiple calls", maxFuzzHTTPVariants, i)
 		}
 	}
-	if err := validateFuzzHTTPMacroConfig("pre_macro", input.PreMacro); err != nil {
+	if err := validateFuzzHTTPMacroConfig("pre_macro", input.PreMacro, true); err != nil {
 		return err
 	}
-	if err := validateFuzzHTTPMacroConfig("post_macro", input.PostMacro); err != nil {
+	if err := validateFuzzHTTPMacroConfig("post_macro", input.PostMacro, false); err != nil {
 		return err
 	}
 	return nil
@@ -140,7 +140,15 @@ func validateFuzzHTTPInput(input *fuzzHTTPInput) error {
 // fuzz_http call. Runtime invocation surfaces the missing-macro error via
 // loadAndBuildMacroDeps and short-circuits the iteration per the OnError
 // policy.
-func validateFuzzHTTPMacroConfig(label string, cfg *fuzzHTTPMacroConfig) error {
+//
+// USK-981: when RunInterval is non-empty, the pre/post legal set is
+// enforced via validatePreMacroHook / validatePostMacroHook so the
+// directional asymmetry (e.g. on_status is post-only) is surfaced at
+// MCP-tool input parse rather than at hook dispatch. scope="job" +
+// non-empty RunInterval is rejected verbatim per Q10 — scope="job"
+// hooks fire exactly once by construction (the call site, not the
+// RunInterval engine knob, owns the single-fire guarantee).
+func validateFuzzHTTPMacroConfig(label string, cfg *fuzzHTTPMacroConfig, isPre bool) error {
 	if cfg == nil {
 		return nil
 	}
@@ -160,6 +168,41 @@ func validateFuzzHTTPMacroConfig(label string, cfg *fuzzHTTPMacroConfig) error {
 	case "", "skip", "abort", "continue":
 	default:
 		return fmt.Errorf("%s: invalid on_error %q (must be skip, abort, or continue)", label, cfg.OnError)
+	}
+	// USK-981 Q10: scope="job" + non-empty RunInterval is structurally
+	// meaningless — scope="job" hooks fire exactly once via the call
+	// site, not via the RunInterval engine knob. Reject at MCP-tool
+	// input parse with the documented verbatim message.
+	if scope == "job" && cfg.RunInterval != "" {
+		return fmt.Errorf("%s: run_interval is only valid for scope=iteration; for scope=job the hook fires exactly once", label)
+	}
+	// USK-981 Q7 + Q12: when RunInterval is non-empty AND scope is
+	// "iteration", delegate to the polarity-specific hooks.go validator
+	// so the disjoint pre/post legal sets are enforced. We construct a
+	// transient hookConfig because validatePreMacroHook /
+	// validatePostMacroHook already implement the disjoint-set + N /
+	// StatusCodes / MatchPattern cross-field rules.
+	if cfg.RunInterval != "" || cfg.N != 0 || len(cfg.StatusCodes) > 0 || cfg.MatchPattern != "" {
+		h := &hookConfig{
+			Macro:        cfg.Name,
+			RunInterval:  cfg.RunInterval,
+			N:            cfg.N,
+			StatusCodes:  cfg.StatusCodes,
+			MatchPattern: cfg.MatchPattern,
+		}
+		var herr error
+		if isPre {
+			herr = validatePreMacroHook(h)
+		} else {
+			herr = validatePostMacroHook(h)
+		}
+		if herr != nil {
+			return fmt.Errorf("%s: %w", label, herr)
+		}
+		// Carry the compiled regex back so the hook executor reuses it
+		// rather than recompiling on every iteration (matches the
+		// validatePostMacroHook precedent for hooksInput callers).
+		cfg.compiledPattern = h.compiledPattern
 	}
 	return nil
 }
@@ -378,20 +421,57 @@ func buildFuzzHTTPVariantLoop(s *Server, plan *fuzzHTTPPlan, timeout time.Durati
 // buildIterationHookExecutor returns the hookExecutor used by the
 // per-iteration call sites. It is always non-nil so the gating logic in
 // runOne can dispatch via the executor; when no hook is configured, the
-// executor is a no-op shell. Iteration-scope passes RunInterval="always"
-// (which is also the default in shouldRunPreMacro / shouldRunPostMacro).
+// executor is a no-op shell.
+//
+// USK-981: iteration-scope hooks thread the user-supplied RunInterval /
+// N / StatusCodes / MatchPattern / compiledPattern into the underlying
+// hookConfig so the engine's shouldRunPreMacro / shouldRunPostMacro
+// gates (always / once / every_n / on_status / on_match) become
+// user-configurable. Empty RunInterval defaults to "always" — the same
+// as the no-knob path. Vars is intentionally NOT mirrored onto the
+// hookConfig.Vars field because fuzz_http's injection contract is
+// "Vars seeds the per-iteration kvStore at iteration start" (see
+// prepareIteration), which fires unconditionally on every iteration —
+// independent of the hook-fire gate. The hookConfig.Vars merge in
+// executePreMacro / executePostMacro is downstream of that gate and
+// would only fire when the hook itself fires.
 func buildIterationHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) *hookExecutor {
 	if preMacro == nil && postMacro == nil {
 		return newHookExecutor(s, nil, &hookState{})
 	}
 	hooks := &hooksInput{}
 	if preMacro != nil {
-		hooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
+		hooks.PreMacro = &hookConfig{
+			Macro:           preMacro.Name,
+			RunInterval:     resolveRunInterval(preMacro.RunInterval),
+			N:               preMacro.N,
+			StatusCodes:     preMacro.StatusCodes,
+			MatchPattern:    preMacro.MatchPattern,
+			compiledPattern: preMacro.compiledPattern,
+		}
 	}
 	if postMacro != nil {
-		hooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always", PassResponse: true}
+		hooks.PostMacro = &hookConfig{
+			Macro:           postMacro.Name,
+			RunInterval:     resolveRunInterval(postMacro.RunInterval),
+			N:               postMacro.N,
+			StatusCodes:     postMacro.StatusCodes,
+			MatchPattern:    postMacro.MatchPattern,
+			compiledPattern: postMacro.compiledPattern,
+			PassResponse:    true,
+		}
 	}
 	return newHookExecutor(s, hooks, &hookState{})
+}
+
+// resolveRunInterval returns the engine-facing RunInterval string,
+// defaulting empty to "always" so the underlying hooks.go gate matches
+// the pre-USK-981 behaviour when the caller does not opt in.
+func resolveRunInterval(s string) string {
+	if s == "" {
+		return "always"
+	}
+	return s
 }
 
 // buildJobHookExecutor returns (jobHookExec, jobKVStore) for the
@@ -399,6 +479,12 @@ func buildIterationHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroCon
 // Distinct from buildIterationHookExecutor so the hookState.preMacroExecuted
 // state is not flipped by the job-side single-fire call. Post-job leaves
 // PassResponse off (no per-iteration response is available — Q21).
+//
+// USK-981: scope="job" forces RunInterval="always" (the validator
+// already rejected non-empty RunInterval for scope="job", so this is
+// belt-and-braces). Vars from job-scope hooks is injected into the
+// returned jobKVStore with reserved-key silent-drop — matches the
+// internal/job/job.go mergeKVStore precedent.
 func buildJobHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) (*hookExecutor, map[string]string) {
 	if !isJobScope(preMacro) && !isJobScope(postMacro) {
 		return nil, nil
@@ -410,7 +496,33 @@ func buildJobHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) (
 	if isJobScope(postMacro) {
 		jobHooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always"}
 	}
-	return newHookExecutor(s, jobHooks, &hookState{}), make(map[string]string)
+	jobKV := make(map[string]string)
+	if isJobScope(preMacro) {
+		injectVarsRespectingReserved(jobKV, preMacro.Vars)
+	}
+	if isJobScope(postMacro) {
+		injectVarsRespectingReserved(jobKV, postMacro.Vars)
+	}
+	return newHookExecutor(s, jobHooks, &hookState{}), jobKV
+}
+
+// injectVarsRespectingReserved copies src into dst, silently dropping
+// keys with the reserved prefix ("__") so a user-supplied Vars entry
+// cannot shadow runtime-populated reserved keys (USK-981 Q2). Matches
+// the internal/job/job.go:mergeKVStore precedent.
+//
+// Local replication is preferred over importing internal/job for two
+// reasons: (1) the package boundary is control plane (internal/mcp) →
+// data path (internal/job), which the project conventions discourage;
+// (2) the function is small enough that DRYing it would cost more in
+// indirection than it saves.
+func injectVarsRespectingReserved(dst map[string]string, src map[string]string) {
+	for k, v := range src {
+		if macro.IsReservedKey(k) {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // runVariantLoop drives the variant loop body and returns
@@ -454,6 +566,22 @@ func (l *fuzzHTTPVariantLoop) runVariantLoop(ctx context.Context) (bool, string,
 // always false. Empty scope defaults to "iteration".
 func isJobScope(cfg *fuzzHTTPMacroConfig) bool {
 	return cfg != nil && cfg.Scope == "job"
+}
+
+// bumpHookIterationCount advances the hookState.requestCount by one so
+// the next iteration's shouldRunPreMacro / shouldRunPostMacro engine
+// gates evaluate against the post-iteration counter (USK-981). Pure
+// counter increment — lastStatusCode / lastError remain at zero values
+// because correctly wiring those requires deciding what counts as an
+// "error" for the on_error gate (transport error vs 4xx vs 5xx vs
+// pre-macro skip), which is deferred to USK-982. This makes
+// RunInterval="every_n" and "once" work end-to-end without committing
+// to on_error semantics yet.
+func (l *fuzzHTTPVariantLoop) bumpHookIterationCount() {
+	if l.hookExec == nil || l.hookExec.state == nil {
+		return
+	}
+	l.hookExec.state.requestCount++
 }
 
 // isIterationScope reports whether cfg is configured as scope="iteration"
@@ -536,6 +664,13 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		return stopReason, nil
 	}
 	if prep.skipped {
+		// USK-981: bump the iteration counter even on skip so RunInterval
+		// engine gates (every_n) treat skipped iterations as consuming
+		// their slot. Without this, on iteration 3 the gate would still
+		// see requestCount=0 from the iter-0 skip and re-fire pre_macro
+		// on every subsequent iteration. lastStatusCode / lastError stay
+		// untouched (D1 deferred to USK-982).
+		l.bumpHookIterationCount()
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
 	}
@@ -553,6 +688,7 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	expandedPayloads, expandErr := expandFuzzHTTPPayloads(payloads, kvStore)
 	if expandErr != nil {
 		l.recordVariantError(ctx, variantIdx, payloads, fmt.Sprintf("template expansion: %v", expandErr))
+		l.bumpHookIterationCount()
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
 	}
@@ -594,6 +730,13 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		l.runPostMacro(ctx, iterCtx, variantIdx, row, kvStore)
 	}
 
+	// USK-981: bump the iteration counter at the end of every normal-
+	// path iteration so RunInterval engine gates (every_n) see one more
+	// completed iteration before the next runOne call evaluates
+	// shouldRunPreMacro. lastStatusCode / lastError stay untouched
+	// (D1 deferred to USK-982).
+	l.bumpHookIterationCount()
+
 	nextIndices(l.indices, l.plan.positions)
 
 	if l.stopOn5xx && statusCode >= 500 && statusCode < 600 {
@@ -632,9 +775,27 @@ func (l *fuzzHTTPVariantLoop) prepareIteration(ctx context.Context, variantIdx i
 	// executePreMacro). Seeded with §__iteration§ / §__nonce§ via
 	// ResolveForIterationWithKV (or SeedIterationKV when no upstream
 	// rotation is configured).
+	//
+	// USK-981 Vars injection order:
+	//   1. jobKVStore copy (job-scope extracts and job-scope Vars)
+	//   2. iteration-scope Vars (operator-supplied static overrides)
+	//   3. SeedIterationKV (per-iteration reserved keys: __iteration,
+	//      __nonce, and any upstream-proxy rotation extracts)
+	//
+	// The order matters: per-iteration reserved keys must be the last
+	// writer so they win on collision, and Vars must be injected with
+	// reserved-key silent-drop (USK-981 Q2) so a Vars entry like
+	// {"__iteration":"override"} is dropped at injection rather than
+	// shadowing the value the iteration loop will seed.
 	kvStore := make(map[string]string)
 	for k, v := range l.jobKVStore {
 		kvStore[k] = v
+	}
+	if isIterationScope(l.preMacro) {
+		injectVarsRespectingReserved(kvStore, l.preMacro.Vars)
+	}
+	if isIterationScope(l.postMacro) {
+		injectVarsRespectingReserved(kvStore, l.postMacro.Vars)
 	}
 	connector.SeedIterationKV(kvStore, variantIdx)
 

--- a/internal/mcp/fuzz_http_macro_integration_test.go
+++ b/internal/mcp/fuzz_http_macro_integration_test.go
@@ -1388,3 +1388,521 @@ func TestFuzzHTTPMacro_ScopeJobPreSkipOnErrorReturnsStoppedReason(t *testing.T) 
 			r.HookName, r.IndexNum, r.Status)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// USK-981 — per-hook Vars overrides + RunInterval field surface.
+// ---------------------------------------------------------------------------
+
+// TestFuzzHTTPMacro_VarsOverrideSeedsKVStore verifies that pre_macro.vars
+// (scope=iteration) seeds every variant's per-iteration kvStore so the
+// header value template §static_token§ resolves on the wire even though
+// no macro extract was configured to populate it. Covers USK-981 §6
+// test #1 (Vars seeds iteration kvStore for §var§ resolution).
+func TestFuzzHTTPMacro_VarsOverrideSeedsKVStore(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	// preServer is a no-op; the pre macro has no extract. Vars is the
+	// only path that can put §static_token§ in the kvStore.
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzTokens atomic.Pointer[[]string]
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("X-Token")
+		for {
+			old := fuzzTokens.Load()
+			var cur []string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, tok)
+			if fuzzTokens.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-noop-vars", preFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+				{"name": "X-Token", "value": "§static_token§"},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name": "pre-noop-vars",
+				"vars": map[string]any{
+					"static_token": "vars-supplied-token",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != 2 {
+		t.Fatalf("CompletedVariants = %d, want 2", out.CompletedVariants)
+	}
+
+	tokens := *fuzzTokens.Load()
+	if len(tokens) != 2 {
+		t.Fatalf("fuzz received %d requests, want 2", len(tokens))
+	}
+	for i, tok := range tokens {
+		if tok != "vars-supplied-token" {
+			t.Errorf("variant %d X-Token = %q, want vars-supplied-token (from pre_macro.vars)", i, tok)
+		}
+	}
+}
+
+// TestFuzzHTTPMacro_VarsCollideWithReservedKeys verifies that a Vars
+// entry whose key matches the reserved prefix ("__iteration") is
+// silently dropped at injection time, so the iteration loop's seeded
+// value of §__iteration§ (variantIdx) wins over the operator's
+// override. Covers USK-981 §6 test #2.
+func TestFuzzHTTPMacro_VarsCollideWithReservedKeys(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzIters atomic.Pointer[[]string]
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		val := r.Header.Get("X-Iter")
+		for {
+			old := fuzzIters.Load()
+			var cur []string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, val)
+			if fuzzIters.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-noop-reserved", preFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+				{"name": "X-Iter", "value": "§__iteration§"},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name": "pre-noop-reserved",
+				"vars": map[string]any{
+					// Reserved-key collision: should be silently dropped so
+					// the iteration loop's seeded value wins. Without the
+					// drop, every variant's X-Iter would read "operator-
+					// override".
+					"__iteration": "operator-override",
+					// Companion non-reserved key to confirm Vars injection
+					// is otherwise functional in the same call.
+					"static_key": "static-value",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != 3 {
+		t.Fatalf("CompletedVariants = %d, want 3", out.CompletedVariants)
+	}
+
+	iters := *fuzzIters.Load()
+	if len(iters) != 3 {
+		t.Fatalf("fuzz received %d requests, want 3", len(iters))
+	}
+	// Each variant must see its own variant index (0, 1, 2) — the Vars
+	// "__iteration" override must NOT have shadowed the per-iteration
+	// reserved key.
+	for i, got := range iters {
+		want := fmt.Sprintf("%d", i)
+		if got != want {
+			t.Errorf("variant %d X-Iter = %q, want %q (reserved-key Vars override must be silently dropped)", i, got, want)
+		}
+		if got == "operator-override" {
+			t.Errorf("variant %d X-Iter = %q — reserved-key Vars override leaked", i, got)
+		}
+	}
+}
+
+// TestFuzzHTTPMacro_VarsScopeJobInjectedOncePerJob verifies that
+// pre_macro.vars on a scope="job" hook is injected into the job
+// kvStore once at job start and propagated into every per-iteration
+// kvStore via the existing copy at iteration setup. Covers USK-981
+// §6 test #3.
+func TestFuzzHTTPMacro_VarsScopeJobInjectedOncePerJob(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzTokens atomic.Pointer[[]string]
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("X-Token")
+		for {
+			old := fuzzTokens.Load()
+			var cur []string
+			if old != nil {
+				cur = append(cur, *old...)
+			}
+			cur = append(cur, tok)
+			if fuzzTokens.CompareAndSwap(old, &cur) {
+				break
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-job-vars-only", preFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+				{"name": "X-Token", "value": "§job_token§"},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":  "pre-job-vars-only",
+				"scope": "job",
+				"vars": map[string]any{
+					"job_token": "job-vars-token",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != 3 {
+		t.Fatalf("CompletedVariants = %d, want 3", out.CompletedVariants)
+	}
+
+	// Pre-job macro called exactly once (scope=job semantics).
+	if got := atomic.LoadInt32(&preCalls); got != 1 {
+		t.Errorf("pre macro called %d times, want 1 (scope=job)", got)
+	}
+
+	// Every variant must see the job-scope Vars value via the job-store
+	// copy at iteration setup.
+	tokens := *fuzzTokens.Load()
+	if len(tokens) != 3 {
+		t.Fatalf("fuzz received %d requests, want 3", len(tokens))
+	}
+	for i, tok := range tokens {
+		if tok != "job-vars-token" {
+			t.Errorf("variant %d X-Token = %q, want job-vars-token (from pre_macro.vars at scope=job)", i, tok)
+		}
+	}
+}
+
+// TestFuzzHTTPMacro_RunIntervalWithScopeJobRejected verifies the
+// cross-field validator rejects scope="job" + non-empty run_interval
+// at MCP-tool input parse time, with the documented verbatim error
+// message. Covers USK-981 §6 test #4 (USK-961 Q10).
+func TestFuzzHTTPMacro_RunIntervalWithScopeJobRejected(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-reject", preFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":         "pre-reject",
+				"scope":        "job",
+				"run_interval": "once",
+			},
+		},
+	})
+	if err != nil {
+		// Some MCP transports surface validation errors as a tool-call
+		// failure rather than an in-band error result. Both are
+		// acceptable, but the error text must include the verbatim
+		// message.
+		if !strings.Contains(err.Error(), "run_interval is only valid for scope=iteration") {
+			t.Fatalf("err = %v, want to contain the documented reject message", err)
+		}
+		return
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true for scope=job + run_interval, got IsError=false")
+	}
+	var msg strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*gomcp.TextContent); ok {
+			msg.WriteString(tc.Text)
+		}
+	}
+	got := msg.String()
+	if !strings.Contains(got, "run_interval is only valid for scope=iteration") {
+		t.Errorf("error text = %q, want to contain 'run_interval is only valid for scope=iteration; for scope=job the hook fires exactly once'", got)
+	}
+	if !strings.Contains(got, "for scope=job the hook fires exactly once") {
+		t.Errorf("error text = %q, want to contain the second-clause documented reject message", got)
+	}
+}
+
+// TestFuzzHTTPMacro_RunIntervalEveryN_PreFiresEveryNthIteration verifies
+// that pre_macro.run_interval="every_n" with N=3 fires on iterations 0,
+// 3, 6 only. Covers USK-981 §6 test #5.
+func TestFuzzHTTPMacro_RunIntervalEveryN_PreFiresEveryNthIteration(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-every-n", preFlowID, "", "", nil)
+
+	// 7 variants: pre fires on iter 0, 3, 6 → 3 pre calls.
+	payloads := []string{"/a0", "/a1", "/a2", "/a3", "/a4", "/a5", "/a6"}
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": payloads},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":         "pre-every-n",
+				"run_interval": "every_n",
+				"n":            3,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != len(payloads) {
+		t.Fatalf("CompletedVariants = %d, want %d", out.CompletedVariants, len(payloads))
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); int(got) != len(payloads) {
+		t.Errorf("fuzz server saw %d requests, want %d", got, len(payloads))
+	}
+	// Pre fires on iter 0, 3, 6 → 3 calls for 7 variants with N=3.
+	if got := atomic.LoadInt32(&preCalls); got != 3 {
+		t.Errorf("pre macro called %d times, want 3 (every_n=3 over 7 iters: 0,3,6)", got)
+	}
+}
+
+// TestFuzzHTTPMacro_RunIntervalOnce verifies that pre_macro
+// .run_interval="once" fires on iteration 0 only and the remaining
+// iterations skip the pre hook. Covers USK-981 §6 test #6.
+func TestFuzzHTTPMacro_RunIntervalOnce(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-once", preFlowID, "", "", nil)
+
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": []string{"/a", "/b", "/c", "/d"}},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":         "pre-once",
+				"run_interval": "once",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != 4 {
+		t.Fatalf("CompletedVariants = %d, want 4", out.CompletedVariants)
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); got != 4 {
+		t.Errorf("fuzz server saw %d requests, want 4", got)
+	}
+	// Pre fires once only.
+	if got := atomic.LoadInt32(&preCalls); got != 1 {
+		t.Errorf("pre macro called %d times, want 1 (run_interval=once)", got)
+	}
+}

--- a/internal/mcp/resources/help_fuzz_http.md
+++ b/internal/mcp/resources/help_fuzz_http.md
@@ -55,11 +55,19 @@ Per-VARIANT timeout in milliseconds. Default `30000`.
 
 ### pre_macro / post_macro (object, optional)
 
-Pre and post macro hooks dispatched around variants by name. Both fields take the same shape (USK-960, USK-961):
+Pre and post macro hooks dispatched around variants by name. Both fields take the same shape (USK-960, USK-961, USK-981):
 
 - **name** (string, REQUIRED): the stored macro name (defined via the `macro` tool's `define_macro` action).
 - **scope** (string, optional): `"iteration"` (default) or `"job"`. See "Macro hook scopes" below.
 - **on_error** (string, optional): `"skip"` (default) | `"abort"` | `"continue"`. See "OnError semantics" below.
+- **vars** (object string→string, optional): static kvStore overrides injected before the macro runs. For `scope="iteration"` the map is injected into every variant's per-iteration kvStore (after the job-store copy, before reserved-key seeding). For `scope="job"` it is injected once into the job kvStore at job start. Keys with the reserved prefix (`__`) are **silently dropped** at injection time so a `vars` entry cannot shadow runtime-populated keys (`__iteration`, `__nonce`, `__response_*`) — the runtime-seeded value always wins (USK-981).
+- **run_interval** (string, optional): hook firing cadence — **`scope="iteration"` only**. Rejected with an error when paired with `scope="job"` (job-scope hooks fire exactly once by construction).
+  - pre_macro legal values: `"always"` (default) | `"once"` | `"every_n"` | `"on_error"`.
+  - post_macro legal values: `"always"` (default) | `"on_status"` | `"on_match"`.
+  - The pre/post legal sets are disjoint: `on_status` and `on_match` are post-only; `once`, `every_n`, and `on_error` are pre-only. Picking the wrong direction is rejected at MCP-tool input parse time.
+- **n** (integer, optional): companion to pre_macro `run_interval="every_n"`. Required when `run_interval="every_n"`; must be ≥ 1.
+- **status_codes** (array of integer, optional): companion to post_macro `run_interval="on_status"`. Required when `run_interval="on_status"`.
+- **match_pattern** (string, optional): companion to post_macro `run_interval="on_match"`. Required when `run_interval="on_match"`.
 
 The hook macro shares the per-iteration (or per-job) KV Store with the fuzz request — `§var§` templates in the request inherit pre-macro extracts, and post-macros (scope=iteration only) receive `__response_status` / `__response_body` / `__response_headers__<lower(name)>__` reserved keys.
 
@@ -72,7 +80,7 @@ The hook macro shares the per-iteration (or per-job) KV Store with the fuzz requ
 
 Mix-scope is supported — `pre_macro` and `post_macro` may pick their scope independently. The job-scope KV Store is merged into each iteration's per-variant store at iteration start; per-iteration reserved keys then overwrite any conflicting job keys ("iteration wins"). So `pre_macro { scope: "job" }` extracting `session_token` makes `§session_token§` resolvable in every variant's request templates.
 
-> `run_interval` is `scope="iteration"` only — the engine knob for `every_n` / `on_status` / etc. dispatch is meaningful only when the hook fires per-variant. `scope="job"` hooks fire exactly once by construction (the call site, not `run_interval`, owns the single-fire guarantee); once the `run_interval` field is publicly surfaced on the fuzz_http hook config, pairing it with `scope="job"` will be rejected at validation time.
+> `run_interval` is `scope="iteration"` only — the engine knob for `every_n` / `on_status` / etc. dispatch is meaningful only when the hook fires per-variant. `scope="job"` hooks fire exactly once by construction (the call site, not `run_interval`, owns the single-fire guarantee); pairing `run_interval` with `scope="job"` is **rejected at MCP-tool input parse** with the error `"run_interval is only valid for scope=iteration; for scope=job the hook fires exactly once"` (USK-961 Q10, surfaced in USK-981).
 
 #### OnError semantics
 

--- a/internal/mcp/resources/schema_fuzz_http.json
+++ b/internal/mcp/resources/schema_fuzz_http.json
@@ -138,6 +138,29 @@
           "type": "string",
           "description": "skip (default; iteration scope skips the variant, job scope skips the whole job) | abort (aborts the whole fuzz run) | continue (record the error and proceed).",
           "enum": ["skip", "abort", "continue"]
+        },
+        "vars": {
+          "type": "object",
+          "description": "Static kvStore overrides injected before the macro runs. For scope=iteration, injected into every variant's per-iteration kvStore after the job-store copy and before reserved-key seeding. For scope=job, injected once into the job kvStore at job start. Keys with the '__' reserved prefix are silently dropped at injection time so a Vars entry cannot shadow runtime-populated reserved keys (__iteration, __nonce, __response_*).",
+          "additionalProperties": { "type": "string" }
+        },
+        "run_interval": {
+          "type": "string",
+          "description": "Hook firing cadence — scope=iteration only. For pre_macro: always (default) | once | every_n | on_error. Rejected with an error when scope='job' (scope=job hooks fire exactly once by construction)."
+        },
+        "n": {
+          "type": "integer",
+          "description": "Iteration cadence for pre_macro run_interval='every_n'. Required when run_interval='every_n'.",
+          "minimum": 1
+        },
+        "status_codes": {
+          "type": "array",
+          "description": "Response status codes gating post_macro run_interval='on_status'. pre_macro does NOT accept on_status — this field is rejected on pre_macro with a non-empty value.",
+          "items": { "type": "integer" }
+        },
+        "match_pattern": {
+          "type": "string",
+          "description": "Response body regex pattern for post_macro run_interval='on_match'. pre_macro does NOT accept on_match — this field is rejected on pre_macro with a non-empty value."
         }
       },
       "additionalProperties": false
@@ -160,6 +183,29 @@
           "type": "string",
           "description": "skip (default; log warn + record error row) | abort (post failures never abort the run; behaviour matches skip for post) | continue (same as skip).",
           "enum": ["skip", "abort", "continue"]
+        },
+        "vars": {
+          "type": "object",
+          "description": "Static kvStore overrides injected before the macro runs. For scope=iteration, injected into every variant's per-iteration kvStore after the job-store copy and before reserved-key seeding. For scope=job, injected once into the job kvStore at job start. Keys with the '__' reserved prefix are silently dropped at injection time so a Vars entry cannot shadow runtime-populated reserved keys (__iteration, __nonce, __response_*).",
+          "additionalProperties": { "type": "string" }
+        },
+        "run_interval": {
+          "type": "string",
+          "description": "Hook firing cadence — scope=iteration only. For post_macro: always (default) | on_status | on_match. Rejected with an error when scope='job' (scope=job hooks fire exactly once by construction)."
+        },
+        "n": {
+          "type": "integer",
+          "description": "Reserved for pre_macro run_interval='every_n'. post_macro does NOT accept every_n; supplying n on post_macro has no effect.",
+          "minimum": 1
+        },
+        "status_codes": {
+          "type": "array",
+          "description": "Response status codes gating post_macro run_interval='on_status'. Required when run_interval='on_status'.",
+          "items": { "type": "integer" }
+        },
+        "match_pattern": {
+          "type": "string",
+          "description": "Response body regex pattern for post_macro run_interval='on_match'. Required when run_interval='on_match'."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- Extends `fuzzHTTPMacroConfig` with `Vars`, `RunInterval`, `N`, `StatusCodes`, `MatchPattern` fields (scope expanded by Phase 1.5 design review from the Issue body's 2-field core).
- Validates `Scope == "job" && RunInterval != ""` at MCP-tool input parse with the documented verbatim error message (per USK-961 Q10).
- Silent-drops reserved-key (`__*`) collisions in Vars at injection time (matches `internal/job/job.go:325` `mergeKVStore` precedent).
- Vars injection sites: job-scope = once into `jobKVStore` at job start; iteration-scope = per-iteration kvStore after job-store copy, before `SeedIterationKV` (per design review Q1).
- Threads `RunInterval` / `N` / `StatusCodes` / `MatchPattern` from `fuzzHTTPMacroConfig` into the underlying `hookConfig` so `shouldRunPreMacro` / `shouldRunPostMacro` engine gates become user-configurable (per design review Q11).
- Increments `hookState.requestCount` at the end of every iteration (including skipped iterations and template-expansion failures) so `RunInterval="every_n"` and `"once"` work end-to-end. `lastStatusCode` / `lastError` remain at zero values (USK-982 follow-up for `on_error` pre-macro semantics).
- Schema + help-doc updates (preserves USK-979's `run_interval` scope-constraint sentence — refined to state the reject is now active rather than pending).
- 6 new tests mirroring the ScopeJob* test harness pattern.

## Scope adjustments from Phase 1.5 design review
- **Expanded**: Original Issue named only `Vars` + `RunInterval`. Design review surfaced that RunInterval is half-wired without the subfields (`n` / `status_codes` / `match_pattern`); included to make `every_n` / `on_status` / `on_match` end-to-end usable.
- **Deferred**: Pre-macro `on_error` RunInterval correctness — `hookExecutor.updateState` wiring lastStatusCode / lastError requires deciding what counts as an "error" (transport vs 4xx vs 5xx vs pre-macro skip). Filed as USK-982. This PR bumps only `requestCount` to unblock `every_n` / `once`.

## Design decisions upheld
- Q1: Vars injected after job-store copy, before SeedIterationKV.
- Q2: Reserved-key collisions silent-dropped via local replication of `mergeKVStore` pattern (control-plane to data-path import avoided).
- Q3: Job-scope Vars injected once into jobKVStore.
- Q6: Cross-field reject lives in `validateFuzzHTTPMacroConfig`.
- Q7: JSON schema `run_interval` is open-string; per-direction enum validation delegated to hooks.go validators.
- Q11: N/StatusCodes/MatchPattern surfaced on fuzzHTTPMacroConfig and forwarded to hookConfig in buildIterationHookExecutor.
- Q12: validateFuzzHTTPMacroConfig gains an `isPre bool` polarity argument that selects validatePreMacroHook vs validatePostMacroHook.

## Test plan
- [x] `TestFuzzHTTPMacro_VarsOverrideSeedsKVStore` — Vars seeds iteration kvStore; §var§ resolves on wire.
- [x] `TestFuzzHTTPMacro_VarsCollideWithReservedKeys` — Vars `__iteration` override silent-dropped; iteration-loop seeded value wins.
- [x] `TestFuzzHTTPMacro_VarsScopeJobInjectedOncePerJob` — pre=job Vars present in every iteration's kvStore; pre called exactly once.
- [x] `TestFuzzHTTPMacro_RunIntervalWithScopeJobRejected` — error text contains the verbatim documented message.
- [x] `TestFuzzHTTPMacro_RunIntervalEveryN_PreFiresEveryNthIteration` — N=3 over 7 iters → pre fires 3 times (iter 0, 3, 6).
- [x] `TestFuzzHTTPMacro_RunIntervalOnce` — pre fires exactly once over 4 iters.
- [x] make lint PASS
- [x] make build PASS
- [x] make test PASS (fast tier)
- [x] go test -race -tags e2e ./internal/mcp/ PASS (full mcp e2e suite)

Resolves USK-981
Follow-up: USK-982
Linear: https://linear.app/usk6666/issue/USK-981

🤖 Generated with [Claude Code](https://claude.com/claude-code)