### PR TITLE
refactor(mcp): extract shared MacroConfig + validators + executor builders into fuzz_macro_common.go

### DIFF
--- a/internal/mcp/fuzz_http.go
+++ b/internal/mcp/fuzz_http.go
@@ -36,7 +36,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -97,95 +96,8 @@ type fuzzHTTPInput struct {
 	// before per-iteration reserved keys are seeded — so pre=job extracts
 	// flow into every variant's request templating. mix-scope (pre and
 	// post with independent scope) is supported.
-	PreMacro  *fuzzHTTPMacroConfig `json:"pre_macro,omitempty" jsonschema:"pre macro hook executed before a variant's send. scope=iteration (default; fires once per variant) | job (fires once before the variant loop; extracts shared with every variant). on_error: skip|abort|continue (default skip). For scope=job, skip returns a successful job result with completed_variants=0 and stopped_reason set"`
-	PostMacro *fuzzHTTPMacroConfig `json:"post_macro,omitempty" jsonschema:"post macro hook executed after a variant's response. scope=iteration (default; fires once per variant against __response_* reserved keys) | job (fires once after the variant loop completes; no __response_* keys, since there is no single response). on_error: skip|abort|continue (default skip). For scope=iteration, pass_response is forced on so __response_status / __response_body / __response_headers__<lower(name)>__ are visible to the macro's template expansion"`
-}
-
-// fuzzHTTPMacroConfig is the pre/post macro hook configuration for
-// fuzz_http (USK-960 per-iteration, USK-961 per-job + mix-scope).
-//
-// scope="iteration" (default) fires once per variant; the per-iteration
-// KV Store is allocated fresh in the variant loop with reserved keys
-// §__iteration§ / §__nonce§ seeded and (for post) reserved __response_*
-// keys injected before the macro runs.
-//
-// scope="job" fires exactly once outside the variant loop against a
-// separate job-scoped KV Store that is merged into each iteration's
-// store before per-iteration reserved keys are seeded — so pre=job
-// extracts flow into every variant's request templating, and post=job
-// summarises after the loop completes. Reserved keys (§__iteration§,
-// §__nonce§, __response_*) are NOT visible to job-scope macros (the
-// loop has not started for pre-job, and is over with discarded per-
-// iteration kvStores for post-job). run_interval is rejected when
-// scope="job" (single-fire by construction).
-type fuzzHTTPMacroConfig struct {
-	// Name is the stored macro name (defined via macro.define).
-	Name string `json:"name" jsonschema:"REQUIRED stored macro name"`
-
-	// Scope: "iteration" (default) or "job". Mix-scope is supported —
-	// pre and post may independently select their scope. Empty defaults
-	// to "iteration".
-	Scope string `json:"scope,omitempty" jsonschema:"iteration (default; fires once per variant) | job (fires once outside the variant loop; KV Store is shared across the whole job and merged into each iteration's per-variant store)"`
-
-	// OnError selects the iteration's behaviour when the hook errors.
-	//   "skip"     (default) — record the iteration as skipped, do not send
-	//                          the fuzz request, do not run the post hook,
-	//                          continue to the next variant.
-	//   "abort"    — abort the fuzz run with an error.
-	//   "continue" — log the error, persist a fuzz_macro_results row, and
-	//                continue to the variant's send (templates may carry
-	//                unresolved §var§ literals — recorded in
-	//                fuzz_results.error).
-	OnError string `json:"on_error,omitempty" jsonschema:"skip (default) | abort | continue"`
-
-	// Vars is a static map of kvStore overrides injected before the macro
-	// runs. Keys with the reserved prefix ("__") are silently dropped at
-	// injection time (matches internal/job/job.go:mergeKVStore precedent)
-	// so a Vars entry cannot shadow runtime-populated reserved keys such
-	// as __iteration / __nonce / __response_* (USK-981 Q2).
-	//
-	// scope="iteration": Vars is injected into every variant's per-
-	// iteration kvStore after the job-store copy and before
-	// SeedIterationKV — so the operator's static overrides are visible to
-	// §var§ template expansion on the variant request but cannot shadow
-	// per-iteration reserved keys.
-	//
-	// scope="job": Vars is injected once into the job kvStore at job
-	// start. The job-store is then naturally merged into every per-
-	// iteration kvStore via the existing copy at iteration setup.
-	Vars map[string]string `json:"vars,omitempty" jsonschema:"static kvStore overrides injected before the macro runs. Keys with the '__' reserved prefix are silently dropped (USK-981)"`
-
-	// RunInterval gates when the hook fires across iterations. Only valid
-	// for scope="iteration" — scope="job" hooks fire exactly once by
-	// construction and the validator rejects scope="job" + non-empty
-	// RunInterval (USK-961 Q10).
-	//
-	// pre_macro legal values: "always" (default) | "once" | "every_n" |
-	// "on_error". post_macro legal values: "always" (default) |
-	// "on_status" | "on_match". Pre and post have disjoint legal sets;
-	// validation runs per-direction via the underlying hooks.go
-	// validators (USK-981 Q7).
-	RunInterval string `json:"run_interval,omitempty" jsonschema:"hook firing cadence (scope=iteration only). pre_macro: always (default) | once | every_n | on_error. post_macro: always (default) | on_status | on_match. Rejected when scope='job'"`
-
-	// N is the interval count for RunInterval="every_n". Required when
-	// RunInterval="every_n"; ignored otherwise.
-	N int `json:"n,omitempty" jsonschema:"iteration cadence for RunInterval='every_n' (>= 1)"`
-
-	// StatusCodes is the list of response status codes that gate
-	// post_macro firing for RunInterval="on_status". Required when
-	// RunInterval="on_status"; ignored otherwise. post_macro only.
-	StatusCodes []int `json:"status_codes,omitempty" jsonschema:"response status codes for post_macro RunInterval='on_status'"`
-
-	// MatchPattern is the regex pattern matched against the response body
-	// for post_macro RunInterval="on_match". Required when
-	// RunInterval="on_match"; ignored otherwise. post_macro only.
-	MatchPattern string `json:"match_pattern,omitempty" jsonschema:"response body regex pattern for post_macro RunInterval='on_match'"`
-
-	// compiledPattern is the pre-compiled MatchPattern, set during
-	// validation so the hook executor reuses it across iterations rather
-	// than recompiling. Not serialised — internal to the validator/
-	// executor handoff. Matches the precedent on hookConfig.compiledPattern.
-	compiledPattern *regexp.Regexp `json:"-"`
+	PreMacro  *MacroConfig `json:"pre_macro,omitempty" jsonschema:"pre macro hook executed before a variant's send. scope=iteration (default; fires once per variant) | job (fires once before the variant loop; extracts shared with every variant). on_error: skip|abort|continue (default skip). For scope=job, skip returns a successful job result with completed_variants=0 and stopped_reason set"`
+	PostMacro *MacroConfig `json:"post_macro,omitempty" jsonschema:"post macro hook executed after a variant's response. scope=iteration (default; fires once per variant against __response_* reserved keys) | job (fires once after the variant loop completes; no __response_* keys, since there is no single response). on_error: skip|abort|continue (default skip). For scope=iteration, pass_response is forced on so __response_status / __response_body / __response_headers__<lower(name)>__ are visible to the macro's template expansion"`
 }
 
 // fuzzHTTPPosition describes one fuzz position. Path is a typed

--- a/internal/mcp/fuzz_http_helpers.go
+++ b/internal/mcp/fuzz_http_helpers.go
@@ -46,7 +46,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
@@ -123,86 +122,11 @@ func validateFuzzHTTPInput(input *fuzzHTTPInput) error {
 			return fmt.Errorf("positions cartesian product exceeds %d variants (computed at position %d); reduce payload counts or split into multiple calls", maxFuzzHTTPVariants, i)
 		}
 	}
-	if err := validateFuzzHTTPMacroConfig("pre_macro", input.PreMacro, true); err != nil {
+	if err := ValidateMacroConfig("pre_macro", input.PreMacro, true); err != nil {
 		return err
 	}
-	if err := validateFuzzHTTPMacroConfig("post_macro", input.PostMacro, false); err != nil {
+	if err := ValidateMacroConfig("post_macro", input.PostMacro, false); err != nil {
 		return err
-	}
-	return nil
-}
-
-// validateFuzzHTTPMacroConfig validates one pre/post macro hook config.
-// scope="iteration" (default) and scope="job" are both accepted (USK-961).
-//
-// macro-name lookup is intentionally deferred to runtime — checking the
-// stored macros table here would require an extra DB roundtrip for every
-// fuzz_http call. Runtime invocation surfaces the missing-macro error via
-// loadAndBuildMacroDeps and short-circuits the iteration per the OnError
-// policy.
-//
-// USK-981: when RunInterval is non-empty, the pre/post legal set is
-// enforced via validatePreMacroHook / validatePostMacroHook so the
-// directional asymmetry (e.g. on_status is post-only) is surfaced at
-// MCP-tool input parse rather than at hook dispatch. scope="job" +
-// non-empty RunInterval is rejected verbatim per Q10 — scope="job"
-// hooks fire exactly once by construction (the call site, not the
-// RunInterval engine knob, owns the single-fire guarantee).
-func validateFuzzHTTPMacroConfig(label string, cfg *fuzzHTTPMacroConfig, isPre bool) error {
-	if cfg == nil {
-		return nil
-	}
-	if cfg.Name == "" {
-		return fmt.Errorf("%s: name is required", label)
-	}
-	scope := cfg.Scope
-	if scope == "" {
-		scope = "iteration"
-	}
-	switch scope {
-	case "iteration", "job":
-	default:
-		return fmt.Errorf("%s: invalid scope %q (must be iteration or job)", label, scope)
-	}
-	switch cfg.OnError {
-	case "", "skip", "abort", "continue":
-	default:
-		return fmt.Errorf("%s: invalid on_error %q (must be skip, abort, or continue)", label, cfg.OnError)
-	}
-	// USK-981 Q10: scope="job" + non-empty RunInterval is structurally
-	// meaningless — scope="job" hooks fire exactly once via the call
-	// site, not via the RunInterval engine knob. Reject at MCP-tool
-	// input parse with the documented verbatim message.
-	if scope == "job" && cfg.RunInterval != "" {
-		return fmt.Errorf("%s: run_interval is only valid for scope=iteration; for scope=job the hook fires exactly once", label)
-	}
-	// USK-981 Q7 + Q12: when RunInterval is non-empty AND scope is
-	// "iteration", delegate to the polarity-specific hooks.go validator
-	// so the disjoint pre/post legal sets are enforced. We construct a
-	// transient hookConfig because validatePreMacroHook /
-	// validatePostMacroHook already implement the disjoint-set + N /
-	// StatusCodes / MatchPattern cross-field rules.
-	if cfg.RunInterval != "" || cfg.N != 0 || len(cfg.StatusCodes) > 0 || cfg.MatchPattern != "" {
-		h := &hookConfig{
-			Macro:        cfg.Name,
-			RunInterval:  cfg.RunInterval,
-			N:            cfg.N,
-			StatusCodes:  cfg.StatusCodes,
-			MatchPattern: cfg.MatchPattern,
-		}
-		var herr error
-		if isPre {
-			herr = validatePreMacroHook(h)
-		} else {
-			herr = validatePostMacroHook(h)
-		}
-		if herr != nil {
-			return fmt.Errorf("%s: %w", label, herr)
-		}
-		// Carry the compiled regex back so the hook executor reuses it
-		// rather than recompiling on every iteration (matches the
-		// validatePostMacroHook precedent for hooksInput callers).
-		cfg.compiledPattern = h.compiledPattern
 	}
 	return nil
 }
@@ -345,14 +269,14 @@ func (s *Server) buildFuzzHTTPPlan(ctx context.Context, input *fuzzHTTPInput) (*
 // and the for-variant loop; post-job runs after the loop body exits
 // (including the stop_on_5xx terminal path, but NOT on ctx cancel or
 // pre-job abort).
-func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *fuzzHTTPMacroConfig) ([]fuzzHTTPVariantRow, int, string, error) {
+func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *MacroConfig) ([]fuzzHTTPVariantRow, int, string, error) {
 	loop := buildFuzzHTTPVariantLoop(s, plan, timeout, stopOn5xx, tag, fuzzID, upstreamProxy, preMacro, postMacro)
 
 	// USK-961 pre-job: fire once before the variant loop. Abort short-
 	// circuits the whole job; skip returns success with stopped_reason;
 	// continue records the error and proceeds with whatever jobKVStore
 	// captured.
-	if isJobScope(preMacro) {
+	if IsJobScope(preMacro) {
 		jobAction, stopReason, retErr := loop.runPreJobMacro(ctx)
 		if retErr != nil {
 			return loop.rows, loop.completed, "", retErr
@@ -371,7 +295,7 @@ func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, ti
 	// post-job fires on natural exhaustion or stop_on_5xx exit, but NOT
 	// on ctx cancel. completedNormally captures "we reached the
 	// post-job firing path through a non-cancel exit".
-	if completedNormally && isJobScope(postMacro) {
+	if completedNormally && IsJobScope(postMacro) {
 		loop.runPostJobMacro(ctx)
 	}
 
@@ -382,7 +306,7 @@ func (s *Server) runFuzzHTTPVariants(ctx context.Context, plan *fuzzHTTPPlan, ti
 // by all variants. Split out of runFuzzHTTPVariants to keep that function
 // below the gocyclo threshold; the construction logic is mechanical and
 // has no branch fan-out outside the hook-config assembly.
-func buildFuzzHTTPVariantLoop(s *Server, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *fuzzHTTPMacroConfig) *fuzzHTTPVariantLoop {
+func buildFuzzHTTPVariantLoop(s *Server, plan *fuzzHTTPPlan, timeout time.Duration, stopOn5xx bool, tag, fuzzID string, upstreamProxy *UpstreamProxyConfig, preMacro, postMacro *MacroConfig) *fuzzHTTPVariantLoop {
 	loop := &fuzzHTTPVariantLoop{
 		s:             s,
 		plan:          plan,
@@ -409,120 +333,13 @@ func buildFuzzHTTPVariantLoop(s *Server, plan *fuzzHTTPPlan, timeout time.Durati
 	}
 	loop.rateLimitHost = rateLimitHost
 
-	loop.hookExec = buildIterationHookExecutor(s, preMacro, postMacro)
-	loop.jobHookExec, loop.jobKVStore = buildJobHookExecutor(s, preMacro, postMacro)
+	loop.hookExec = BuildIterationHookExecutor(s, preMacro, postMacro)
+	loop.jobHookExec, loop.jobKVStore = BuildJobHookExecutor(s, preMacro, postMacro)
 
 	loop.rows = make([]fuzzHTTPVariantRow, 0, plan.totalVariants)
 	loop.indices = make([]int, len(plan.positions))
 
 	return loop
-}
-
-// buildIterationHookExecutor returns the hookExecutor used by the
-// per-iteration call sites. It is always non-nil so the gating logic in
-// runOne can dispatch via the executor; when no hook is configured, the
-// executor is a no-op shell.
-//
-// USK-981: iteration-scope hooks thread the user-supplied RunInterval /
-// N / StatusCodes / MatchPattern / compiledPattern into the underlying
-// hookConfig so the engine's shouldRunPreMacro / shouldRunPostMacro
-// gates (always / once / every_n / on_status / on_match) become
-// user-configurable. Empty RunInterval defaults to "always" — the same
-// as the no-knob path. Vars is intentionally NOT mirrored onto the
-// hookConfig.Vars field because fuzz_http's injection contract is
-// "Vars seeds the per-iteration kvStore at iteration start" (see
-// prepareIteration), which fires unconditionally on every iteration —
-// independent of the hook-fire gate. The hookConfig.Vars merge in
-// executePreMacro / executePostMacro is downstream of that gate and
-// would only fire when the hook itself fires.
-func buildIterationHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) *hookExecutor {
-	if preMacro == nil && postMacro == nil {
-		return newHookExecutor(s, nil, &hookState{})
-	}
-	hooks := &hooksInput{}
-	if preMacro != nil {
-		hooks.PreMacro = &hookConfig{
-			Macro:           preMacro.Name,
-			RunInterval:     resolveRunInterval(preMacro.RunInterval),
-			N:               preMacro.N,
-			StatusCodes:     preMacro.StatusCodes,
-			MatchPattern:    preMacro.MatchPattern,
-			compiledPattern: preMacro.compiledPattern,
-		}
-	}
-	if postMacro != nil {
-		hooks.PostMacro = &hookConfig{
-			Macro:           postMacro.Name,
-			RunInterval:     resolveRunInterval(postMacro.RunInterval),
-			N:               postMacro.N,
-			StatusCodes:     postMacro.StatusCodes,
-			MatchPattern:    postMacro.MatchPattern,
-			compiledPattern: postMacro.compiledPattern,
-			PassResponse:    true,
-		}
-	}
-	return newHookExecutor(s, hooks, &hookState{})
-}
-
-// resolveRunInterval returns the engine-facing RunInterval string,
-// defaulting empty to "always" so the underlying hooks.go gate matches
-// the pre-USK-981 behaviour when the caller does not opt in.
-func resolveRunInterval(s string) string {
-	if s == "" {
-		return "always"
-	}
-	return s
-}
-
-// buildJobHookExecutor returns (jobHookExec, jobKVStore) for the
-// scope="job" call sites, or (nil, nil) when neither hook is job-scoped.
-// Distinct from buildIterationHookExecutor so the hookState.preMacroExecuted
-// state is not flipped by the job-side single-fire call. Post-job leaves
-// PassResponse off (no per-iteration response is available — Q21).
-//
-// USK-981: scope="job" forces RunInterval="always" (the validator
-// already rejected non-empty RunInterval for scope="job", so this is
-// belt-and-braces). Vars from job-scope hooks is injected into the
-// returned jobKVStore with reserved-key silent-drop — matches the
-// internal/job/job.go mergeKVStore precedent.
-func buildJobHookExecutor(s *Server, preMacro, postMacro *fuzzHTTPMacroConfig) (*hookExecutor, map[string]string) {
-	if !isJobScope(preMacro) && !isJobScope(postMacro) {
-		return nil, nil
-	}
-	jobHooks := &hooksInput{}
-	if isJobScope(preMacro) {
-		jobHooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
-	}
-	if isJobScope(postMacro) {
-		jobHooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always"}
-	}
-	jobKV := make(map[string]string)
-	if isJobScope(preMacro) {
-		injectVarsRespectingReserved(jobKV, preMacro.Vars)
-	}
-	if isJobScope(postMacro) {
-		injectVarsRespectingReserved(jobKV, postMacro.Vars)
-	}
-	return newHookExecutor(s, jobHooks, &hookState{}), jobKV
-}
-
-// injectVarsRespectingReserved copies src into dst, silently dropping
-// keys with the reserved prefix ("__") so a user-supplied Vars entry
-// cannot shadow runtime-populated reserved keys (USK-981 Q2). Matches
-// the internal/job/job.go:mergeKVStore precedent.
-//
-// Local replication is preferred over importing internal/job for two
-// reasons: (1) the package boundary is control plane (internal/mcp) →
-// data path (internal/job), which the project conventions discourage;
-// (2) the function is small enough that DRYing it would cost more in
-// indirection than it saves.
-func injectVarsRespectingReserved(dst map[string]string, src map[string]string) {
-	for k, v := range src {
-		if macro.IsReservedKey(k) {
-			continue
-		}
-		dst[k] = v
-	}
 }
 
 // runVariantLoop drives the variant loop body and returns
@@ -562,37 +379,6 @@ func (l *fuzzHTTPVariantLoop) runVariantLoop(ctx context.Context) (bool, string,
 	return true, "", nil
 }
 
-// isJobScope reports whether cfg is configured as scope="job". Nil is
-// always false. Empty scope defaults to "iteration".
-func isJobScope(cfg *fuzzHTTPMacroConfig) bool {
-	return cfg != nil && cfg.Scope == "job"
-}
-
-// bumpHookIterationCount advances the hookState.requestCount by one so
-// the next iteration's shouldRunPreMacro / shouldRunPostMacro engine
-// gates evaluate against the post-iteration counter (USK-981). Pure
-// counter increment — lastStatusCode / lastError remain at zero values
-// because correctly wiring those requires deciding what counts as an
-// "error" for the on_error gate (transport error vs 4xx vs 5xx vs
-// pre-macro skip), which is deferred to USK-982. This makes
-// RunInterval="every_n" and "once" work end-to-end without committing
-// to on_error semantics yet.
-func (l *fuzzHTTPVariantLoop) bumpHookIterationCount() {
-	if l.hookExec == nil || l.hookExec.state == nil {
-		return
-	}
-	l.hookExec.state.requestCount++
-}
-
-// isIterationScope reports whether cfg is configured as scope="iteration"
-// (or empty, which defaults to iteration). Nil is always false.
-func isIterationScope(cfg *fuzzHTTPMacroConfig) bool {
-	if cfg == nil {
-		return false
-	}
-	return cfg.Scope == "" || cfg.Scope == "iteration"
-}
-
 // fuzzHTTPVariantLoop bundles the per-run state shared across iterations
 // so the inner loop body (runOne) is a method on a small struct instead
 // of an 11-argument free function. The split keeps cyclomatic complexity
@@ -612,8 +398,8 @@ type fuzzHTTPVariantLoop struct {
 	tag           string
 	fuzzID        string
 	upstreamProxy *UpstreamProxyConfig
-	preMacro      *fuzzHTTPMacroConfig
-	postMacro     *fuzzHTTPMacroConfig
+	preMacro      *MacroConfig
+	postMacro     *MacroConfig
 	encoders      *pipeline.WireEncoderRegistry
 	pipe          *pipeline.Pipeline
 	dial          session.DialFunc
@@ -670,7 +456,7 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		// see requestCount=0 from the iter-0 skip and re-fire pre_macro
 		// on every subsequent iteration. lastStatusCode / lastError stay
 		// untouched (D1 deferred to USK-982).
-		l.bumpHookIterationCount()
+		BumpHookIterationCount(l.hookExec)
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
 	}
@@ -688,7 +474,7 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	expandedPayloads, expandErr := expandFuzzHTTPPayloads(payloads, kvStore)
 	if expandErr != nil {
 		l.recordVariantError(ctx, variantIdx, payloads, fmt.Sprintf("template expansion: %v", expandErr))
-		l.bumpHookIterationCount()
+		BumpHookIterationCount(l.hookExec)
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
 	}
@@ -726,7 +512,7 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	// USK-961: gate post-iteration on scope="iteration" (or empty —
 	// defaults to iteration). scope="job" post runs once after the
 	// variant loop completes.
-	if isIterationScope(l.postMacro) {
+	if IsIterationScope(l.postMacro) {
 		l.runPostMacro(ctx, iterCtx, variantIdx, row, kvStore)
 	}
 
@@ -735,7 +521,7 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	// completed iteration before the next runOne call evaluates
 	// shouldRunPreMacro. lastStatusCode / lastError stay untouched
 	// (D1 deferred to USK-982).
-	l.bumpHookIterationCount()
+	BumpHookIterationCount(l.hookExec)
 
 	nextIndices(l.indices, l.plan.positions)
 
@@ -787,17 +573,10 @@ func (l *fuzzHTTPVariantLoop) prepareIteration(ctx context.Context, variantIdx i
 	// reserved-key silent-drop (USK-981 Q2) so a Vars entry like
 	// {"__iteration":"override"} is dropped at injection rather than
 	// shadowing the value the iteration loop will seed.
-	kvStore := make(map[string]string)
-	for k, v := range l.jobKVStore {
-		kvStore[k] = v
-	}
-	if isIterationScope(l.preMacro) {
-		injectVarsRespectingReserved(kvStore, l.preMacro.Vars)
-	}
-	if isIterationScope(l.postMacro) {
-		injectVarsRespectingReserved(kvStore, l.postMacro.Vars)
-	}
-	connector.SeedIterationKV(kvStore, variantIdx)
+	//
+	// USK-983: the build sequence is shared with fuzz_ws / fuzz_grpc /
+	// fuzz_raw via PrepareIteration in fuzz_macro_common.go.
+	kvStore := PrepareIteration(l.jobKVStore, l.preMacro, l.postMacro, variantIdx)
 
 	iterCtx, ipErr := l.upstreamProxy.ResolveForIterationWithKV(ctx, variantIdx, kvStore)
 	if ipErr != nil {
@@ -808,7 +587,7 @@ func (l *fuzzHTTPVariantLoop) prepareIteration(ctx context.Context, variantIdx i
 	// USK-961: pre-iteration only fires when pre is configured at
 	// scope="iteration" (empty defaults to iteration). When pre is
 	// scope="job", the executor was invoked once outside the loop.
-	if !isIterationScope(l.preMacro) {
+	if !IsIterationScope(l.preMacro) {
 		return fuzzHTTPIterationPrep{kvStore: kvStore, iterCtx: iterCtx}, "", nil
 	}
 	preState, retErr := l.runPreMacro(ctx, iterCtx, variantIdx, payloads, kvStore)
@@ -920,7 +699,7 @@ const (
 // fuzz_macro_results.index_num=-1 is the documented sentinel for
 // job-scope hook rows (see FuzzMacroResult.IndexNum doc comment).
 func (l *fuzzHTTPVariantLoop) runPreJobMacro(ctx context.Context) (fuzzHTTPJobPreOutcome, string, error) {
-	if l.jobHookExec == nil || l.preMacro == nil || !isJobScope(l.preMacro) {
+	if l.jobHookExec == nil || l.preMacro == nil || !IsJobScope(l.preMacro) {
 		return fuzzHTTPPreJobOK, "", nil
 	}
 	_, hookErr := l.jobHookExec.executePreMacro(ctx, l.jobKVStore)
@@ -959,7 +738,7 @@ func (l *fuzzHTTPVariantLoop) runPreJobMacro(ctx context.Context) (fuzzHTTPJobPr
 // fuzz_macro_results row at index_num=-1 and return. Matches
 // per-iteration post precedent (post failures don't escalate to retErr).
 func (l *fuzzHTTPVariantLoop) runPostJobMacro(ctx context.Context) {
-	if l.jobHookExec == nil || l.postMacro == nil || !isJobScope(l.postMacro) {
+	if l.jobHookExec == nil || l.postMacro == nil || !IsJobScope(l.postMacro) {
 		return
 	}
 	// Post-job has no per-iteration response to inject. Pass zero values

--- a/internal/mcp/fuzz_macro_common.go
+++ b/internal/mcp/fuzz_macro_common.go
@@ -1,0 +1,380 @@
+// Package mcp fuzz_macro_common.go holds the shared infrastructure for
+// pre/post macro hooks across the typed fuzz tools: fuzz_http (live
+// today) and fuzz_ws / fuzz_grpc / fuzz_raw (in-progress per USK-984 /
+// USK-985 / USK-986). The exported symbols here are the contract those
+// per-protocol fuzz tools call into so the macro hook config struct
+// (MacroConfig), its validator, the iteration / job hookExecutor
+// builders, and the per-iteration kvStore prep are written once and
+// reused across protocols.
+//
+// USK-983: Pure-refactor extraction from fuzz_http_helpers.go and
+// fuzz_http.go — fuzz_http's behaviour is unchanged. The exported
+// names mark the seam that the sibling fuzz_ws / fuzz_grpc / fuzz_raw
+// implementations will plug into.
+package mcp
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/macro"
+)
+
+// MacroConfig is the pre/post macro hook configuration shared by the
+// typed fuzz tools (fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw).
+// USK-960 introduced per-iteration hooks; USK-961 added per-job +
+// mix-scope; USK-983 extracted the per-protocol-neutral parts here so
+// fuzz_ws / fuzz_grpc / fuzz_raw can reuse the same struct shape and
+// validators without duplicating the schema tags.
+//
+// scope="iteration" (default) fires once per variant; the per-iteration
+// KV Store is allocated fresh in the variant loop with reserved keys
+// §__iteration§ / §__nonce§ seeded and (for post) reserved __response_*
+// keys injected before the macro runs.
+//
+// scope="job" fires exactly once outside the variant loop against a
+// separate job-scoped KV Store that is merged into each iteration's
+// store before per-iteration reserved keys are seeded — so pre=job
+// extracts flow into every variant's request templating, and post=job
+// summarises after the loop completes. Reserved keys (§__iteration§,
+// §__nonce§, __response_*) are NOT visible to job-scope macros (the
+// loop has not started for pre-job, and is over with discarded per-
+// iteration kvStores for post-job). run_interval is rejected when
+// scope="job" (single-fire by construction).
+type MacroConfig struct {
+	// Name is the stored macro name (defined via macro.define).
+	Name string `json:"name" jsonschema:"REQUIRED stored macro name"`
+
+	// Scope: "iteration" (default) or "job". Mix-scope is supported —
+	// pre and post may independently select their scope. Empty defaults
+	// to "iteration".
+	Scope string `json:"scope,omitempty" jsonschema:"iteration (default; fires once per variant) | job (fires once outside the variant loop; KV Store is shared across the whole job and merged into each iteration's per-variant store)"`
+
+	// OnError selects the iteration's behaviour when the hook errors.
+	//   "skip"     (default) — record the iteration as skipped, do not send
+	//                          the fuzz request, do not run the post hook,
+	//                          continue to the next variant.
+	//   "abort"    — abort the fuzz run with an error.
+	//   "continue" — log the error, persist a fuzz_macro_results row, and
+	//                continue to the variant's send (templates may carry
+	//                unresolved §var§ literals — recorded in
+	//                fuzz_results.error).
+	OnError string `json:"on_error,omitempty" jsonschema:"skip (default) | abort | continue"`
+
+	// Vars is a static map of kvStore overrides injected before the macro
+	// runs. Keys with the reserved prefix ("__") are silently dropped at
+	// injection time (matches internal/job/job.go:mergeKVStore precedent)
+	// so a Vars entry cannot shadow runtime-populated reserved keys such
+	// as __iteration / __nonce / __response_* (USK-981 Q2).
+	//
+	// scope="iteration": Vars is injected into every variant's per-
+	// iteration kvStore after the job-store copy and before
+	// SeedIterationKV — so the operator's static overrides are visible to
+	// §var§ template expansion on the variant request but cannot shadow
+	// per-iteration reserved keys.
+	//
+	// scope="job": Vars is injected once into the job kvStore at job
+	// start. The job-store is then naturally merged into every per-
+	// iteration kvStore via the existing copy at iteration setup.
+	Vars map[string]string `json:"vars,omitempty" jsonschema:"static kvStore overrides injected before the macro runs. Keys with the '__' reserved prefix are silently dropped (USK-981)"`
+
+	// RunInterval gates when the hook fires across iterations. Only valid
+	// for scope="iteration" — scope="job" hooks fire exactly once by
+	// construction and the validator rejects scope="job" + non-empty
+	// RunInterval (USK-961 Q10).
+	//
+	// pre_macro legal values: "always" (default) | "once" | "every_n" |
+	// "on_error". post_macro legal values: "always" (default) |
+	// "on_status" | "on_match". Pre and post have disjoint legal sets;
+	// validation runs per-direction via the underlying hooks.go
+	// validators (USK-981 Q7).
+	RunInterval string `json:"run_interval,omitempty" jsonschema:"hook firing cadence (scope=iteration only). pre_macro: always (default) | once | every_n | on_error. post_macro: always (default) | on_status | on_match. Rejected when scope='job'"`
+
+	// N is the interval count for RunInterval="every_n". Required when
+	// RunInterval="every_n"; ignored otherwise.
+	N int `json:"n,omitempty" jsonschema:"iteration cadence for RunInterval='every_n' (>= 1)"`
+
+	// StatusCodes is the list of response status codes that gate
+	// post_macro firing for RunInterval="on_status". Required when
+	// RunInterval="on_status"; ignored otherwise. post_macro only.
+	StatusCodes []int `json:"status_codes,omitempty" jsonschema:"response status codes for post_macro RunInterval='on_status'"`
+
+	// MatchPattern is the regex pattern matched against the response body
+	// for post_macro RunInterval="on_match". Required when
+	// RunInterval="on_match"; ignored otherwise. post_macro only.
+	MatchPattern string `json:"match_pattern,omitempty" jsonschema:"response body regex pattern for post_macro RunInterval='on_match'"`
+
+	// compiledPattern is the pre-compiled MatchPattern, set during
+	// validation so the hook executor reuses it across iterations rather
+	// than recompiling. Not serialised — internal to the validator/
+	// executor handoff. Matches the precedent on hookConfig.compiledPattern.
+	compiledPattern *regexp.Regexp `json:"-"`
+}
+
+// ValidateMacroConfig validates one pre/post macro hook config.
+// scope="iteration" (default) and scope="job" are both accepted (USK-961).
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+//
+// macro-name lookup is intentionally deferred to runtime — checking the
+// stored macros table here would require an extra DB roundtrip for every
+// fuzz_* call. Runtime invocation surfaces the missing-macro error via
+// loadAndBuildMacroDeps and short-circuits the iteration per the OnError
+// policy.
+//
+// USK-981: when RunInterval is non-empty, the pre/post legal set is
+// enforced via validatePreMacroHook / validatePostMacroHook so the
+// directional asymmetry (e.g. on_status is post-only) is surfaced at
+// MCP-tool input parse rather than at hook dispatch. scope="job" +
+// non-empty RunInterval is rejected verbatim per Q10 — scope="job"
+// hooks fire exactly once by construction (the call site, not the
+// RunInterval engine knob, owns the single-fire guarantee).
+func ValidateMacroConfig(label string, cfg *MacroConfig, isPre bool) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Name == "" {
+		return fmt.Errorf("%s: name is required", label)
+	}
+	scope := cfg.Scope
+	if scope == "" {
+		scope = "iteration"
+	}
+	switch scope {
+	case "iteration", "job":
+	default:
+		return fmt.Errorf("%s: invalid scope %q (must be iteration or job)", label, scope)
+	}
+	switch cfg.OnError {
+	case "", "skip", "abort", "continue":
+	default:
+		return fmt.Errorf("%s: invalid on_error %q (must be skip, abort, or continue)", label, cfg.OnError)
+	}
+	// USK-981 Q10: scope="job" + non-empty RunInterval is structurally
+	// meaningless — scope="job" hooks fire exactly once via the call
+	// site, not via the RunInterval engine knob. Reject at MCP-tool
+	// input parse with the documented verbatim message.
+	if scope == "job" && cfg.RunInterval != "" {
+		return fmt.Errorf("%s: run_interval is only valid for scope=iteration; for scope=job the hook fires exactly once", label)
+	}
+	// USK-981 Q7 + Q12: when RunInterval is non-empty AND scope is
+	// "iteration", delegate to the polarity-specific hooks.go validator
+	// so the disjoint pre/post legal sets are enforced. We construct a
+	// transient hookConfig because validatePreMacroHook /
+	// validatePostMacroHook already implement the disjoint-set + N /
+	// StatusCodes / MatchPattern cross-field rules.
+	if cfg.RunInterval != "" || cfg.N != 0 || len(cfg.StatusCodes) > 0 || cfg.MatchPattern != "" {
+		h := &hookConfig{
+			Macro:        cfg.Name,
+			RunInterval:  cfg.RunInterval,
+			N:            cfg.N,
+			StatusCodes:  cfg.StatusCodes,
+			MatchPattern: cfg.MatchPattern,
+		}
+		var herr error
+		if isPre {
+			herr = validatePreMacroHook(h)
+		} else {
+			herr = validatePostMacroHook(h)
+		}
+		if herr != nil {
+			return fmt.Errorf("%s: %w", label, herr)
+		}
+		// Carry the compiled regex back so the hook executor reuses it
+		// rather than recompiling on every iteration (matches the
+		// validatePostMacroHook precedent for hooksInput callers).
+		cfg.compiledPattern = h.compiledPattern
+	}
+	return nil
+}
+
+// BuildIterationHookExecutor returns the hookExecutor used by the
+// per-iteration call sites. It is always non-nil so the gating logic in
+// the per-protocol fuzz runOne can dispatch via the executor; when no
+// hook is configured, the executor is a no-op shell.
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+//
+// USK-981: iteration-scope hooks thread the user-supplied RunInterval /
+// N / StatusCodes / MatchPattern / compiledPattern into the underlying
+// hookConfig so the engine's shouldRunPreMacro / shouldRunPostMacro
+// gates (always / once / every_n / on_status / on_match) become
+// user-configurable. Empty RunInterval defaults to "always" — the same
+// as the no-knob path. Vars is intentionally NOT mirrored onto the
+// hookConfig.Vars field because fuzz_*'s injection contract is
+// "Vars seeds the per-iteration kvStore at iteration start" (see
+// PrepareIteration), which fires unconditionally on every iteration —
+// independent of the hook-fire gate. The hookConfig.Vars merge in
+// executePreMacro / executePostMacro is downstream of that gate and
+// would only fire when the hook itself fires.
+func BuildIterationHookExecutor(s *Server, preMacro, postMacro *MacroConfig) *hookExecutor {
+	if preMacro == nil && postMacro == nil {
+		return newHookExecutor(s, nil, &hookState{})
+	}
+	hooks := &hooksInput{}
+	if preMacro != nil {
+		hooks.PreMacro = &hookConfig{
+			Macro:           preMacro.Name,
+			RunInterval:     resolveRunInterval(preMacro.RunInterval),
+			N:               preMacro.N,
+			StatusCodes:     preMacro.StatusCodes,
+			MatchPattern:    preMacro.MatchPattern,
+			compiledPattern: preMacro.compiledPattern,
+		}
+	}
+	if postMacro != nil {
+		hooks.PostMacro = &hookConfig{
+			Macro:           postMacro.Name,
+			RunInterval:     resolveRunInterval(postMacro.RunInterval),
+			N:               postMacro.N,
+			StatusCodes:     postMacro.StatusCodes,
+			MatchPattern:    postMacro.MatchPattern,
+			compiledPattern: postMacro.compiledPattern,
+			PassResponse:    true,
+		}
+	}
+	return newHookExecutor(s, hooks, &hookState{})
+}
+
+// resolveRunInterval returns the engine-facing RunInterval string,
+// defaulting empty to "always" so the underlying hooks.go gate matches
+// the pre-USK-981 behaviour when the caller does not opt in.
+func resolveRunInterval(s string) string {
+	if s == "" {
+		return "always"
+	}
+	return s
+}
+
+// BuildJobHookExecutor returns (jobHookExec, jobKVStore) for the
+// scope="job" call sites, or (nil, nil) when neither hook is job-scoped.
+// Distinct from BuildIterationHookExecutor so the hookState.preMacroExecuted
+// state is not flipped by the job-side single-fire call. Post-job leaves
+// PassResponse off (no per-iteration response is available — Q21).
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+//
+// USK-981: scope="job" forces RunInterval="always" (the validator
+// already rejected non-empty RunInterval for scope="job", so this is
+// belt-and-braces). Vars from job-scope hooks is injected into the
+// returned jobKVStore with reserved-key silent-drop — matches the
+// internal/job/job.go mergeKVStore precedent.
+func BuildJobHookExecutor(s *Server, preMacro, postMacro *MacroConfig) (*hookExecutor, map[string]string) {
+	if !IsJobScope(preMacro) && !IsJobScope(postMacro) {
+		return nil, nil
+	}
+	jobHooks := &hooksInput{}
+	if IsJobScope(preMacro) {
+		jobHooks.PreMacro = &hookConfig{Macro: preMacro.Name, RunInterval: "always"}
+	}
+	if IsJobScope(postMacro) {
+		jobHooks.PostMacro = &hookConfig{Macro: postMacro.Name, RunInterval: "always"}
+	}
+	jobKV := make(map[string]string)
+	if IsJobScope(preMacro) {
+		InjectVarsRespectingReserved(jobKV, preMacro.Vars)
+	}
+	if IsJobScope(postMacro) {
+		InjectVarsRespectingReserved(jobKV, postMacro.Vars)
+	}
+	return newHookExecutor(s, jobHooks, &hookState{}), jobKV
+}
+
+// InjectVarsRespectingReserved copies src into dst, silently dropping
+// keys with the reserved prefix ("__") so a user-supplied Vars entry
+// cannot shadow runtime-populated reserved keys (USK-981 Q2). Matches
+// the internal/job/job.go:mergeKVStore precedent.
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+//
+// Local replication is preferred over importing internal/job for two
+// reasons: (1) the package boundary is control plane (internal/mcp) →
+// data path (internal/job), which the project conventions discourage;
+// (2) the function is small enough that DRYing it would cost more in
+// indirection than it saves.
+func InjectVarsRespectingReserved(dst map[string]string, src map[string]string) {
+	for k, v := range src {
+		if macro.IsReservedKey(k) {
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+// BumpHookIterationCount advances the hookState.requestCount by one so
+// the next iteration's shouldRunPreMacro / shouldRunPostMacro engine
+// gates evaluate against the post-iteration counter (USK-981). Pure
+// counter increment — lastStatusCode / lastError remain at zero values
+// because correctly wiring those requires deciding what counts as an
+// "error" for the on_error gate (transport error vs 4xx vs 5xx vs
+// pre-macro skip), which is deferred to USK-982. This makes
+// RunInterval="every_n" and "once" work end-to-end without committing
+// to on_error semantics yet.
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983) —
+// converted from a method on *fuzzHTTPVariantLoop to a free function so
+// the per-protocol variant loops can call it without duplicating the
+// counter-advance logic.
+func BumpHookIterationCount(exec *hookExecutor) {
+	if exec == nil || exec.state == nil {
+		return
+	}
+	exec.state.requestCount++
+}
+
+// IsJobScope reports whether cfg is configured as scope="job". Nil is
+// always false. Empty scope defaults to "iteration".
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+func IsJobScope(cfg *MacroConfig) bool {
+	return cfg != nil && cfg.Scope == "job"
+}
+
+// IsIterationScope reports whether cfg is configured as scope="iteration"
+// (or empty, which defaults to iteration). Nil is always false.
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983).
+func IsIterationScope(cfg *MacroConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Scope == "" || cfg.Scope == "iteration"
+}
+
+// PrepareIteration builds and returns the per-variant kvStore for a
+// fuzz iteration. The Vars injection order (matching USK-981) is:
+//
+//  1. jobKV copy (job-scope extracts and job-scope Vars)
+//  2. iteration-scope Vars from preMacro (operator-supplied static overrides)
+//  3. iteration-scope Vars from postMacro
+//  4. connector.SeedIterationKV (per-iteration reserved keys:
+//     __iteration, __nonce, and any upstream-proxy rotation extracts)
+//
+// The order matters: per-iteration reserved keys must be the last
+// writer so they win on collision, and Vars must be injected with
+// reserved-key silent-drop (USK-981 Q2) so a Vars entry like
+// {"__iteration":"override"} is dropped at injection rather than
+// shadowing the value the iteration loop will seed.
+//
+// Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983) —
+// extracts the per-protocol-neutral kvStore-build prefix from
+// fuzz_http's prepareIteration so the sibling fuzz tools can reuse the
+// exact same Vars-injection order without duplicating the merge logic.
+// The upstream-proxy resolution and pre-macro dispatch that follow this
+// step remain per-protocol because they touch protocol-specific row
+// recording (`recordVariantError`, etc.).
+func PrepareIteration(jobKV map[string]string, preMacro, postMacro *MacroConfig, variantIdx int) map[string]string {
+	kvStore := make(map[string]string)
+	for k, v := range jobKV {
+		kvStore[k] = v
+	}
+	if IsIterationScope(preMacro) {
+		InjectVarsRespectingReserved(kvStore, preMacro.Vars)
+	}
+	if IsIterationScope(postMacro) {
+		InjectVarsRespectingReserved(kvStore, postMacro.Vars)
+	}
+	connector.SeedIterationKV(kvStore, variantIdx)
+	return kvStore
+}


### PR DESCRIPTION
## Summary
- Extracted `MacroConfig` struct (renamed from `fuzzHTTPMacroConfig`), validators, and executor builders from `internal/mcp/fuzz_http_helpers.go` into a new `internal/mcp/fuzz_macro_common.go` so sibling fuzz tools can reuse the seam.
- Converted `bumpHookIterationCount` from a method on `*fuzzHTTPVariantLoop` to a free function `BumpHookIterationCount(exec *hookExecutor)`.
- Extracted the kvStore-build prefix of `prepareIteration` into a free function `PrepareIteration(jobKV, preMacro, postMacro, variantIdx)`.
- **No behavior change** in fuzz_http — existing integration tests (USK-960/961/979/981 suite) continue to pass unchanged.

## Test plan
- [x] `make lint` PASS
- [x] `make build` PASS
- [x] `make test` PASS
- [x] `make test-e2e-smoke` PASS (first run was a flake; re-ran clean with EXIT=0)
- [x] `go test -tags e2e -run "TestFuzzHTTPMacro|TestFuzzHTTP_UpstreamProxyRotation" ./internal/mcp/` PASS (the no-behavior-change gate — covers USK-960/961/979/981 suite)

## Notes for review
- This is a pure refactor — review priority is **no behavior change**.
- All `json:` / `jsonschema:` tags on `MacroConfig` preserved byte-identical from the prior `fuzzHTTPMacroConfig` definition.
- `isJobScope` / `isIterationScope` were extracted alongside the named items even though not in the Issue's extraction list — they are pure predicates over `*MacroConfig` and USK-984/985/986 will need them.
- `resolveRunInterval` kept unexported alongside `BuildIterationHookExecutor` (sole caller).
- The fuzz_http-specific variant-loop wiring (`fuzzHTTPVariantLoop` struct, `prepareIteration`'s upstream-proxy + pre-macro dispatch suffix) stays in `fuzz_http_helpers.go` — those touch protocol-specific row recording and are not shared infrastructure.

Resolves USK-983
Linear: https://linear.app/usk6666/issue/USK-983

Generated with [Claude Code](https://claude.com/claude-code)