### PR TITLE
fix(proxybuild): N-chain GOAWAY -> redial transparency (USK-716 regression)

### DIFF
--- a/internal/connector/h2_redial.go
+++ b/internal/connector/h2_redial.go
@@ -14,12 +14,25 @@ import (
 // upstream proxy) are resolved through cfg the same way the original
 // CONNECT path did — runtime-mutable overrides therefore reach the redial.
 //
+// generation identifies which step of the redial chain this dial is for
+// (USK-991): generation==1 is the first redial off the pooled Layer
+// (label suffix `/upstream-redial`, preserving the USK-816 wire log shape);
+// generation>=2 appends `-N` (e.g. `/upstream-redial-2`) so subsequent
+// chain steps are individually identifiable in flow / structured logs.
+// Callers in proxybuild pass len(chain)+1 (where chain is the slice of
+// prior fresh Layers).
+//
 // USK-816: invoked by proxybuild.buildOnHTTP2Stack at dial-closure time
 // when the pooled upstreamH2 has gone stale during a long intercept hold
 // (server sent GOAWAY, or upstream FIN closed the conn). The fresh Layer
 // is owned by the caller — this helper does NOT insert it into HTTP2Pool
 // because the per-CONNECT lifecycle owns the redial; reuse across
 // CONNECTs is the pool's job and is opt-in via Pool.Put.
+//
+// USK-991: also invoked when a previously redialed Layer itself goes
+// stale (recursive GOAWAY chain). Browser-equivalent semantics: every
+// GOAWAY observed mid-CONNECT triggers a fresh dial transparently; no
+// cap on chain length (the per-CONNECT lifecycle is the natural bound).
 //
 // Returned errors are upstream dial / TLS / http2.New errors verbatim so
 // the caller can wrap them via fmt.Errorf("dial: %w", ...) the same way
@@ -33,6 +46,7 @@ func RedialUpstreamH2(
 	target string,
 	stale *http2.Layer,
 	cfg *BuildConfig,
+	generation int,
 ) (*http2.Layer, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("connector: RedialUpstreamH2: cfg is nil")
@@ -73,11 +87,7 @@ func RedialUpstreamH2(
 	// fresh stream on the wire — not to re-record TLS.
 	envCtx := stale.EnvelopeContextTemplate()
 
-	connID := envCtx.ConnID
-	if connID == "" {
-		connID = "redial"
-	}
-	connID += "/upstream-redial"
+	connID := redialConnIDLabel(envCtx.ConnID, generation)
 
 	fresh, err := http2.New(upstreamConn, connID, http2.ClientRole,
 		http2.WithScheme("https"),
@@ -92,4 +102,22 @@ func RedialUpstreamH2(
 	}
 
 	return fresh, nil
+}
+
+// redialConnIDLabel composes the ConnID suffix for a fresh redial Layer.
+// generation<=1 yields the historical `/upstream-redial` suffix (USK-816
+// wire log shape); generation>=2 appends `-N` so each chain step in a
+// multi-GOAWAY CONNECT (USK-991) is individually identifiable in flow
+// records and structured logs. An empty incoming ConnID is replaced
+// with the literal "redial" so the resulting label is never just
+// `/upstream-redial` (which would be ambiguous across CONNECTs in log
+// aggregators).
+func redialConnIDLabel(baseConnID string, generation int) string {
+	if baseConnID == "" {
+		baseConnID = "redial"
+	}
+	if generation <= 1 {
+		return baseConnID + "/upstream-redial"
+	}
+	return fmt.Sprintf("%s/upstream-redial-%d", baseConnID, generation)
 }

--- a/internal/connector/h2_redial_test.go
+++ b/internal/connector/h2_redial_test.go
@@ -1,0 +1,60 @@
+package connector
+
+import (
+	"testing"
+)
+
+// TestRedialConnIDLabel_GenerationProgression locks the USK-991 label
+// scheme:
+//   - generation<=1 preserves the USK-816 historical suffix
+//     `/upstream-redial` so existing log scrapers / flow filters keep
+//     working unchanged.
+//   - generation>=2 appends `-N` so each chain step is visibly distinct
+//     in flow rows / structured logs / debugging dumps.
+//
+// Also pins the empty-base-ConnID fallback to "redial" so the suffix is
+// never the only component (which would conflict across CONNECTs in any
+// log aggregator that groups by ConnID prefix).
+func TestRedialConnIDLabel_GenerationProgression(t *testing.T) {
+	tests := []struct {
+		name       string
+		base       string
+		generation int
+		want       string
+	}{
+		{"first redial preserves USK-816 label", "conn-abc", 1, "conn-abc/upstream-redial"},
+		{"generation 0 also yields the first-redial label", "conn-abc", 0, "conn-abc/upstream-redial"},
+		{"second redial appends -2", "conn-abc", 2, "conn-abc/upstream-redial-2"},
+		{"third redial appends -3", "conn-abc", 3, "conn-abc/upstream-redial-3"},
+		{"empty base ConnID falls back to 'redial'", "", 1, "redial/upstream-redial"},
+		{"empty base + Nth redial still labels uniquely", "", 5, "redial/upstream-redial-5"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redialConnIDLabel(tc.base, tc.generation)
+			if got != tc.want {
+				t.Errorf("redialConnIDLabel(%q, %d) = %q, want %q",
+					tc.base, tc.generation, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRedialConnIDLabel_ChainUniqueness asserts that a 5-step chain
+// produces 5 distinct ConnID labels — the user-visible guarantee USK-991
+// added so a multi-GOAWAY flow can be triaged in logs / flow lists.
+func TestRedialConnIDLabel_ChainUniqueness(t *testing.T) {
+	const base = "live-conn-xyz"
+	seen := make(map[string]struct{})
+	for gen := 1; gen <= 5; gen++ {
+		label := redialConnIDLabel(base, gen)
+		if _, dup := seen[label]; dup {
+			t.Errorf("generation %d label %q collides with a prior chain step", gen, label)
+		}
+		seen[label] = struct{}{}
+	}
+	if got := len(seen); got != 5 {
+		t.Fatalf("5-step chain produced %d distinct labels, want 5", got)
+	}
+}

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -868,26 +868,25 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 		upstreamLOpts := httpaggregator.OptionsFromLayer(upstreamH2)
 		upstreamLOpts.StateReleaser = deps.PluginV2Engine
 
-		// USK-816: when the pooled upstreamH2 goes stale during a long
-		// intercept hold (server GOAWAY / idle FIN), per-stream dial closures
+		// USK-816 / USK-991: when the pooled upstreamH2 (or a previously
+		// redialed Layer) goes stale during a long intercept hold — server
+		// GOAWAY / idle FIN — per-stream dial closures transparently
 		// fall back to a fresh dial. The fresh Layer is shared across all
-		// subsequent streams in this CONNECT lifecycle via redial.Load +
-		// mutex-serialised redial.Store, so concurrent streams do not each
-		// open a new upstream conn. The fresh Layer is owned by this handler
-		// — it is closed in the deferred cleanup below.
-		var redial atomic.Pointer[http2.Layer]
-		// Single-writer close: only the goroutine that wins the redialDial
-		// mutex and stores into redial owns its Close. Subsequent loads
-		// observe the pointer and reuse without taking ownership.
-		var redialDial sync.Mutex
-		redialFn := func(dctx context.Context, t string, stale *http2.Layer) (*http2.Layer, error) {
-			return connector.RedialUpstreamH2(dctx, t, stale, deps.BuildConfig)
+		// subsequent streams in this CONNECT lifecycle via redialChain.current
+		// + mutex-serialised dial, so concurrent streams do not each open a
+		// new upstream conn. The fresh Layers are owned by this handler — all
+		// chain steps are closed in the deferred cleanup below.
+		//
+		// USK-991: the chain is unbounded (browser-equivalent transparency:
+		// no cap; the per-CONNECT lifetime is the natural bound). Prior
+		// Layers are retained for the CONNECT's lifetime so in-flight
+		// streams on them drain naturally up to GOAWAY's last_stream_id
+		// (RFC 9113 §6.8) — close-on-CONNECT-exit, not close-on-swap.
+		chain := newRedialChain()
+		redialFn := func(dctx context.Context, t string, stale *http2.Layer, generation int) (*http2.Layer, error) {
+			return connector.RedialUpstreamH2(dctx, t, stale, deps.BuildConfig, generation)
 		}
-		defer func() {
-			if l := redial.Load(); l != nil {
-				_ = l.Close()
-			}
-		}()
+		defer chain.closeAll()
 
 		var wg sync.WaitGroup
 		for {
@@ -985,7 +984,7 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 						return
 					}
 					dial := func(dctx context.Context, env *envelope.Envelope) (layer.Channel, error) {
-						upL := selectUpstreamForDial(dctx, target, upstreamH2, &redial, &redialDial, redialFn, logger)
+						upL := selectUpstreamForDial(dctx, target, upstreamH2, chain, redialFn, logger)
 						upCh, oerr := upL.OpenStream(dctx)
 						if oerr != nil {
 							return nil, oerr
@@ -1023,11 +1022,71 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 	}
 }
 
+// redialFunc is the closure proxybuild hands to selectUpstreamForDial.
+// generation is 1 for the first redial off the pooled upstreamH2, 2 for
+// the next chain step, etc. (USK-991). Implementations stamp the fresh
+// Layer's ConnID with a generation-aware suffix so per-step diagnostics
+// stay readable.
+type redialFunc func(ctx context.Context, target string, stale *http2.Layer, generation int) (*http2.Layer, error)
+
+// redialChain holds the chain of fresh *http2.Layer instances produced
+// by recursive GOAWAY-driven redials within a single CONNECT lifecycle
+// (USK-991). The pooled upstreamH2 is the implicit chain[0] and is
+// managed separately by dispatchStack (Pool.Put/Close).
+//
+// Invariants:
+//   - mu serialises append-to-layers + current.Store. Single-writer-on-
+//     append guarantees no in-flight goroutine observes a partially
+//     constructed slice and that current always points to a Layer
+//     already inserted into layers.
+//   - current is a pointer to the most recently appended fresh Layer or
+//     nil before the first redial; readers (selectUpstreamForDial) use
+//     it on the fast path without acquiring mu.
+//   - layers retains every fresh Layer for the CONNECT's lifetime. They
+//     are all closed by closeAll() from the buildOnHTTP2Stack defer.
+//     Browser-equivalent semantics: prior chain steps drain their in-
+//     flight streams naturally up to GOAWAY's last_stream_id (RFC 9113
+//     §6.8); the proxy does not tear them down on swap.
+type redialChain struct {
+	mu      sync.Mutex
+	layers  []*http2.Layer
+	current atomic.Pointer[http2.Layer]
+}
+
+func newRedialChain() *redialChain {
+	return &redialChain{}
+}
+
+// closeAll closes every fresh Layer accumulated in the chain. Called
+// from the buildOnHTTP2Stack defer at CONNECT exit. Idempotent on
+// repeated calls because http2.Layer.Close() is itself idempotent (the
+// USK-739/798 patterns establish this for both directions).
+func (c *redialChain) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, l := range c.layers {
+		_ = l.Close()
+	}
+	// Hand back the empty slot so a CONNECT that somehow re-enters
+	// (it does not today) would not double-close.
+	c.layers = nil
+	c.current.Store(nil)
+}
+
 // selectUpstreamForDial returns the *http2.Layer to use for OpenStream on
-// this dial attempt. It re-checks the pooled upstreamH2's liveness via
-// GoAwayClosed / IsShutdown (USK-816). When stale, it fresh-dials a
-// replacement Layer atomically, sharing the result with concurrent streams
-// in the same CONNECT lifecycle.
+// this dial attempt. It walks the redial chain and re-checks the
+// currently-active Layer's liveness via GoAwayClosed / IsShutdown each
+// call (USK-816 for the 1st step, USK-991 for the recursive case).
+// When the active Layer is stale, it fresh-dials a replacement Layer
+// under chain.mu, appends to chain.layers, atomically swaps
+// chain.current, and returns the fresh Layer. The same fresh Layer is
+// observed by concurrent streams via chain.current.Load() so they do
+// not each open a new upstream conn.
+//
+// Active-Layer selection rule:
+//   - chain.current.Load() if non-nil (we've already redialed at least
+//     once in this CONNECT)
+//   - else the pooled upstreamH2
 //
 // Why GoAwayClosed/IsShutdown at dial-closure time: USK-796 added the same
 // check at Pool.Get to evict stale entries before handing them out, but
@@ -1035,7 +1094,7 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 // span server GOAWAY / idle-close mid-CONNECT — the pool already gave us
 // the Layer, so the dial closure must re-check.
 //
-// Why we do NOT Pool.Evict the stale Layer here: the surrounding
+// Why we do NOT Pool.Evict the stale pooled Layer here: the surrounding
 // dispatchStack flow runs `Pool.Put(poolKey, upstreamH2)` deferred at
 // handler exit, and the still-running clientToUpstream goroutines on
 // other concurrent streams may still hold references. Single-writer
@@ -1043,43 +1102,88 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 // pool's selectLocked path on the next Pool.Get — it is the canonical
 // stale-entry evictor (USK-796) and runs after our handler has returned.
 //
-// The redialDial mutex serialises the fresh-dial attempt so concurrent
-// streams observing staleness produce one upstream conn (not N). On
-// dial failure, the original (stale) upstreamH2 is returned — OpenStream
-// will then surface the underlying error to the caller, so failure
-// propagates naturally (state=error / failure_reason=refused).
+// Why we hold prior chain steps until CONNECT exit (USK-991): browser-
+// equivalent semantics. A GOAWAY tells the client "no new streams" but
+// existing streams up to last_stream_id complete normally (RFC 9113
+// §6.8). Closing prior chain steps on swap would abort their in-flight
+// streams; holding them lets those streams drain and only NEW streams
+// fall through to the fresh chain step. The slice is bounded in
+// practice by the CONNECT's lifetime — there is no chain cap; this is
+// a deliberate decision for diagnostic transparency, see USK-991.
+//
+// The chain.mu serialises the fresh-dial attempt so concurrent streams
+// observing staleness produce one upstream conn (not N). On dial
+// failure, the previous (stale) Layer is returned — OpenStream will
+// then surface the underlying error to the caller, so failure
+// propagates naturally (state=error / failure_reason=refused). The
+// failed dial is NOT cached, so the next call retries cleanly.
 func selectUpstreamForDial(
 	dctx context.Context,
 	target string,
 	upstreamH2 *http2.Layer,
-	redial *atomic.Pointer[http2.Layer],
-	redialDial *sync.Mutex,
-	redialFn func(context.Context, string, *http2.Layer) (*http2.Layer, error),
+	chain *redialChain,
+	dialFresh redialFunc,
 	logger *slog.Logger,
 ) *http2.Layer {
-	if l := redial.Load(); l != nil {
-		return l
+	// Fast path: lock-free read of the active Layer. current.Load() is
+	// either nil (no redial yet — use pooled) or points to a Layer that
+	// was appended to chain.layers under chain.mu prior to the swap, so
+	// readers observing it are guaranteed to see a valid entry.
+	active := upstreamH2
+	if l := chain.current.Load(); l != nil {
+		active = l
 	}
-	if !(upstreamH2.GoAwayClosed() || upstreamH2.IsShutdown()) {
-		return upstreamH2
+	if !isStaleH2(active) {
+		return active
 	}
 
-	redialDial.Lock()
-	defer redialDial.Unlock()
-	if l := redial.Load(); l != nil {
-		return l
+	// Slow path: race to fresh-dial the next chain step. The mutex
+	// serialises both the re-check and the append+swap, so concurrent
+	// streams observing the same stale Layer collapse into a single
+	// fresh dial — and at most one per stale step.
+	chain.mu.Lock()
+	defer chain.mu.Unlock()
+	// Re-check under lock — another goroutine may have already swapped in
+	// the next chain step while we were spinning on mu.
+	active = upstreamH2
+	if l := chain.current.Load(); l != nil {
+		active = l
+	}
+	if !isStaleH2(active) {
+		return active
 	}
 
-	fresh, err := redialFn(dctx, target, upstreamH2)
+	// Generation = number of fresh Layers already appended + 1. The
+	// pooled upstreamH2 is implicit chain[0] (generation 0); the first
+	// fresh dial is generation 1, the second is generation 2, etc. The
+	// connector helper translates generation into the ConnID suffix
+	// (`/upstream-redial` for gen 1; `/upstream-redial-N` for gen >= 2).
+	nextGen := len(chain.layers) + 1
+	fresh, err := dialFresh(dctx, target, active, nextGen)
 	if err != nil {
 		logger.Warn("proxybuild: upstream h2 redial failed",
-			"target", target, "error", err)
-		return upstreamH2
+			"target", target, "generation", nextGen, "error", err)
+		// Return the (stale) active Layer. The caller's OpenStream will
+		// surface the underlying ErrorRefused so the session records
+		// state=error / failure_reason=refused — the failure mode is
+		// then visible to the operator rather than silently swallowed.
+		// The failed dial is NOT appended to chain.layers, so the next
+		// call retries cleanly.
+		return active
 	}
-	redial.Store(fresh)
+	chain.layers = append(chain.layers, fresh)
+	chain.current.Store(fresh)
 	logger.Debug("proxybuild: upstream h2 redialed after stale-conn detection",
-		"target", target)
+		"target", target, "generation", nextGen)
 	return fresh
+}
+
+// isStaleH2 returns true when the layer has emitted GOAWAY-close or
+// been observed shutdown (USK-796 surfaces). Used by both the fast and
+// slow paths of selectUpstreamForDial; the slow path re-checks under
+// chain.mu so concurrent stream redials still single-flight.
+func isStaleH2(l *http2.Layer) bool {
+	return l.GoAwayClosed() || l.IsShutdown()
 }
 
 // buildSessionOptions populates the SessionOptions threaded into every

--- a/internal/proxybuild/h2_redial_test.go
+++ b/internal/proxybuild/h2_redial_test.go
@@ -3,6 +3,7 @@ package proxybuild
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -13,13 +14,15 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
 )
 
-// USK-816: when the pooled upstream H2 Layer goes stale during a long
-// intercept hold (server GOAWAY / idle FIN), selectUpstreamForDial must
-// fresh-dial via the injected redialFn instead of returning the stale
-// Layer. Without this guard the next OpenStream on the stale Layer either
-// fails with ErrorRefused (state=error/refused) or succeeds-but-returns
-// END_STREAM only (silent state=complete with empty response). Both
-// failure modes are recorded in phase5.md as the production symptom.
+// USK-816 / USK-991: when the pooled upstream H2 Layer goes stale during a
+// long intercept hold (server GOAWAY / idle FIN), selectUpstreamForDial
+// must fresh-dial via the injected redialFn instead of returning the
+// stale Layer. Without this guard the next OpenStream on the stale Layer
+// either fails with ErrorRefused (state=error/refused) or succeeds-but-
+// returns END_STREAM only (silent state=complete with empty response).
+// USK-991 extends the same guard recursively: a previously redialed
+// Layer that itself goes stale must trigger a 2nd (and Nth) fresh dial,
+// not be returned as-is.
 
 // dialPeerH2Layer constructs a real *http2.Layer in ClientRole at one end
 // of a net.Pipe. The peer end is returned so the test can close it (to
@@ -69,8 +72,8 @@ func awaitShutdown(t *testing.T, l *http2.Layer) {
 // TestSelectUpstreamForDial_StaleLayerTriggersRedial reproduces the core
 // USK-816 invariant. The pooled upstreamH2 is forced into stale state
 // (peer FIN → IsShutdown==true). selectUpstreamForDial must invoke the
-// injected redialFn to obtain a fresh Layer, store it via the atomic
-// pointer, and return it.
+// injected redialFn to obtain a fresh Layer, store it via chain.current,
+// and return it.
 func TestSelectUpstreamForDial_StaleLayerTriggersRedial(t *testing.T) {
 	stale, peer := dialPeerH2Layer(t)
 	defer stale.Close()
@@ -85,7 +88,7 @@ func TestSelectUpstreamForDial_StaleLayerTriggersRedial(t *testing.T) {
 	defer freshPeer.Close()
 
 	var redialCalls int32
-	redialFn := func(ctx context.Context, target string, prev *http2.Layer) (*http2.Layer, error) {
+	redialFn := func(ctx context.Context, target string, prev *http2.Layer, gen int) (*http2.Layer, error) {
 		atomic.AddInt32(&redialCalls, 1)
 		if prev != stale {
 			t.Errorf("redialFn prev = %p, want %p (stale Layer)", prev, stale)
@@ -93,28 +96,30 @@ func TestSelectUpstreamForDial_StaleLayerTriggersRedial(t *testing.T) {
 		if target != "example.test:443" {
 			t.Errorf("redialFn target = %q, want %q", target, "example.test:443")
 		}
+		if gen != 1 {
+			t.Errorf("redialFn generation = %d, want 1 (first redial)", gen)
+		}
 		return fresh, nil
 	}
 
-	var ptr atomic.Pointer[http2.Layer]
-	var mu sync.Mutex
+	chain := newRedialChain()
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
-		stale, &ptr, &mu, redialFn, silentLogger())
+		stale, chain, redialFn, silentLogger())
 
 	if got != fresh {
 		t.Errorf("selectUpstreamForDial returned %p, want fresh %p", got, fresh)
 	}
-	if ptr.Load() != fresh {
-		t.Errorf("redial pointer = %p, want fresh %p", ptr.Load(), fresh)
+	if cur := chain.current.Load(); cur != fresh {
+		t.Errorf("chain.current = %p, want fresh %p", cur, fresh)
 	}
 	if n := atomic.LoadInt32(&redialCalls); n != 1 {
 		t.Errorf("redialFn called %d times, want 1", n)
 	}
 
 	// Subsequent calls reuse the cached fresh Layer; redialFn must not fire
-	// again.
+	// again as long as fresh is healthy.
 	got2 := selectUpstreamForDial(context.Background(), "example.test:443",
-		stale, &ptr, &mu, redialFn, silentLogger())
+		stale, chain, redialFn, silentLogger())
 	if got2 != fresh {
 		t.Errorf("second call returned %p, want fresh %p", got2, fresh)
 	}
@@ -136,21 +141,20 @@ func TestSelectUpstreamForDial_HealthyLayerSkipsRedial(t *testing.T) {
 			healthy.IsShutdown(), healthy.GoAwayClosed())
 	}
 
-	redialFn := func(_ context.Context, _ string, _ *http2.Layer) (*http2.Layer, error) {
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		t.Error("redialFn should not be called for a healthy Layer")
 		return nil, errors.New("unexpected redial")
 	}
 
-	var ptr atomic.Pointer[http2.Layer]
-	var mu sync.Mutex
+	chain := newRedialChain()
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
-		healthy, &ptr, &mu, redialFn, silentLogger())
+		healthy, chain, redialFn, silentLogger())
 
 	if got != healthy {
 		t.Errorf("selectUpstreamForDial returned %p, want healthy %p", got, healthy)
 	}
-	if ptr.Load() != nil {
-		t.Errorf("redial pointer = %p, want nil (no redial)", ptr.Load())
+	if cur := chain.current.Load(); cur != nil {
+		t.Errorf("chain.current = %p, want nil (no redial)", cur)
 	}
 }
 
@@ -169,20 +173,22 @@ func TestSelectUpstreamForDial_RedialFailureFallsBackToStale(t *testing.T) {
 	awaitShutdown(t, stale)
 
 	wantErr := errors.New("redial: network unreachable")
-	redialFn := func(_ context.Context, _ string, _ *http2.Layer) (*http2.Layer, error) {
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		return nil, wantErr
 	}
 
-	var ptr atomic.Pointer[http2.Layer]
-	var mu sync.Mutex
+	chain := newRedialChain()
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
-		stale, &ptr, &mu, redialFn, silentLogger())
+		stale, chain, redialFn, silentLogger())
 
 	if got != stale {
 		t.Errorf("selectUpstreamForDial after redial-fail = %p, want stale %p", got, stale)
 	}
-	if ptr.Load() != nil {
-		t.Errorf("redial pointer = %p, want nil (failed redial must not be cached)", ptr.Load())
+	if cur := chain.current.Load(); cur != nil {
+		t.Errorf("chain.current = %p, want nil (failed redial must not be cached)", cur)
+	}
+	if got := len(chain.layers); got != 0 {
+		t.Errorf("chain.layers length = %d, want 0 (failed dial must not be appended)", got)
 	}
 }
 
@@ -231,20 +237,19 @@ func TestSelectUpstreamForDial_ConcurrentStreamsShareSingleRedial(t *testing.T) 
 	// Block the first redial briefly so concurrent callers stack up on the
 	// mutex; the test then asserts only one call ever ran.
 	gate := make(chan struct{})
-	redialFn := func(_ context.Context, _ string, _ *http2.Layer) (*http2.Layer, error) {
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		<-gate
 		atomic.AddInt32(&redialCalls, 1)
 		return fresh, nil
 	}
 
-	var ptr atomic.Pointer[http2.Layer]
-	var mu sync.Mutex
+	chain := newRedialChain()
 	const n = 8
 	results := make(chan *http2.Layer, n)
 	for i := 0; i < n; i++ {
 		go func() {
 			results <- selectUpstreamForDial(context.Background(), "example.test:443",
-				stale, &ptr, &mu, redialFn, silentLogger())
+				stale, chain, redialFn, silentLogger())
 		}()
 	}
 
@@ -265,4 +270,240 @@ func TestSelectUpstreamForDial_ConcurrentStreamsShareSingleRedial(t *testing.T) 
 	if got := atomic.LoadInt32(&redialCalls); got != 1 {
 		t.Errorf("redialFn fired %d times, want 1 (single-flight)", got)
 	}
+}
+
+// closeRecordingLayer wraps a real *http2.Layer with an atomic Close
+// counter so chain.closeAll() assertions can verify each chain step is
+// closed exactly once. (Methods that are not exercised by the test are
+// untouched; we only need Close + the staleness pollers.)
+//
+// Note: http2.Layer has methods that the chain doesn't call in tests
+// (e.g. OpenStream), so we wrap only for Close-count verification and
+// keep the real Layer reachable via .l for the assertions that need it.
+
+// TestSelectUpstreamForDial_NChainRedials reproduces the USK-991 core
+// case: a previously redialed Layer that itself receives GOAWAY/EOF
+// must trigger an Nth fresh dial, not be returned as-is.
+//
+// Staging: pooled → fresh1 → fresh2 → fresh3.
+// Each stage is driven into IsShutdown via peer.Close(); the next call
+// to selectUpstreamForDial must observe the new staleness, take the
+// chain.mu, and dial the next fresh Layer with monotonically increasing
+// generation (1, 2, 3, ...).
+func TestSelectUpstreamForDial_NChainRedials(t *testing.T) {
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+
+	// Stage 3 fresh Layers up front; the redialFn returns them in order.
+	fresh1, peer1 := dialPeerH2Layer(t)
+	defer fresh1.Close()
+	defer peer1.Close()
+	fresh2, peer2 := dialPeerH2Layer(t)
+	defer fresh2.Close()
+	defer peer2.Close()
+	fresh3, peer3 := dialPeerH2Layer(t)
+	defer fresh3.Close()
+	defer peer3.Close()
+
+	freshSeq := []*http2.Layer{fresh1, fresh2, fresh3}
+	var seenGens []int
+	var idx int32
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, gen int) (*http2.Layer, error) {
+		i := atomic.AddInt32(&idx, 1)
+		seenGens = append(seenGens, gen)
+		if int(i) > len(freshSeq) {
+			t.Fatalf("redialFn called more than %d times (got %d)", len(freshSeq), i)
+		}
+		return freshSeq[i-1], nil
+	}
+
+	chain := newRedialChain()
+
+	// Stage 0: kill pooled, expect fresh1 with generation=1.
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+	got := selectUpstreamForDial(context.Background(), "example.test:443",
+		pooled, chain, redialFn, silentLogger())
+	if got != fresh1 {
+		t.Fatalf("stage 1: got %p, want fresh1 %p", got, fresh1)
+	}
+
+	// Stage 1: kill fresh1, expect fresh2 with generation=2.
+	_ = peer1.Close()
+	awaitShutdown(t, fresh1)
+	got = selectUpstreamForDial(context.Background(), "example.test:443",
+		pooled, chain, redialFn, silentLogger())
+	if got != fresh2 {
+		t.Fatalf("stage 2: got %p, want fresh2 %p", got, fresh2)
+	}
+
+	// Stage 2: kill fresh2, expect fresh3 with generation=3.
+	_ = peer2.Close()
+	awaitShutdown(t, fresh2)
+	got = selectUpstreamForDial(context.Background(), "example.test:443",
+		pooled, chain, redialFn, silentLogger())
+	if got != fresh3 {
+		t.Fatalf("stage 3: got %p, want fresh3 %p", got, fresh3)
+	}
+
+	wantGens := []int{1, 2, 3}
+	if len(seenGens) != len(wantGens) {
+		t.Fatalf("redialFn generation sequence = %v, want %v", seenGens, wantGens)
+	}
+	for i, g := range seenGens {
+		if g != wantGens[i] {
+			t.Errorf("redialFn call #%d: generation = %d, want %d", i+1, g, wantGens[i])
+		}
+	}
+
+	// Chain holds every fresh Layer for closeAll.
+	if got, want := len(chain.layers), 3; got != want {
+		t.Errorf("chain.layers length = %d, want %d", got, want)
+	}
+	if cur := chain.current.Load(); cur != fresh3 {
+		t.Errorf("chain.current = %p, want fresh3 %p (final stage)", cur, fresh3)
+	}
+}
+
+// TestSelectUpstreamForDial_NChainConcurrentSingleFlightPerStep extends
+// the concurrent-streams test (USK-816) to the N-chain case (USK-991).
+// At each chain step, M concurrent goroutines that observe the same
+// staleness must coalesce into a single fresh dial — verified across
+// two consecutive chain steps in one test.
+func TestSelectUpstreamForDial_NChainConcurrentSingleFlightPerStep(t *testing.T) {
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+	fresh1, peer1 := dialPeerH2Layer(t)
+	defer fresh1.Close()
+	defer peer1.Close()
+	fresh2, peer2 := dialPeerH2Layer(t)
+	defer fresh2.Close()
+	defer peer2.Close()
+
+	var dialCount int32
+	gate := make(chan struct{})
+	// We unblock the dial sequentially, one chain step at a time.
+	// On the 1st redial call we return fresh1; on the 2nd, fresh2.
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		<-gate
+		n := atomic.AddInt32(&dialCount, 1)
+		switch n {
+		case 1:
+			return fresh1, nil
+		case 2:
+			return fresh2, nil
+		default:
+			return nil, fmt.Errorf("unexpected dial #%d", n)
+		}
+	}
+
+	chain := newRedialChain()
+	const m = 8
+
+	// Step A: pooled is stale → all M goroutines must converge on fresh1.
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+
+	resultsA := make(chan *http2.Layer, m)
+	var startA sync.WaitGroup
+	startA.Add(m)
+	for i := 0; i < m; i++ {
+		go func() {
+			startA.Done()
+			resultsA <- selectUpstreamForDial(context.Background(), "example.test:443",
+				pooled, chain, redialFn, silentLogger())
+		}()
+	}
+	startA.Wait()
+	time.Sleep(50 * time.Millisecond)
+	// Unblock the 1st dial only — and wait for it to complete so all
+	// goroutines on this step return.
+	gate <- struct{}{}
+	for i := 0; i < m; i++ {
+		select {
+		case got := <-resultsA:
+			if got != fresh1 {
+				t.Errorf("step A goroutine %d got %p, want fresh1 %p", i, got, fresh1)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("step A goroutine %d did not return", i)
+		}
+	}
+	if got := atomic.LoadInt32(&dialCount); got != 1 {
+		t.Fatalf("step A dialCount = %d, want 1", got)
+	}
+
+	// Step B: fresh1 is now stale → all M goroutines must converge on fresh2.
+	_ = peer1.Close()
+	awaitShutdown(t, fresh1)
+
+	resultsB := make(chan *http2.Layer, m)
+	var startB sync.WaitGroup
+	startB.Add(m)
+	for i := 0; i < m; i++ {
+		go func() {
+			startB.Done()
+			resultsB <- selectUpstreamForDial(context.Background(), "example.test:443",
+				pooled, chain, redialFn, silentLogger())
+		}()
+	}
+	startB.Wait()
+	time.Sleep(50 * time.Millisecond)
+	gate <- struct{}{}
+	for i := 0; i < m; i++ {
+		select {
+		case got := <-resultsB:
+			if got != fresh2 {
+				t.Errorf("step B goroutine %d got %p, want fresh2 %p", i, got, fresh2)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("step B goroutine %d did not return", i)
+		}
+	}
+	if got := atomic.LoadInt32(&dialCount); got != 2 {
+		t.Fatalf("step B dialCount = %d, want 2 (one new dial per step)", got)
+	}
+}
+
+// TestRedialChain_CloseAllClosesEveryStep asserts that closeAll() closes
+// every fresh Layer accumulated in the chain — required for the defer
+// in buildOnHTTP2Stack to release the chain at CONNECT exit. The chain
+// also clears current+layers so a repeat call is a no-op (idempotent).
+func TestRedialChain_CloseAllClosesEveryStep(t *testing.T) {
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+	fresh1, peer1 := dialPeerH2Layer(t)
+	defer peer1.Close()
+	fresh2, peer2 := dialPeerH2Layer(t)
+	defer peer2.Close()
+	fresh3, peer3 := dialPeerH2Layer(t)
+	defer peer3.Close()
+
+	chain := newRedialChain()
+	chain.layers = append(chain.layers, fresh1, fresh2, fresh3)
+	chain.current.Store(fresh3)
+
+	chain.closeAll()
+
+	for i, l := range []*http2.Layer{fresh1, fresh2, fresh3} {
+		if !l.IsShutdown() && !l.GoAwayClosed() {
+			// Layer.Close sets the underlying signals; assert at least one
+			// observable shutdown signal is set.
+			t.Errorf("chain step %d: Close did not signal shutdown (IsShutdown=%v GoAwayClosed=%v)",
+				i+1, l.IsShutdown(), l.GoAwayClosed())
+		}
+	}
+	if got := len(chain.layers); got != 0 {
+		t.Errorf("after closeAll, chain.layers length = %d, want 0", got)
+	}
+	if cur := chain.current.Load(); cur != nil {
+		t.Errorf("after closeAll, chain.current = %p, want nil", cur)
+	}
+
+	// Repeat call must be a no-op (defer might run twice in hypothetical
+	// re-entry; closeAll must not panic).
+	chain.closeAll()
 }


### PR DESCRIPTION
## Summary
- Fixes the USK-716 regression where a redialed h2 connection that itself receives a GOAWAY produces `dial: stream error refused: layer shutdown` on the next request after idle. Concrete production repro: freee accounts, 2026-05-23, flow `667c9360-8192-43f7-9ea7-9be6fab85480` — login burst -> 1m34s idle -> 2nd GOAWAY -> `GET /logout` dies.
- `selectUpstreamForDial` now walks a `redialChain` (slice + `current` atomic pointer + `mu`), re-checking the currently-active Layer (pooled or `redial[k]`) for `GoAwayClosed`/`IsShutdown` on every dial-closure call and chaining to a fresh `redial[k+1]` when stale. No cap on chain length — browser-equivalent transparency.
- Prior chain steps are retained in the slice and closed at CONNECT exit (single `defer chain.closeAll()`), so in-flight streams on `redial[k-1]` drain naturally up to GOAWAY's `last_stream_id` (RFC 9113 §6.8) — matches browser behaviour rather than aborting them.
- ConnID label propagation: `/upstream` -> `/upstream-redial` -> `/upstream-redial-2` -> `/upstream-redial-3` -> ... for diagnostic traceability across chain steps. `generation==1` keeps the USK-816 historical suffix so existing log scrapers stay happy.

## Implementation notes
- `internal/proxybuild/builder.go`: new `redialChain` struct (`mu sync.Mutex` + `layers []*http2.Layer` + `current atomic.Pointer[http2.Layer]`). `selectUpstreamForDial` signature now takes `*redialChain` + `redialFunc` (typed wrapper carrying the generation hint). Single-flight per chain step via `chain.mu`; the lock-free fast path reads `chain.current` and falls through to slow path only when stale.
- `internal/connector/h2_redial.go`: `RedialUpstreamH2` gains a `generation int` parameter and delegates label construction to the new `redialConnIDLabel` helper.
- Failed dials are NOT appended to `chain.layers` and do NOT update `chain.current` — they fall back to the prior (stale) Layer so `OpenStream` surfaces the underlying `ErrorRefused` to the session (recorded as `state=error / failure_reason=refused`); next call retries cleanly.

## Test plan
- [x] `TestSelectUpstreamForDial_NChainRedials` — 3-stage chain (pooled -> fresh1 -> fresh2 -> fresh3) asserts each `Close()` of the active peer drives the next fresh dial and generation increments 1, 2, 3.
- [x] `TestSelectUpstreamForDial_NChainConcurrentSingleFlightPerStep` — 8 concurrent goroutines per step coalesce into exactly one fresh dial; verified across TWO consecutive chain steps under `-race`.
- [x] `TestRedialChain_CloseAllClosesEveryStep` — every appended Layer is shut down and the chain is idempotent on repeat close.
- [x] `TestRedialConnIDLabel_GenerationProgression` + `TestRedialConnIDLabel_ChainUniqueness` — locks the `/upstream-redial[-N]` scheme and asserts all 5 chain labels are distinct.
- [x] Existing USK-816 tests (`TestSelectUpstreamForDial_StaleLayerTriggersRedial`, `_HealthyLayerSkipsRedial`, `_RedialFailureFallsBackToStale`, `_PreFix_OpenStreamOnStaleLayerFails`, `_ConcurrentStreamsShareSingleRedial`) ported to the new signature — all still green.
- [x] `make build` / `make test` / `make lint` green locally.

## Out of scope (will become follow-up Issues)
- Proactive eviction + pre-warm a fresh connection while idle (Issue body fix 3) — needs a new Layer -> consumer observer hook; deferred to keep PR narrow.
- Auto-redial-and-retry on `Refused: layer shutdown` at the connector level (Issue body fix 4) — different surface, different design; deferred.

Resolves USK-991
Related: USK-716, USK-816
Linear: https://linear.app/usk6666/issue/USK-991

🤖 Generated with [Claude Code](https://claude.com/claude-code)