### PR TITLE
fix(proxybuild): auto-retry on Refused: layer shutdown at OpenStream (USK-993)

### DIFF
--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -984,8 +984,9 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 						return
 					}
 					dial := func(dctx context.Context, env *envelope.Envelope) (layer.Channel, error) {
-						upL := selectUpstreamForDial(dctx, target, upstreamH2, chain, redialFn, logger)
-						upCh, oerr := upL.OpenStream(dctx)
+						upL, upCh, oerr := openUpstreamStreamWithRetry(
+							dctx, target, upstreamH2, chain, redialFn, logger,
+						)
 						if oerr != nil {
 							return nil, oerr
 						}
@@ -1184,6 +1185,126 @@ func selectUpstreamForDial(
 // chain.mu so concurrent stream redials still single-flight.
 func isStaleH2(l *http2.Layer) bool {
 	return l.GoAwayClosed() || l.IsShutdown()
+}
+
+// openStreamFunc is the OpenStream signature, injected so the unit test
+// can drive Refused-then-succeed sequences deterministically without
+// staging real layer.Shutdown transitions. The production caller uses
+// http2OpenStream which adapts (*http2.Layer).OpenStream verbatim.
+type openStreamFunc func(ctx context.Context, l *http2.Layer) (layer.Channel, error)
+
+// http2OpenStream is the production binding of openStreamFunc.
+func http2OpenStream(ctx context.Context, l *http2.Layer) (layer.Channel, error) {
+	return l.OpenStream(ctx)
+}
+
+// openUpstreamStreamWithRetry resolves the active upstream Layer via
+// selectUpstreamForDial and calls OpenStream on it. When OpenStream
+// returns a `*layer.StreamError{Code: ErrorRefused}` (USK-993 residual
+// race: the Layer was healthy at selectUpstreamForDial time but
+// transitioned to shutdown / GOAWAY before the OpenStream syscall), the
+// helper retries exactly once. The retry re-calls selectUpstreamForDial,
+// which detects the staleness via isStaleH2 and fresh-dials under
+// chain.mu single-flight (so concurrent streams sharing the same race
+// converge on a single new Layer).
+//
+// Retry budget:
+//   - Exactly 1 retry per dial closure invocation. If the second attempt
+//     also returns Refused (or any other error), the underlying error is
+//     returned verbatim — session records state=error / failure_reason=
+//     refused, matching the pre-fix observable. The retry budget is
+//     stack-local, so it cannot accumulate across requests.
+//
+// Idempotency:
+//   - OpenStream returns ErrorRefused before any HEADERS frame is
+//     enqueued (see internal/layer/http2/layer.go:481-498: the three
+//     Refused emission sites — "layer shutdown", "GOAWAY sent",
+//     "GOAWAY received" — all return before sendHeadersEvent /
+//     allocateAndEnqueueFirstHeaders ever runs). No stream_id is
+//     allocated; no bytes hit the wire. Retry is byte-for-byte
+//     equivalent to a fresh request regardless of HTTP method, so POST/
+//     PUT/DELETE etc. are safe (stronger than RFC 9113 §6.8 needs).
+//
+// Classifier:
+//   - We match by Code (layer.ErrorRefused), not by Reason string. All
+//     three Refused emission sites are pre-HEADERS races with identical
+//     retry-safety; Reason-string matching would be brittle.
+//
+// Browser parity:
+//   - Without the retry, the residual race window between
+//     selectUpstreamForDial and OpenStream surfaces as state=error to
+//     operators even though zero wire bytes were sent — diagnostic
+//     distortion (see CLAUDE.md feedback memory: MITM browser-parity
+//     north star). The retry absorbs the failure transparently when a
+//     fresh dial succeeds.
+func openUpstreamStreamWithRetry(
+	dctx context.Context,
+	target string,
+	upstreamH2 *http2.Layer,
+	chain *redialChain,
+	dialFresh redialFunc,
+	logger *slog.Logger,
+) (*http2.Layer, layer.Channel, error) {
+	return openUpstreamStreamWithRetryFn(
+		dctx, target, upstreamH2, chain, dialFresh, http2OpenStream, logger,
+	)
+}
+
+// openUpstreamStreamWithRetryFn is the OpenStream-injectable form used
+// by tests. Production code calls openUpstreamStreamWithRetry which
+// passes http2OpenStream.
+func openUpstreamStreamWithRetryFn(
+	dctx context.Context,
+	target string,
+	upstreamH2 *http2.Layer,
+	chain *redialChain,
+	dialFresh redialFunc,
+	openStream openStreamFunc,
+	logger *slog.Logger,
+) (*http2.Layer, layer.Channel, error) {
+	upL := selectUpstreamForDial(dctx, target, upstreamH2, chain, dialFresh, logger)
+	upCh, err := openStream(dctx, upL)
+	if err == nil {
+		return upL, upCh, nil
+	}
+	if !isRefusedStreamError(err) {
+		return nil, nil, err
+	}
+	// Attempt 1 returned Refused. Retry exactly once. The second
+	// selectUpstreamForDial sees the now-stale Layer (the very Refused
+	// codes imply shutdown/GOAWAY on upL) and fresh-dials under
+	// chain.mu. Concurrent streams hitting the same race converge on
+	// the same fresh Layer through chain.current.
+	logger.Debug("proxybuild: OpenStream refused, retrying after fresh dial",
+		"target", target, "reason", refusedReason(err))
+	upL2 := selectUpstreamForDial(dctx, target, upstreamH2, chain, dialFresh, logger)
+	upCh2, err2 := openStream(dctx, upL2)
+	if err2 != nil {
+		return nil, nil, err2
+	}
+	return upL2, upCh2, nil
+}
+
+// isRefusedStreamError reports whether err is a *layer.StreamError whose
+// Code is layer.ErrorRefused. Matches all three OpenStream Refused
+// emission sites (layer shutdown / GOAWAY sent / GOAWAY received) — all
+// pre-HEADERS, so all retry-safe regardless of HTTP method.
+func isRefusedStreamError(err error) bool {
+	var se *layer.StreamError
+	if !errors.As(err, &se) {
+		return false
+	}
+	return se.Code == layer.ErrorRefused
+}
+
+// refusedReason returns the Reason field of a refused StreamError for
+// logging. Returns the error's string form if Reason is unavailable.
+func refusedReason(err error) string {
+	var se *layer.StreamError
+	if errors.As(err, &se) {
+		return se.Reason
+	}
+	return err.Error()
 }
 
 // buildSessionOptions populates the SessionOptions threaded into every

--- a/internal/proxybuild/h2_openstream_retry_integration_test.go
+++ b/internal/proxybuild/h2_openstream_retry_integration_test.go
@@ -1,0 +1,366 @@
+//go:build e2e
+
+// USK-993 smoke-tier integration coverage for the auto-redial-and-retry
+// behaviour at OpenStream-Refused. The unit tests in h2_redial_test.go
+// pin the helper-level invariants deterministically (Refused → retry →
+// success, budget exactly 1, classifier widened to all 3 Refused
+// reasons). This file confirms the helper is wired into the production
+// dial closure via BuildLiveStack and that the end-to-end recording
+// surface is `state=complete` for the POST method when the upstream
+// Layer is forced stale during the intercept hold.
+//
+// Why smoke tier (`//go:build e2e`, NOT `e2e && !e2e_smoke`): the retry
+// is part of the merge-gate browser-parity guarantee. A regression that
+// reverts to `state=error` on POST during the residual race would land
+// silently if this only ran nightly. See CLAUDE.md "e2e test tiers"
+// note and design review §12.
+package proxybuild_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	gohttp "net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	h2pool "github.com/usk6666/yorishiro-proxy/internal/layer/http2/pool"
+	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
+	httprules "github.com/usk6666/yorishiro-proxy/internal/rules/http"
+)
+
+// shuttableH2Upstream is an h2 TLS upstream that can be commanded to send
+// GOAWAY to all active connections. The handler accepts POST requests and
+// echoes the body; the listener wraps each accepted TLS conn so the test
+// can drive a coordinated shutdown.
+type shuttableH2Upstream struct {
+	addr        string
+	tlsLn       net.Listener
+	h2s         *http2.Server
+	wg          sync.WaitGroup
+	mu          sync.Mutex
+	activeConns []*tls.Conn
+	closed      atomic.Bool
+}
+
+func startShuttableH2Upstream(t *testing.T, cn string, handler gohttp.Handler) *shuttableH2Upstream {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{cn, "localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  key,
+		}},
+		NextProtos: []string{"h2"},
+	}
+
+	tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &shuttableH2Upstream{
+		addr:  tcpLn.Addr().String(),
+		tlsLn: tcpLn,
+		h2s:   &http2.Server{},
+	}
+
+	go func() {
+		for {
+			c, aerr := tcpLn.Accept()
+			if aerr != nil {
+				return
+			}
+			tlsConn := tls.Server(c, tlsCfg)
+			srv.mu.Lock()
+			srv.activeConns = append(srv.activeConns, tlsConn)
+			srv.mu.Unlock()
+			srv.wg.Add(1)
+			go func(tc *tls.Conn) {
+				defer srv.wg.Done()
+				defer tc.Close()
+				if herr := tc.Handshake(); herr != nil {
+					return
+				}
+				srv.h2s.ServeConn(tc, &http2.ServeConnOpts{Handler: handler})
+			}(tlsConn)
+		}
+	}()
+
+	return srv
+}
+
+// closeAll forcibly closes every active TLS connection. The MITM's
+// upstream-side h2 Layer reader observes EOF and flips IsShutdown true
+// — staging the staleness that drives the retry path.
+func (s *shuttableH2Upstream) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.activeConns {
+		_ = c.Close()
+	}
+}
+
+func (s *shuttableH2Upstream) shutdown() {
+	if !s.closed.CompareAndSwap(false, true) {
+		return
+	}
+	_ = s.tlsLn.Close()
+	doneCh := make(chan struct{})
+	go func() { s.wg.Wait(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// TestUSK993_H2_POST_StateCompleteAfterUpstreamShutdown_DuringHold pins
+// the integration-level browser-parity invariant: a POST request that is
+// held by an intercept rule MUST land as `state=complete` even when the
+// upstream connection is closed (forces IsShutdown→true on the upstream
+// Layer) during the hold. Without USK-993 the residual race between
+// selectUpstreamForDial and OpenStream surfaces as `state=error` /
+// `failure_reason=refused` — even though zero wire bytes hit the wire.
+// With USK-993 the dial closure retries once and the request completes
+// transparently.
+//
+// This is the merge-gate smoke variant: it does not deterministically
+// stage the microsecond race (the unit tests in h2_redial_test.go do
+// that), but it confirms the helper is wired into the production dial
+// closure and that POST goes through under the worst-case scheduling
+// pattern.
+func TestUSK993_H2_POST_StateCompleteAfterUpstreamShutdown_DuringHold(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var hits atomic.Int64
+	up := startShuttableH2Upstream(t, "usk993-post", gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("echo:" + string(body)))
+	}))
+	defer up.shutdown()
+
+	intercept := httprules.NewInterceptEngine()
+	intercept.AddRule(httprules.InterceptRule{
+		ID:          "usk993-hold-post",
+		Enabled:     true,
+		Direction:   httprules.DirectionRequest,
+		PathPattern: regexp.MustCompile(`^/usk993$`),
+	})
+	holdQueue := common.NewHoldQueue()
+	holdQueue.SetTimeout(10 * time.Second)
+
+	pool := h2pool.New(h2pool.PoolOptions{})
+	defer pool.Close()
+
+	store := &flowStoreForH2Pool{}
+	proxyAddr := startProxyForH2PoolInterceptTest(t, ctx, store, intercept, holdQueue, pool)
+
+	type result struct {
+		status int
+		body   string
+		err    error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		cli := newH2ClientThroughProxyForPoolTest(proxyAddr, up.addr)
+		req, _ := gohttp.NewRequestWithContext(ctx, "POST", "https://"+up.addr+"/usk993",
+			strings.NewReader("payload-993"))
+		resp, err := cli.Do(req)
+		if err != nil {
+			resCh <- result{err: err}
+			return
+		}
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resCh <- result{status: resp.StatusCode, body: string(b)}
+	}()
+
+	// Wait for the intercept to capture the request, then forcibly close
+	// the upstream h2 conn. The Layer reader observes EOF → IsShutdown
+	// flips true. On release, the dial closure must observe the stale
+	// Layer (via selectUpstreamForDial → isStaleH2) and fresh-dial OR
+	// hit the OpenStream-Refused retry path (USK-993). Either way, the
+	// request must reach the upstream because the upstream listener is
+	// still accepting.
+	releaseFirstHeldEntry(t, holdQueue, 5*time.Second, func(_ *common.HeldEntry) *common.HoldAction {
+		// Close upstream conns just before release so the dial closure
+		// runs with a stale Layer.
+		up.closeAll()
+		// Yield briefly so the reader goroutine observes EOF and flips
+		// IsShutdown before the dial closure samples it.
+		time.Sleep(50 * time.Millisecond)
+		return &common.HoldAction{Type: common.ActionRelease}
+	})
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("client error: %v", r.err)
+		}
+		if r.status != 200 {
+			t.Errorf("POST status = %d, want 200 (USK-993: residual race must not surface as state=error)", r.status)
+		}
+		if r.body != "echo:payload-993" {
+			t.Errorf("POST body = %q, want %q", r.body, "echo:payload-993")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("POST never returned (USK-993: retry path may be unwired)")
+	}
+
+	if hits.Load() == 0 {
+		t.Error("upstream observed 0 POST hits — POST never reached upstream")
+	}
+
+	// Wait for recording to settle.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.Streams()) >= 1 {
+			if got := store.Streams()[0].State; got == "complete" || got == "error" {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	streams := store.Streams()
+	if len(streams) < 1 {
+		t.Fatalf("expected >=1 stream recorded, got %d", len(streams))
+	}
+	if got, want := streams[0].State, "complete"; got != want {
+		t.Errorf("stream State = %q, want %q (USK-993: POST must record state=complete despite upstream shutdown during hold; failure_reason=%q)",
+			got, want, streams[0].FailureReason)
+	}
+}
+
+// TestUSK993_H2_GET_StateCompleteAfterUpstreamShutdown_DuringHold mirrors
+// the POST variant for an idempotent method. The retry behaviour is the
+// same regardless of method (OpenStream-Refused is pre-HEADERS — no bytes
+// have hit the wire — so retry is byte-for-byte equivalent to a fresh
+// request). This test exists to confirm method-axis parity rather than
+// independent coverage.
+func TestUSK993_H2_GET_StateCompleteAfterUpstreamShutdown_DuringHold(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var hits atomic.Int64
+	up := startShuttableH2Upstream(t, "usk993-get", gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok:" + r.URL.Path))
+	}))
+	defer up.shutdown()
+
+	intercept := httprules.NewInterceptEngine()
+	intercept.AddRule(httprules.InterceptRule{
+		ID:          "usk993-hold-get",
+		Enabled:     true,
+		Direction:   httprules.DirectionRequest,
+		PathPattern: regexp.MustCompile(`^/usk993get$`),
+	})
+	holdQueue := common.NewHoldQueue()
+	holdQueue.SetTimeout(10 * time.Second)
+
+	pool := h2pool.New(h2pool.PoolOptions{})
+	defer pool.Close()
+
+	store := &flowStoreForH2Pool{}
+	proxyAddr := startProxyForH2PoolInterceptTest(t, ctx, store, intercept, holdQueue, pool)
+
+	type result struct {
+		status int
+		body   string
+		err    error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		cli := newH2ClientThroughProxyForPoolTest(proxyAddr, up.addr)
+		req, _ := gohttp.NewRequestWithContext(ctx, "GET", "https://"+up.addr+"/usk993get", nil)
+		resp, err := cli.Do(req)
+		if err != nil {
+			resCh <- result{err: err}
+			return
+		}
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resCh <- result{status: resp.StatusCode, body: string(b)}
+	}()
+
+	releaseFirstHeldEntry(t, holdQueue, 5*time.Second, func(_ *common.HeldEntry) *common.HoldAction {
+		up.closeAll()
+		time.Sleep(50 * time.Millisecond)
+		return &common.HoldAction{Type: common.ActionRelease}
+	})
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("client error: %v", r.err)
+		}
+		if r.status != 200 {
+			t.Errorf("GET status = %d, want 200", r.status)
+		}
+		if r.body != "ok:/usk993get" {
+			t.Errorf("GET body = %q, want %q", r.body, "ok:/usk993get")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("GET never returned")
+	}
+
+	if hits.Load() == 0 {
+		t.Error("upstream observed 0 hits")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.Streams()) >= 1 {
+			if got := store.Streams()[0].State; got == "complete" || got == "error" {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	streams := store.Streams()
+	if len(streams) < 1 {
+		t.Fatalf("expected >=1 stream recorded, got %d", len(streams))
+	}
+	if got, want := streams[0].State, "complete"; got != want {
+		t.Errorf("GET stream State = %q, want %q (failure_reason=%q)",
+			got, want, streams[0].FailureReason)
+	}
+}

--- a/internal/proxybuild/h2_pool_helpers_test.go
+++ b/internal/proxybuild/h2_pool_helpers_test.go
@@ -1,0 +1,322 @@
+//go:build e2e
+
+// Shared test helpers for proxybuild h2-pool integration tests.
+//
+// These helpers stage a TLS h2 upstream + a CONNECT-tunnel client + a
+// BuildLiveStack-assembled proxy with HTTP2Pool wired in. They are used
+// by both the smoke tier (USK-993 OpenStream-retry coverage —
+// h2_openstream_retry_integration_test.go) and the full tier (USK-816
+// h2-pool intercept coverage — h2_pool_intercept_integration_test.go).
+// Putting them under //go:build e2e (no `!e2e_smoke` exclusion) lets the
+// merge-gate smoke run pick them up.
+package proxybuild_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net"
+	gohttp "net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/usk6666/yorishiro-proxy/internal/cert"
+	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	h2pool "github.com/usk6666/yorishiro-proxy/internal/layer/http2/pool"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
+	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
+	httprules "github.com/usk6666/yorishiro-proxy/internal/rules/http"
+	"github.com/usk6666/yorishiro-proxy/internal/testutil"
+)
+
+// startH2TLSUpstreamForPoolTest spins up a TLS upstream that serves HTTP/2 via
+// golang.org/x/net/http2.Server. Returns the listener addr, an accept counter
+// (used to verify pool reuse), and a shutdown closure.
+func startH2TLSUpstreamForPoolTest(t *testing.T, cn string, handler gohttp.Handler) (addr string, acceptCount func() int64, shutdown func()) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{cn, "localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  key,
+		}},
+		NextProtos: []string{"h2"},
+	}
+
+	tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var accepts atomic.Int64
+	h2s := &http2.Server{}
+
+	var wg sync.WaitGroup
+	go func() {
+		for {
+			c, aerr := tcpLn.Accept()
+			if aerr != nil {
+				return
+			}
+			accepts.Add(1)
+			tlsConn := tls.Server(c, tlsCfg)
+			wg.Add(1)
+			go func(tc *tls.Conn) {
+				defer wg.Done()
+				defer tc.Close()
+				if herr := tc.Handshake(); herr != nil {
+					return
+				}
+				h2s.ServeConn(tc, &http2.ServeConnOpts{Handler: handler})
+			}(tlsConn)
+		}
+	}()
+
+	return tcpLn.Addr().String(), func() int64 { return accepts.Load() }, func() {
+		_ = tcpLn.Close()
+		doneCh := make(chan struct{})
+		go func() { wg.Wait(); close(doneCh) }()
+		select {
+		case <-doneCh:
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// connectTunnelDialerForPoolTest opens a CONNECT tunnel to proxyAddr for the
+// given target.
+func connectTunnelDialerForPoolTest(proxyAddr, target string) (net.Conn, error) {
+	c, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	if _, werr := c.Write([]byte(req)); werr != nil {
+		c.Close()
+		return nil, werr
+	}
+	br := bytes.NewBuffer(nil)
+	buf := make([]byte, 1)
+	for {
+		n, rerr := c.Read(buf)
+		if rerr != nil {
+			c.Close()
+			return nil, rerr
+		}
+		if n == 0 {
+			continue
+		}
+		br.Write(buf[:n])
+		text := br.String()
+		if (len(text) >= 4 && text[len(text)-4:] == "\r\n\r\n") || (len(text) >= 2 && text[len(text)-2:] == "\n\n") {
+			break
+		}
+		if br.Len() > 4096 {
+			c.Close()
+			return nil, fmt.Errorf("CONNECT response too large")
+		}
+	}
+	if !bytes.Contains(br.Bytes(), []byte(" 200")) {
+		c.Close()
+		return nil, fmt.Errorf("CONNECT failed: %s", br.String())
+	}
+	return c, nil
+}
+
+// newH2ClientThroughProxyForPoolTest wires an http.Client that funnels every
+// request through proxyAddr using CONNECT + TLS h2.
+func newH2ClientThroughProxyForPoolTest(proxyAddr, target string) *gohttp.Client {
+	tr := &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // test
+			NextProtos:         []string{"h2"},
+		},
+		DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+			raw, err := connectTunnelDialerForPoolTest(proxyAddr, target)
+			if err != nil {
+				return nil, err
+			}
+			tlsConn := tls.Client(raw, cfg)
+			if err := tlsConn.Handshake(); err != nil {
+				raw.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		},
+	}
+	return &gohttp.Client{Transport: tr, Timeout: 30 * time.Second}
+}
+
+// startProxyForH2PoolInterceptTest builds a live Stack via BuildLiveStack and
+// starts its listener. The stack is wired with a non-nil HTTP2Pool to mirror
+// production wiring (mcpserver/init.go:467).
+func startProxyForH2PoolInterceptTest(
+	t *testing.T,
+	ctx context.Context,
+	store flow.Writer,
+	intercept *httprules.InterceptEngine,
+	holdQueue *common.HoldQueue,
+	pool *h2pool.Pool,
+) (proxyAddr string) {
+	t.Helper()
+
+	ca := &cert.CA{}
+	if err := ca.Generate(); err != nil {
+		t.Fatalf("CA.Generate: %v", err)
+	}
+
+	logger := testutil.DiscardLogger()
+	if testing.Verbose() && os.Getenv("USK816_DEBUG") != "" {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+
+	deps := proxybuild.Deps{
+		Logger:       logger,
+		ListenerName: "usk-pool-test",
+		ListenAddr:   "127.0.0.1:0",
+		FlowStore:    store,
+		BuildConfig: &connector.BuildConfig{
+			ProxyConfig:        &config.ProxyConfig{},
+			Issuer:             cert.NewIssuer(ca),
+			InsecureSkipVerify: true,
+			HTTP2Pool:          pool,
+		},
+		HTTPInterceptEngine: intercept,
+		HoldQueue:           holdQueue,
+	}
+
+	stack, err := proxybuild.BuildLiveStack(ctx, deps)
+	if err != nil {
+		t.Fatalf("BuildLiveStack: %v", err)
+	}
+	go func() { _ = stack.Listener.Start(ctx) }()
+
+	select {
+	case <-stack.Listener.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener not ready in 5s")
+	}
+	addr := stack.Listener.Addr()
+	if addr == "" {
+		t.Fatal("listener has no addr")
+	}
+	return addr
+}
+
+// flowStoreForH2Pool is a flow.Writer that records every Stream/Flow under a
+// mutex so test goroutines can inspect them safely.
+type flowStoreForH2Pool struct {
+	mu      sync.Mutex
+	streams []*flow.Stream
+	updates map[string][]flow.StreamUpdate
+	flows   []*flow.Flow
+}
+
+func (s *flowStoreForH2Pool) SaveStream(_ context.Context, st *flow.Stream) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *st
+	s.streams = append(s.streams, &cp)
+	return nil
+}
+
+func (s *flowStoreForH2Pool) UpdateStream(_ context.Context, id string, upd flow.StreamUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.updates == nil {
+		s.updates = make(map[string][]flow.StreamUpdate)
+	}
+	s.updates[id] = append(s.updates[id], upd)
+	for _, st := range s.streams {
+		if st.ID == id {
+			if upd.State != "" {
+				st.State = upd.State
+			}
+			if upd.FailureReason != "" {
+				st.FailureReason = upd.FailureReason
+			}
+		}
+	}
+	return nil
+}
+
+func (s *flowStoreForH2Pool) SaveFlow(_ context.Context, f *flow.Flow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *f
+	s.flows = append(s.flows, &cp)
+	return nil
+}
+
+func (s *flowStoreForH2Pool) Streams() []*flow.Stream {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*flow.Stream, len(s.streams))
+	copy(out, s.streams)
+	return out
+}
+
+func (s *flowStoreForH2Pool) Flows() []*flow.Flow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*flow.Flow, len(s.flows))
+	copy(out, s.flows)
+	return out
+}
+
+// releaseFirstHeldEntry waits up to timeout for the queue to receive a held
+// entry and then releases it with the given action. Returns the released
+// entry so the caller can mutate it for modify_and_forward.
+func releaseFirstHeldEntry(t *testing.T, q *common.HoldQueue, timeout time.Duration, build func(held *common.HeldEntry) *common.HoldAction) *common.HeldEntry {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if q.Len() > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	entries := q.List()
+	if len(entries) == 0 {
+		t.Fatal("no held entry observed within timeout")
+	}
+	held := entries[0]
+	if err := q.Release(held.ID, build(held)); err != nil {
+		t.Fatalf("HoldQueue.Release: %v", err)
+	}
+	return held
+}

--- a/internal/proxybuild/h2_pool_helpers_test.go
+++ b/internal/proxybuild/h2_pool_helpers_test.go
@@ -286,7 +286,10 @@ func (s *flowStoreForH2Pool) Streams() []*flow.Stream {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]*flow.Stream, len(s.streams))
-	copy(out, s.streams)
+	for i, st := range s.streams {
+		cp := *st
+		out[i] = &cp
+	}
 	return out
 }
 
@@ -294,7 +297,10 @@ func (s *flowStoreForH2Pool) Flows() []*flow.Flow {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]*flow.Flow, len(s.flows))
-	copy(out, s.flows)
+	for i, f := range s.flows {
+		cp := *f
+		out[i] = &cp
+	}
 	return out
 }
 

--- a/internal/proxybuild/h2_pool_intercept_integration_test.go
+++ b/internal/proxybuild/h2_pool_intercept_integration_test.go
@@ -15,7 +15,6 @@
 package proxybuild_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -23,311 +22,29 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
 	"io"
-	"log/slog"
 	"math/big"
 	"net"
 	gohttp "net/http"
-	"os"
 	"regexp"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"golang.org/x/net/http2"
 
-	"github.com/usk6666/yorishiro-proxy/internal/cert"
-	"github.com/usk6666/yorishiro-proxy/internal/config"
-	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	h2pool "github.com/usk6666/yorishiro-proxy/internal/layer/http2/pool"
-	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
 	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
 	httprules "github.com/usk6666/yorishiro-proxy/internal/rules/http"
-	"github.com/usk6666/yorishiro-proxy/internal/testutil"
 )
 
-// startH2TLSUpstreamForPoolTest spins up a TLS upstream that serves HTTP/2 via
-// golang.org/x/net/http2.Server. Returns the listener addr, an accept counter
-// (used to verify pool reuse), and a shutdown closure. Modeled on the
-// internal/layer/http2 helper but local to this package so the proxybuild
-// import surface stays clean.
-func startH2TLSUpstreamForPoolTest(t *testing.T, cn string, handler gohttp.Handler) (addr string, acceptCount func() int64, shutdown func()) {
-	t.Helper()
-
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: cn},
-		NotBefore:             time.Now().Add(-time.Minute),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:              []string{cn, "localhost"},
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{{
-			Certificate: [][]byte{certDER},
-			PrivateKey:  key,
-		}},
-		NextProtos: []string{"h2"},
-	}
-
-	tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var accepts atomic.Int64
-	h2s := &http2.Server{}
-
-	var wg sync.WaitGroup
-	go func() {
-		for {
-			c, aerr := tcpLn.Accept()
-			if aerr != nil {
-				return
-			}
-			accepts.Add(1)
-			tlsConn := tls.Server(c, tlsCfg)
-			wg.Add(1)
-			go func(tc *tls.Conn) {
-				defer wg.Done()
-				defer tc.Close()
-				if herr := tc.Handshake(); herr != nil {
-					return
-				}
-				h2s.ServeConn(tc, &http2.ServeConnOpts{Handler: handler})
-			}(tlsConn)
-		}
-	}()
-
-	return tcpLn.Addr().String(), func() int64 { return accepts.Load() }, func() {
-		_ = tcpLn.Close()
-		doneCh := make(chan struct{})
-		go func() { wg.Wait(); close(doneCh) }()
-		select {
-		case <-doneCh:
-		case <-time.After(2 * time.Second):
-		}
-	}
-}
-
-// connectTunnelDialerForPoolTest opens a CONNECT tunnel to proxyAddr for the
-// given target. Mirrors the http2_integration_test helper.
-func connectTunnelDialerForPoolTest(proxyAddr, target string) (net.Conn, error) {
-	c, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
-	if _, werr := c.Write([]byte(req)); werr != nil {
-		c.Close()
-		return nil, werr
-	}
-	br := bytes.NewBuffer(nil)
-	buf := make([]byte, 1)
-	for {
-		n, rerr := c.Read(buf)
-		if rerr != nil {
-			c.Close()
-			return nil, rerr
-		}
-		if n == 0 {
-			continue
-		}
-		br.Write(buf[:n])
-		text := br.String()
-		if (len(text) >= 4 && text[len(text)-4:] == "\r\n\r\n") || (len(text) >= 2 && text[len(text)-2:] == "\n\n") {
-			break
-		}
-		if br.Len() > 4096 {
-			c.Close()
-			return nil, fmt.Errorf("CONNECT response too large")
-		}
-	}
-	if !bytes.Contains(br.Bytes(), []byte(" 200")) {
-		c.Close()
-		return nil, fmt.Errorf("CONNECT failed: %s", br.String())
-	}
-	return c, nil
-}
-
-// newH2ClientThroughProxyForPoolTest wires an http.Client that funnels every
-// request through proxyAddr using CONNECT + TLS h2.
-func newH2ClientThroughProxyForPoolTest(proxyAddr, target string) *gohttp.Client {
-	tr := &http2.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // test
-			NextProtos:         []string{"h2"},
-		},
-		DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-			raw, err := connectTunnelDialerForPoolTest(proxyAddr, target)
-			if err != nil {
-				return nil, err
-			}
-			tlsConn := tls.Client(raw, cfg)
-			if err := tlsConn.Handshake(); err != nil {
-				raw.Close()
-				return nil, err
-			}
-			return tlsConn, nil
-		},
-	}
-	return &gohttp.Client{Transport: tr, Timeout: 30 * time.Second}
-}
-
-// startProxyForH2PoolInterceptTest builds a live Stack via BuildLiveStack and
-// starts its listener. The stack is wired with a non-nil HTTP2Pool to mirror
-// production wiring (mcpserver/init.go:467).
-func startProxyForH2PoolInterceptTest(
-	t *testing.T,
-	ctx context.Context,
-	store flow.Writer,
-	intercept *httprules.InterceptEngine,
-	holdQueue *common.HoldQueue,
-	pool *h2pool.Pool,
-) (proxyAddr string) {
-	t.Helper()
-
-	ca := &cert.CA{}
-	if err := ca.Generate(); err != nil {
-		t.Fatalf("CA.Generate: %v", err)
-	}
-
-	logger := testutil.DiscardLogger()
-	if testing.Verbose() && os.Getenv("USK816_DEBUG") != "" {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	}
-
-	deps := proxybuild.Deps{
-		Logger:       logger,
-		ListenerName: "usk-816-test",
-		ListenAddr:   "127.0.0.1:0",
-		FlowStore:    store,
-		BuildConfig: &connector.BuildConfig{
-			ProxyConfig:        &config.ProxyConfig{},
-			Issuer:             cert.NewIssuer(ca),
-			InsecureSkipVerify: true,
-			HTTP2Pool:          pool,
-		},
-		HTTPInterceptEngine: intercept,
-		HoldQueue:           holdQueue,
-	}
-
-	stack, err := proxybuild.BuildLiveStack(ctx, deps)
-	if err != nil {
-		t.Fatalf("BuildLiveStack: %v", err)
-	}
-	go func() { _ = stack.Listener.Start(ctx) }()
-
-	select {
-	case <-stack.Listener.Ready():
-	case <-time.After(5 * time.Second):
-		t.Fatal("listener not ready in 5s")
-	}
-	addr := stack.Listener.Addr()
-	if addr == "" {
-		t.Fatal("listener has no addr")
-	}
-	return addr
-}
-
-// flowStoreForH2Pool is a flow.Writer that records every Stream/Flow under a
-// mutex so test goroutines can inspect them safely.
-type flowStoreForH2Pool struct {
-	mu      sync.Mutex
-	streams []*flow.Stream
-	updates map[string][]flow.StreamUpdate
-	flows   []*flow.Flow
-}
-
-func (s *flowStoreForH2Pool) SaveStream(_ context.Context, st *flow.Stream) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *st
-	s.streams = append(s.streams, &cp)
-	return nil
-}
-
-func (s *flowStoreForH2Pool) UpdateStream(_ context.Context, id string, upd flow.StreamUpdate) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.updates == nil {
-		s.updates = make(map[string][]flow.StreamUpdate)
-	}
-	s.updates[id] = append(s.updates[id], upd)
-	for _, st := range s.streams {
-		if st.ID == id {
-			if upd.State != "" {
-				st.State = upd.State
-			}
-			if upd.FailureReason != "" {
-				st.FailureReason = upd.FailureReason
-			}
-		}
-	}
-	return nil
-}
-
-func (s *flowStoreForH2Pool) SaveFlow(_ context.Context, f *flow.Flow) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *f
-	s.flows = append(s.flows, &cp)
-	return nil
-}
-
-func (s *flowStoreForH2Pool) Streams() []*flow.Stream {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]*flow.Stream, len(s.streams))
-	copy(out, s.streams)
-	return out
-}
-
-func (s *flowStoreForH2Pool) Flows() []*flow.Flow {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]*flow.Flow, len(s.flows))
-	copy(out, s.flows)
-	return out
-}
-
-// releaseFirstHeldEntry waits up to timeout for the queue to receive a held
-// entry and then releases it with the given action. Returns the released
-// entry's stored envelope so the caller can mutate it for modify_and_forward.
-func releaseFirstHeldEntry(t *testing.T, q *common.HoldQueue, timeout time.Duration, build func(held *common.HeldEntry) *common.HoldAction) *common.HeldEntry {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if q.Len() > 0 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	entries := q.List()
-	if len(entries) == 0 {
-		t.Fatal("no held entry observed within timeout")
-	}
-	held := entries[0]
-	if err := q.Release(held.ID, build(held)); err != nil {
-		t.Fatalf("HoldQueue.Release: %v", err)
-	}
-	return held
-}
+// Shared helpers — startH2TLSUpstreamForPoolTest, connectTunnelDialerForPoolTest,
+// newH2ClientThroughProxyForPoolTest, startProxyForH2PoolInterceptTest,
+// flowStoreForH2Pool, releaseFirstHeldEntry — moved to h2_pool_helpers_test.go
+// (build tag //go:build e2e) so both this full-tier file and the USK-993
+// smoke-tier file (h2_openstream_retry_integration_test.go) share them.
 
 // TestUSK816_H2Pool_InterceptRelease_ResponseRelays is the headline regression
 // test. It exercises the production assembly (BuildLiveStack + non-nil

--- a/internal/proxybuild/h2_redial_test.go
+++ b/internal/proxybuild/h2_redial_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
 )
 
@@ -507,3 +509,371 @@ func TestRedialChain_CloseAllClosesEveryStep(t *testing.T) {
 	// re-entry; closeAll must not panic).
 	chain.closeAll()
 }
+
+// USK-993 — auto-redial-and-retry on `Refused: layer shutdown` at OpenStream.
+//
+// The N-chain redial (USK-991) closes the chain.mu serialisation gap, but a
+// residual race remains: selectUpstreamForDial returns Layer L (healthy at
+// the time of staleness check) and the caller's OpenStream syscall sees L
+// shut down before the channel is constructed. OpenStream returns
+// *layer.StreamError{Code: ErrorRefused, Reason: <one of three pre-HEADERS
+// races>} and the request would previously die with state=error even
+// though zero wire bytes were sent. USK-993 wraps the dial closure with a
+// one-shot retry that re-runs selectUpstreamForDial (which now observes
+// the stale Layer and fresh-dials under chain.mu single-flight).
+
+// TestOpenUpstreamStreamWithRetry_RefusedTriggersRetry pins the core
+// USK-993 invariant: attempt 1 returns ErrorRefused → exactly one redial
+// is requested → attempt 2 succeeds → the caller receives the fresh
+// Layer's Channel. Table-driven across the three Refused reasons.
+func TestOpenUpstreamStreamWithRetry_RefusedTriggersRetry(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+	}{
+		{"layer_shutdown", "layer shutdown"},
+		{"goaway_sent", "GOAWAY sent"},
+		{"goaway_received", "GOAWAY received"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pooled, pooledPeer := dialPeerH2Layer(t)
+			defer pooled.Close()
+			defer pooledPeer.Close()
+
+			fresh, freshPeer := dialPeerH2Layer(t)
+			defer fresh.Close()
+			defer freshPeer.Close()
+
+			// Drive pooled into stale so the *second* selectUpstreamForDial
+			// call inside the helper fresh-dials. The first call returns the
+			// pooled Layer (the helper does not drive shutdown between the
+			// two selectUpstreamForDial calls — the stub openStream is what
+			// surfaces the Refused, mimicking the residual race).
+			_ = pooledPeer.Close()
+			awaitShutdown(t, pooled)
+
+			var redialCalls int32
+			redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+				atomic.AddInt32(&redialCalls, 1)
+				return fresh, nil
+			}
+
+			stubChan := stubChannel{streamID: 7}
+			var openCalls int32
+			openFn := func(_ context.Context, l *http2.Layer) (layer.Channel, error) {
+				n := atomic.AddInt32(&openCalls, 1)
+				if n == 1 {
+					return nil, &layer.StreamError{
+						Code:   layer.ErrorRefused,
+						Reason: tc.reason,
+					}
+				}
+				if l != fresh {
+					t.Errorf("attempt %d: openStream got %p, want fresh %p", n, l, fresh)
+				}
+				return stubChan, nil
+			}
+
+			chain := newRedialChain()
+			gotL, gotCh, err := openUpstreamStreamWithRetryFn(
+				context.Background(), "example.test:443",
+				pooled, chain, redialFn, openFn, silentLogger(),
+			)
+			if err != nil {
+				t.Fatalf("openUpstreamStreamWithRetryFn: %v", err)
+			}
+			if gotL != fresh {
+				t.Errorf("returned Layer = %p, want fresh %p", gotL, fresh)
+			}
+			if gotCh != stubChan {
+				t.Errorf("returned Channel = %#v, want stub", gotCh)
+			}
+			if n := atomic.LoadInt32(&openCalls); n != 2 {
+				t.Errorf("openStream called %d times, want exactly 2 (attempt + 1 retry)", n)
+			}
+			if n := atomic.LoadInt32(&redialCalls); n != 1 {
+				t.Errorf("redialFn called %d times, want exactly 1", n)
+			}
+		})
+	}
+}
+
+// TestOpenUpstreamStreamWithRetry_BudgetExactlyOne pins that a second
+// Refused does NOT trigger a third attempt — the budget is exactly 1
+// retry per dial closure invocation. The 2nd Refused error is returned
+// verbatim so session.ClassifyError preserves the taxonomy
+// (state=error / failure_reason=refused).
+func TestOpenUpstreamStreamWithRetry_BudgetExactlyOne(t *testing.T) {
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return fresh, nil
+	}
+
+	wantReason := "GOAWAY received"
+	var openCalls int32
+	openFn := func(_ context.Context, _ *http2.Layer) (layer.Channel, error) {
+		atomic.AddInt32(&openCalls, 1)
+		return nil, &layer.StreamError{Code: layer.ErrorRefused, Reason: wantReason}
+	}
+
+	chain := newRedialChain()
+	_, _, err := openUpstreamStreamWithRetryFn(
+		context.Background(), "example.test:443",
+		pooled, chain, redialFn, openFn, silentLogger(),
+	)
+	if err == nil {
+		t.Fatal("openUpstreamStreamWithRetryFn returned nil error, want second-attempt Refused")
+	}
+	var se *layer.StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("returned error is not *layer.StreamError: %T %v", err, err)
+	}
+	if se.Code != layer.ErrorRefused {
+		t.Errorf("se.Code = %v, want ErrorRefused", se.Code)
+	}
+	if se.Reason != wantReason {
+		t.Errorf("se.Reason = %q, want %q (verbatim second-attempt error)", se.Reason, wantReason)
+	}
+	if n := atomic.LoadInt32(&openCalls); n != 2 {
+		t.Errorf("openStream called %d times, want exactly 2 (attempt + 1 retry, budget cap)", n)
+	}
+}
+
+// TestOpenUpstreamStreamWithRetry_NonRefusedPassesThrough confirms that
+// errors other than ErrorRefused are NOT retried — they pass through
+// verbatim. Retry-safety reasoning depends on the pre-HEADERS guarantee
+// of the three Refused emission sites; other errors (e.g. ErrorInternal,
+// ErrorAborted, context cancellation) may have written wire bytes and
+// must not be retried.
+func TestOpenUpstreamStreamWithRetry_NonRefusedPassesThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"internal_error", &layer.StreamError{Code: layer.ErrorInternalError, Reason: "boom"}},
+		{"aborted", &layer.StreamError{Code: layer.ErrorAborted, Reason: "peer rst"}},
+		{"protocol_error", &layer.StreamError{Code: layer.ErrorProtocol, Reason: "malformed"}},
+		{"context_canceled", context.Canceled},
+		{"plain_error", errors.New("dial: network unreachable")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pooled, peer := dialPeerH2Layer(t)
+			defer pooled.Close()
+			defer peer.Close()
+
+			redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+				t.Error("redialFn must not be called for non-Refused error")
+				return nil, errors.New("unexpected redial")
+			}
+
+			var openCalls int32
+			openFn := func(_ context.Context, _ *http2.Layer) (layer.Channel, error) {
+				atomic.AddInt32(&openCalls, 1)
+				return nil, tc.err
+			}
+
+			chain := newRedialChain()
+			_, _, err := openUpstreamStreamWithRetryFn(
+				context.Background(), "example.test:443",
+				pooled, chain, redialFn, openFn, silentLogger(),
+			)
+			if !errors.Is(err, tc.err) && err != tc.err { //nolint:errorlint
+				// errors.Is matches *StreamError by Code (see Is()); plain errors
+				// are reference-equal. Both paths above cover the comparison.
+				if !sameErr(err, tc.err) {
+					t.Errorf("got err = %v, want %v (verbatim)", err, tc.err)
+				}
+			}
+			if n := atomic.LoadInt32(&openCalls); n != 1 {
+				t.Errorf("openStream called %d times, want exactly 1 (no retry on non-Refused)", n)
+			}
+		})
+	}
+}
+
+// TestOpenUpstreamStreamWithRetry_FirstAttemptSucceedsNoRetry pins the
+// happy path: when attempt 1 succeeds, no retry is attempted and no
+// redial is triggered.
+func TestOpenUpstreamStreamWithRetry_FirstAttemptSucceedsNoRetry(t *testing.T) {
+	pooled, peer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer peer.Close()
+
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		t.Error("redialFn must not be called on happy path")
+		return nil, errors.New("unexpected redial")
+	}
+
+	stubChan := stubChannel{streamID: 3}
+	var openCalls int32
+	openFn := func(_ context.Context, l *http2.Layer) (layer.Channel, error) {
+		atomic.AddInt32(&openCalls, 1)
+		if l != pooled {
+			t.Errorf("openStream got %p, want pooled %p", l, pooled)
+		}
+		return stubChan, nil
+	}
+
+	chain := newRedialChain()
+	gotL, gotCh, err := openUpstreamStreamWithRetryFn(
+		context.Background(), "example.test:443",
+		pooled, chain, redialFn, openFn, silentLogger(),
+	)
+	if err != nil {
+		t.Fatalf("openUpstreamStreamWithRetryFn: %v", err)
+	}
+	if gotL != pooled {
+		t.Errorf("returned Layer = %p, want pooled %p", gotL, pooled)
+	}
+	if gotCh != stubChan {
+		t.Errorf("returned Channel = %#v, want stub", gotCh)
+	}
+	if n := atomic.LoadInt32(&openCalls); n != 1 {
+		t.Errorf("openStream called %d times, want exactly 1 (no retry on success)", n)
+	}
+}
+
+// TestOpenUpstreamStreamWithRetry_ConcurrentRefusedSingleFlightRedial
+// pins that N concurrent streams hitting the residual race converge on a
+// single fresh dial via chain.mu (USK-993 layered on USK-991's single-
+// flight). Each goroutine sees Refused on attempt 1 and must observe the
+// same fresh Layer on attempt 2; the redialFn must fire exactly once.
+func TestOpenUpstreamStreamWithRetry_ConcurrentRefusedSingleFlightRedial(t *testing.T) {
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+
+	// Drive pooled stale so the second selectUpstreamForDial call inside
+	// each helper invocation observes staleness and converges on
+	// chain.mu.
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	var redialCalls int32
+	gate := make(chan struct{})
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		<-gate
+		atomic.AddInt32(&redialCalls, 1)
+		return fresh, nil
+	}
+
+	openFn := func(_ context.Context, l *http2.Layer) (layer.Channel, error) {
+		if l == pooled {
+			// Stage the residual race: pooled was returned even though
+			// stale (selectUpstream's fast path may return it before the
+			// IsShutdown flip is observed in another goroutine on a real
+			// system; the stub forces the symptom).
+			return nil, &layer.StreamError{Code: layer.ErrorRefused, Reason: "layer shutdown"}
+		}
+		return stubChannel{streamID: 1}, nil
+	}
+
+	chain := newRedialChain()
+	const n = 8
+	results := make(chan *http2.Layer, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			gotL, _, err := openUpstreamStreamWithRetryFn(
+				context.Background(), "example.test:443",
+				pooled, chain, redialFn, openFn, silentLogger(),
+			)
+			if err != nil {
+				t.Errorf("openUpstreamStreamWithRetryFn: %v", err)
+				results <- nil
+				return
+			}
+			results <- gotL
+		}()
+	}
+
+	// Let goroutines converge on chain.mu, then release the dial.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+
+	for i := 0; i < n; i++ {
+		select {
+		case got := <-results:
+			if got != fresh {
+				t.Errorf("goroutine %d got %p, want fresh %p", i, got, fresh)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("goroutine %d did not return", i)
+		}
+	}
+	if got := atomic.LoadInt32(&redialCalls); got != 1 {
+		t.Errorf("redialFn fired %d times, want 1 (single-flight under chain.mu)", got)
+	}
+}
+
+// TestIsRefusedStreamError covers the classifier directly.
+func TestIsRefusedStreamError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"refused_layer_shutdown", &layer.StreamError{Code: layer.ErrorRefused, Reason: "layer shutdown"}, true},
+		{"refused_goaway_sent", &layer.StreamError{Code: layer.ErrorRefused, Reason: "GOAWAY sent"}, true},
+		{"refused_goaway_received", &layer.StreamError{Code: layer.ErrorRefused, Reason: "GOAWAY received"}, true},
+		{"refused_no_reason", &layer.StreamError{Code: layer.ErrorRefused}, true},
+		{"internal_error", &layer.StreamError{Code: layer.ErrorInternalError}, false},
+		{"aborted", &layer.StreamError{Code: layer.ErrorAborted}, false},
+		{"canceled", &layer.StreamError{Code: layer.ErrorCanceled}, false},
+		{"protocol_error", &layer.StreamError{Code: layer.ErrorProtocol}, false},
+		{"context_canceled", context.Canceled, false},
+		{"plain_error", errors.New("network unreachable"), false},
+		{"wrapped_refused", fmt.Errorf("dial: %w", &layer.StreamError{Code: layer.ErrorRefused, Reason: "layer shutdown"}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRefusedStreamError(tc.err); got != tc.want {
+				t.Errorf("isRefusedStreamError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// sameErr returns true if a and b refer to the same error value, handling
+// the *layer.StreamError comparison case (errors.Is matches by Code only,
+// so reference equality is required for "verbatim" assertions).
+func sameErr(a, b error) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Error() == b.Error()
+}
+
+// stubChannel implements layer.Channel for OpenStream return values in
+// the unit test. The retry helper only inspects the returned Channel by
+// passing it through to the caller, so the methods below are minimal
+// stubs that never fire on the test paths.
+type stubChannel struct {
+	streamID int
+}
+
+func (s stubChannel) StreamID() string                                   { return fmt.Sprintf("stub-%d", s.streamID) }
+func (s stubChannel) Next(_ context.Context) (*envelope.Envelope, error) { return nil, io.EOF }
+func (s stubChannel) Send(_ context.Context, _ *envelope.Envelope) error { return nil }
+func (s stubChannel) Close() error                                       { return nil }
+func (s stubChannel) Closed() <-chan struct{}                            { return nil }
+func (s stubChannel) Err() error                                         { return nil }


### PR DESCRIPTION
## Summary
- Add 1-retry budget in the proxybuild dial closure when `OpenStream` returns `*layer.StreamError{Code: ErrorRefused}` (any of the three pre-HEADERS Refused reasons: `layer shutdown`, `GOAWAY sent`, `GOAWAY received`).
- Retry trigger: second call to `selectUpstreamForDial`, which detects the stale Layer via existing `isStaleH2` and produces a fresh chain step via `chain.mu` single-flight (concurrent streams hitting the same residual race converge on one new upstream conn).
- Idempotency-safe even for POST: `OpenStream` returns Refused before any HEADERS/DATA bytes hit the wire (see `internal/layer/http2/layer.go:481-498`). No `stream_id` ever allocated by attempt 1.
- Classifier widened beyond Issue body's literal `"layer shutdown"` to **all three Refused reasons** by `Code == layer.ErrorRefused` — same retry-safety, browser-parity north-star, user-approved decision recorded in design review.

## Closes the residual race
USK-991 (PR #65) closed the N-chain GOAWAY → redial gap under `chain.mu` single-flight, but the window between `selectUpstreamForDial` returning healthy Layer L and the caller's `OpenStream(L)` call remained — if L flipped stale in that window, OpenStream returned Refused and the request died with `state=error / failure_reason=refused` even though zero wire bytes had been sent. USK-993 absorbs this transparently.

## Test plan
- [x] Unit test in `internal/proxybuild/h2_redial_test.go` — 5 new tests, table-driven across the 3 Refused reasons + 5 non-Refused error types + happy path + concurrent single-flight + isRefusedStreamError classifier.
- [x] Smoke-tier integration test (`//go:build e2e`) in `internal/proxybuild/h2_openstream_retry_integration_test.go` — POST + GET variants drive upstream shutdown during intercept hold, assert `state=complete` recording.
- [x] 2-consecutive-failure path returns the 2nd-attempt error verbatim (budget exactly 1).
- [x] Concurrent streams share single-flight redial via `chain.mu` (no double-dial).
- [x] `make build` / `make test` / `make lint` / `make test-e2e-smoke` green locally.

## Refactor note
Extracted shared test harness helpers from `h2_pool_intercept_integration_test.go` into a new `h2_pool_helpers_test.go` with `//go:build e2e` (no `!e2e_smoke` exclusion) so both the smoke-tier USK-993 file and the full-tier USK-816 file reuse the same `startH2TLSUpstreamForPoolTest`, `startProxyForH2PoolInterceptTest`, `flowStoreForH2Pool`, `releaseFirstHeldEntry`. No behavioural change to existing tests.

Resolves USK-993
Linear: https://linear.app/usk6666/issue/USK-993

🤖 Generated with [Claude Code](https://claude.com/claude-code)