### PR TITLE
feat(mcp/fuzz_http): wire updateState so on_error pre-macro fires after real errors

### DIFF
--- a/internal/mcp/fuzz_http_helpers.go
+++ b/internal/mcp/fuzz_http_helpers.go
@@ -454,8 +454,13 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		// engine gates (every_n) treat skipped iterations as consuming
 		// their slot. Without this, on iteration 3 the gate would still
 		// see requestCount=0 from the iter-0 skip and re-fire pre_macro
-		// on every subsequent iteration. lastStatusCode / lastError stay
-		// untouched (D1 deferred to USK-982).
+		// on every subsequent iteration.
+		//
+		// USK-982: stay on counter-only Bump here — the skip path never
+		// reached the wire so there is no wire result to record. The
+		// previous wire-completed iteration's lastStatusCode / lastError
+		// remain in place, so an on_error gate on the next iteration
+		// still reacts to the most recent real outcome.
 		BumpHookIterationCount(l.hookExec)
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
@@ -474,6 +479,9 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 	expandedPayloads, expandErr := expandFuzzHTTPPayloads(payloads, kvStore)
 	if expandErr != nil {
 		l.recordVariantError(ctx, variantIdx, payloads, fmt.Sprintf("template expansion: %v", expandErr))
+		// USK-982: counter-only bump — like prep.skipped, template-
+		// expansion failures never reached the wire, so lastStatusCode /
+		// lastError carry over from the previous wire-completed iter.
 		BumpHookIterationCount(l.hookExec)
 		nextIndices(l.indices, l.plan.positions)
 		return "", nil
@@ -516,12 +524,21 @@ func (l *fuzzHTTPVariantLoop) runOne(ctx context.Context, variantIdx int) (strin
 		l.runPostMacro(ctx, iterCtx, variantIdx, row, kvStore)
 	}
 
-	// USK-981: bump the iteration counter at the end of every normal-
-	// path iteration so RunInterval engine gates (every_n) see one more
-	// completed iteration before the next runOne call evaluates
-	// shouldRunPreMacro. lastStatusCode / lastError stay untouched
-	// (D1 deferred to USK-982).
-	BumpHookIterationCount(l.hookExec)
+	// USK-981 / USK-982: record the iteration's wire result so the next
+	// runOne call's shouldRunPreMacro sees the correct lastStatusCode /
+	// lastError for the on_error gate, AND advance the iteration counter
+	// for the every_n gate. updateState bumps requestCount and records
+	// (statusCode, runErr != nil) atomically — replacing the counter-
+	// only BumpHookIterationCount used during USK-981.
+	//
+	// Note the per-call-site distinction: only this normal-path branch
+	// has wire-result information. The pre-wire abort branches above
+	// (prep.skipped, template-expansion error) keep BumpHookIterationCount
+	// since they never reached the wire and have no wire result to
+	// record — leaving lastStatusCode / lastError unchanged so the
+	// previous wire-completed iteration's outcome carries over to the
+	// next on_error evaluation.
+	l.hookExec.updateState(statusCode, runErr != nil)
 
 	nextIndices(l.indices, l.plan.positions)
 

--- a/internal/mcp/fuzz_http_macro_integration_test.go
+++ b/internal/mcp/fuzz_http_macro_integration_test.go
@@ -1906,3 +1906,166 @@ func TestFuzzHTTPMacro_RunIntervalOnce(t *testing.T) {
 		t.Errorf("pre macro called %d times, want 1 (run_interval=once)", got)
 	}
 }
+
+// TestFuzzHTTPMacro_RunIntervalOnError_FiresAfterError verifies that
+// pre_macro.run_interval="on_error" fires only on the iteration that
+// follows a wire-recorded error (HTTP status >= 400 or transport error).
+// With 3 iterations where the middle (iter 1) returns 500 and iters 0
+// and 2 return 200, pre fires exactly once — on iter 2, reacting to
+// iter 1's 500. Iter 0 does NOT fire (no previous request to react to,
+// per USK-982 D-Q6). Covers USK-982 acceptance criterion #1.
+func TestFuzzHTTPMacro_RunIntervalOnError_FiresAfterError(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&fuzzCalls, 1)
+		// fuzzCalls is now the 1-based count of this hit. The middle
+		// iteration (1-based n == 2, 0-based iter 1) returns 500; the
+		// surrounding iterations return 200.
+		if n == 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-on-error", preFlowID, "", "", nil)
+
+	payloads := []string{"/a0", "/a1", "/a2"}
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": payloads},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":         "pre-on-error",
+				"run_interval": "on_error",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != len(payloads) {
+		t.Fatalf("CompletedVariants = %d, want %d", out.CompletedVariants, len(payloads))
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); int(got) != len(payloads) {
+		t.Errorf("fuzz server saw %d requests, want %d", got, len(payloads))
+	}
+	// Pre fires only on iter 2, reacting to iter 1's 500 → 1 call.
+	// Iter 0: requestCount==0 → no fire (USK-982 D-Q6).
+	// Iter 1: previous (iter 0) was 200 → no fire.
+	// Iter 2: previous (iter 1) was 500 → fire.
+	if got := atomic.LoadInt32(&preCalls); got != 1 {
+		t.Errorf("pre macro called %d times, want 1 (on_error fires only on iter 2 after iter 1's 500)", got)
+	}
+}
+
+// TestFuzzHTTPMacro_RunIntervalOnError_DoesNotFireWithoutError verifies
+// that pre_macro.run_interval="on_error" never fires when every iteration
+// is a successful 200 — there is no error to react to and iter 0 does
+// not fire vacuously (USK-982 D-Q6). Covers USK-982 acceptance criterion #2.
+func TestFuzzHTTPMacro_RunIntervalOnError_DoesNotFireWithoutError(t *testing.T) {
+	cs, store := setupFuzzHTTPMacroSession(t)
+
+	var preCalls int32
+	preServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&preCalls, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(preServer.Close)
+
+	var fuzzCalls int32
+	fuzzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fuzzCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fuzzServer.Close)
+
+	preFlowID := recordMacroFlow(t, store, "POST", preServer.URL+"/noop", nil, nil)
+	defineMacroForTest(t, cs, "pre-on-error-quiet", preFlowID, "", "", nil)
+
+	payloads := []string{"/a0", "/a1", "/a2"}
+	authority := strings.TrimPrefix(fuzzServer.URL, "http://")
+	res, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "fuzz_http",
+		Arguments: map[string]any{
+			"method":    "GET",
+			"scheme":    "http",
+			"authority": authority,
+			"path":      "/probe",
+			"headers": []map[string]any{
+				{"name": "Host", "value": authority},
+			},
+			"positions": []map[string]any{
+				{"path": "path", "payloads": payloads},
+			},
+			"timeout_ms": 5000,
+			"pre_macro": map[string]any{
+				"name":         "pre-on-error-quiet",
+				"run_interval": "on_error",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fuzz_http: %v", err)
+	}
+	if res.IsError {
+		var msg strings.Builder
+		for _, c := range res.Content {
+			if tc, ok := c.(*gomcp.TextContent); ok {
+				msg.WriteString(tc.Text)
+				msg.WriteString("\n")
+			}
+		}
+		t.Fatalf("fuzz_http returned error: %s", msg.String())
+	}
+
+	var out fuzzHTTPResult
+	raw, _ := json.Marshal(res.StructuredContent)
+	_ = json.Unmarshal(raw, &out)
+	if out.CompletedVariants != len(payloads) {
+		t.Fatalf("CompletedVariants = %d, want %d", out.CompletedVariants, len(payloads))
+	}
+	if got := atomic.LoadInt32(&fuzzCalls); int(got) != len(payloads) {
+		t.Errorf("fuzz server saw %d requests, want %d", got, len(payloads))
+	}
+	// All responses are 200 — pre never fires.
+	if got := atomic.LoadInt32(&preCalls); got != 0 {
+		t.Errorf("pre macro called %d times, want 0 (on_error never fires when all iters are 200)", got)
+	}
+}

--- a/internal/mcp/fuzz_macro_common.go
+++ b/internal/mcp/fuzz_macro_common.go
@@ -305,12 +305,16 @@ func InjectVarsRespectingReserved(dst map[string]string, src map[string]string) 
 // BumpHookIterationCount advances the hookState.requestCount by one so
 // the next iteration's shouldRunPreMacro / shouldRunPostMacro engine
 // gates evaluate against the post-iteration counter (USK-981). Pure
-// counter increment — lastStatusCode / lastError remain at zero values
-// because correctly wiring those requires deciding what counts as an
-// "error" for the on_error gate (transport error vs 4xx vs 5xx vs
-// pre-macro skip), which is deferred to USK-982. This makes
-// RunInterval="every_n" and "once" work end-to-end without committing
-// to on_error semantics yet.
+// counter increment — lastStatusCode / lastError remain untouched and
+// carry over from the previous wire-completed iteration. Use this on
+// pre-wire abort paths (pre-macro skip, template-expansion error,
+// upstream-proxy resolution failure) where there is no wire result to
+// record but the slot must still be consumed for every_n / once gates.
+//
+// Wire-completed iterations should call hookExecutor.updateState
+// (statusCode, runErr != nil) instead — that helper bumps requestCount
+// AND records the wire result so the on_error gate sees the correct
+// previous-iteration status on the next evaluation (USK-982).
 //
 // Shared by fuzz_http / fuzz_ws / fuzz_grpc / fuzz_raw (USK-983) —
 // converted from a method on *fuzzHTTPVariantLoop to a free function so

--- a/internal/mcp/hooks.go
+++ b/internal/mcp/hooks.go
@@ -494,10 +494,14 @@ func (he *hookExecutor) shouldRunPreMacro(h *hookConfig) bool {
 		}
 		return he.state.requestCount%h.N == 0
 	case "on_error":
-		// Run if the previous request had an error (4xx/5xx or transport error).
-		// Always run on the first request (no previous error to check).
+		// Fires when the previous main request had an error (transport
+		// error or HTTP status >= 400). Returns false on the first
+		// iteration — there is no previous request to react to (USK-982).
+		// This makes "fires only after a real error" match the operator
+		// mental model and avoids a vacuous iter-0 fire when no error has
+		// been observed yet.
 		if he.state.requestCount == 0 {
-			return true
+			return false
 		}
 		return he.state.lastError || he.state.lastStatusCode >= 400
 	default:

--- a/internal/mcp/hooks_test.go
+++ b/internal/mcp/hooks_test.go
@@ -204,9 +204,11 @@ func TestShouldRunPreMacro_OnError(t *testing.T) {
 	}
 	h := &hookConfig{Macro: "m", RunInterval: "on_error"}
 
-	// First request: always run (no previous error to check).
-	if !he.shouldRunPreMacro(h) {
-		t.Error("first request: shouldRunPreMacro(on_error) = false, want true")
+	// First request: do NOT run (no previous request to react to —
+	// USK-982 D-Q6: "fires only after a real error" means iter 0 must
+	// not fire vacuously).
+	if he.shouldRunPreMacro(h) {
+		t.Error("first request: shouldRunPreMacro(on_error) = true, want false (USK-982: no previous request)")
 	}
 	he.state.requestCount++
 	he.state.lastStatusCode = 200

--- a/internal/mcp/resources/help_fuzz_http.md
+++ b/internal/mcp/resources/help_fuzz_http.md
@@ -65,6 +65,7 @@ Pre and post macro hooks dispatched around variants by name. Both fields take th
   - pre_macro legal values: `"always"` (default) | `"once"` | `"every_n"` | `"on_error"`.
   - post_macro legal values: `"always"` (default) | `"on_status"` | `"on_match"`.
   - The pre/post legal sets are disjoint: `on_status` and `on_match` are post-only; `once`, `every_n`, and `on_error` are pre-only. Picking the wrong direction is rejected at MCP-tool input parse time.
+  - `on_error` semantics (USK-982): fires when the previous variant's response was a transport error or had HTTP status >= 400. Does **NOT** fire on iteration 0 — there is no previous request to react to. Use for reactive flows like "re-authenticate after a 401". The trigger looks at the previous iteration only; consecutive errors will fire the hook on every iteration after the first error, while a single error fires it exactly once on the next iteration.
 - **n** (integer, optional): companion to pre_macro `run_interval="every_n"`. Required when `run_interval="every_n"`; must be ≥ 1.
 - **status_codes** (array of integer, optional): companion to post_macro `run_interval="on_status"`. Required when `run_interval="on_status"`.
 - **match_pattern** (string, optional): companion to post_macro `run_interval="on_match"`. Required when `run_interval="on_match"`.


### PR DESCRIPTION
## Summary
- Wire `hookExecutor.updateState(statusCode, runErr != nil)` at the fuzz_http variant loop's normal-path post-iteration bump (replaces `BumpHookIterationCount` there). Skip + template-expand-error call sites keep the counter-only bump.
- Change `shouldRunPreMacro`'s `on_error` iter-0 from `return true` (vacuous fire) to `return false` — fire only after a real error.
- Add `TestFuzzHTTPMacro_RunIntervalOnError_FiresAfterError` and `TestFuzzHTTPMacro_RunIntervalOnError_DoesNotFireWithoutError`.
- Update `help_fuzz_http.md` `on_error` semantics. Update `TestShouldRunPreMacro_OnError` unit test to match the new iter-0 = no-fire contract.

## Design notes
Per Phase 1.5 design review:
- Shared seam left untouched (Option C) — fuzz_ws/grpc/raw have different status semantics; forcing a single shared signature would hit the "hardcoded-flag anti-pattern". Follow-up Issues will wire each protocol's on_error with protocol-appropriate "error" definitions.
- `shouldRunPostMacro` has no `on_error` case (only `always` / `on_status` / `on_match`), so no symmetry fix was needed there.

## Test plan
- [x] `make test` passes (all existing fuzz_http macro tests still pass — D-Q6 changes only the on_error branch)
- [x] New `TestFuzzHTTPMacro_RunIntervalOnError_FiresAfterError` shows pre fires exactly once (iter 2, after iter 1's 500)
- [x] New `TestFuzzHTTPMacro_RunIntervalOnError_DoesNotFireWithoutError` shows pre fires zero times when all responses are 200

Resolves USK-982
Linear: https://linear.app/usk6666/issue/USK-982

🤖 Generated with [Claude Code](https://claude.com/claude-code)