### PR TITLE
fix(layer/http2,proxybuild): plumb GOAWAY observer through h2 pool for first-GOAWAY browser parity

### DIFF
--- a/internal/layer/http2/goaway_observer_test.go
+++ b/internal/layer/http2/goaway_observer_test.go
@@ -1,6 +1,7 @@
 package http2
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -128,6 +129,245 @@ func TestWithGoAwayObserver_DefaultNoOption(t *testing.T) {
 	}
 	if !l.GoAwayClosed() {
 		t.Fatal("GoAwayClosed() did not flip true within 2s")
+	}
+}
+
+// USK-994 — Layer.RegisterGoAwayObserver runtime API.
+//
+// The runtime registration mirrors WithGoAwayObserver's semantics with
+// three additions: (a) multiple observers can coexist on one Layer
+// (per-CONNECT registrations against a shared pooled Layer), (b) a
+// late registration after GOAWAY has already fired runs cb
+// synchronously inside RegisterGoAwayObserver, (c) the returned cancel
+// func is mandatory for caller lifecycle hygiene because Layers
+// outlive any single registration in the pooled path.
+
+// TestRegisterGoAwayObserver_FiresEachRegistration covers the multi-
+// observer fan-out: N concurrent CONNECTs each register their own cb
+// against one Layer; the single peer GOAWAY fires every cb exactly
+// once.
+func TestRegisterGoAwayObserver_FiresEachRegistration(t *testing.T) {
+	l, peer, cleanup := startClientLayer(t)
+	defer cleanup()
+	peer.consumePeerSettings(t)
+
+	const N = 3
+	var fires [N]int32
+	for i := 0; i < N; i++ {
+		i := i
+		_ = l.RegisterGoAwayObserver(func() {
+			atomic.AddInt32(&fires[i], 1)
+		})
+	}
+
+	if err := peer.wr.WriteGoAway(0, ErrCodeNo, nil); err != nil {
+		t.Fatalf("write GOAWAY: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		all := true
+		for i := 0; i < N; i++ {
+			if atomic.LoadInt32(&fires[i]) == 0 {
+				all = false
+				break
+			}
+		}
+		if all {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	for i := 0; i < N; i++ {
+		if got := atomic.LoadInt32(&fires[i]); got != 1 {
+			t.Errorf("observer #%d fired %d times, want 1", i, got)
+		}
+	}
+}
+
+// TestRegisterGoAwayObserver_FiresImmediatelyIfGoAwayAlreadySeen
+// covers the race-close invariant: a CONNECT that registers AFTER the
+// pooled Layer has already observed GOAWAY (e.g. the pool handed out a
+// recently-evicted-but-still-in-flight Layer to a fresh CONNECT) fires
+// cb synchronously inside RegisterGoAwayObserver so the wake-up signal
+// is not lost.
+func TestRegisterGoAwayObserver_FiresImmediatelyIfGoAwayAlreadySeen(t *testing.T) {
+	l, peer, cleanup := startClientLayer(t)
+	defer cleanup()
+	peer.consumePeerSettings(t)
+
+	if err := peer.wr.WriteGoAway(0, ErrCodeNo, nil); err != nil {
+		t.Fatalf("write GOAWAY: %v", err)
+	}
+
+	// Wait until the reader has processed the GOAWAY frame (so goAwayHit
+	// flips true).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !l.GoAwayClosed() {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !l.GoAwayClosed() {
+		t.Fatal("GoAwayClosed did not flip true before late registration")
+	}
+
+	fired := make(chan struct{}, 1)
+	cancel := l.RegisterGoAwayObserver(func() {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+	})
+	defer cancel()
+
+	// cb must have fired synchronously inside RegisterGoAwayObserver.
+	select {
+	case <-fired:
+	default:
+		t.Fatal("RegisterGoAwayObserver did not fire cb synchronously after GoAwayClosed was already true")
+	}
+}
+
+// TestRegisterGoAwayObserver_CancelFuncRemovesFromList covers the
+// lifecycle hygiene path: a CONNECT that cancels its registration
+// before any GOAWAY arrives must NOT have its cb invoked when the
+// Layer eventually observes GOAWAY (the future CONNECT case the cancel
+// func protects against).
+func TestRegisterGoAwayObserver_CancelFuncRemovesFromList(t *testing.T) {
+	l, peer, cleanup := startClientLayer(t)
+	defer cleanup()
+	peer.consumePeerSettings(t)
+
+	var fires int32
+	cancel := l.RegisterGoAwayObserver(func() {
+		atomic.AddInt32(&fires, 1)
+	})
+	cancel()
+
+	if err := peer.wr.WriteGoAway(0, ErrCodeNo, nil); err != nil {
+		t.Fatalf("write GOAWAY: %v", err)
+	}
+
+	// Wait for the reader to settle.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !l.GoAwayClosed() {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Give the readerLoop a moment past the handleGoAwayFrame snapshot.
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&fires); got != 0 {
+		t.Errorf("cancelled cb fired %d times, want 0", got)
+	}
+}
+
+// TestRegisterGoAwayObserver_CancelIsIdempotent covers the defensive
+// shape of the cancel contract: callers in defer-chains should be
+// able to call cancel more than once without panicking (mirrors
+// sync.Once-wrapped idempotent close in closeAll).
+func TestRegisterGoAwayObserver_CancelIsIdempotent(t *testing.T) {
+	l, _, cleanup := startClientLayer(t)
+	defer cleanup()
+
+	cancel := l.RegisterGoAwayObserver(func() {})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("double cancel panicked: %v", r)
+		}
+	}()
+	cancel()
+	cancel()
+}
+
+// TestRegisterGoAwayObserver_NilObserverIsSafe documents the no-op
+// behavior matching WithGoAwayObserver(nil) — callers can register
+// unconditionally.
+func TestRegisterGoAwayObserver_NilObserverIsSafe(t *testing.T) {
+	l, _, cleanup := startClientLayer(t)
+	defer cleanup()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("nil cb panicked: %v", r)
+		}
+	}()
+	cancel := l.RegisterGoAwayObserver(nil)
+	cancel() // safe to call cancel on nil-registration
+}
+
+// TestRegisterGoAwayObserver_BootstrapWithGoAwayObserverStillWorks
+// pins the backward-compat invariant: the legacy
+// WithGoAwayObserver(cb) construction-time path continues to fire cb
+// exactly once on GOAWAY. USK-994 routes the bootstrap through the
+// same RegisterGoAwayObserver machinery as runtime callers, so this
+// is an end-to-end check that the bootstrap shim is wired correctly.
+func TestRegisterGoAwayObserver_BootstrapWithGoAwayObserverStillWorks(t *testing.T) {
+	var fires int32
+	obs := func() {
+		atomic.AddInt32(&fires, 1)
+	}
+
+	_, peer, cleanup := startClientLayer(t, WithGoAwayObserver(obs))
+	defer cleanup()
+	peer.consumePeerSettings(t)
+
+	if err := peer.wr.WriteGoAway(0, ErrCodeNo, nil); err != nil {
+		t.Fatalf("write GOAWAY: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&fires) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&fires); got != 1 {
+		t.Errorf("bootstrap observer fired %d times, want 1", got)
+	}
+}
+
+// TestRegisterGoAwayObserver_NObserversFireConcurrentlySafe is the
+// -race-clean check: N concurrent register / cancel goroutines plus a
+// peer GOAWAY do not deadlock or panic under -race. Useful catch for
+// regressions in goAwayObsMu acquisition order.
+func TestRegisterGoAwayObserver_NObserversFireConcurrentlySafe(t *testing.T) {
+	l, peer, cleanup := startClientLayer(t)
+	defer cleanup()
+	peer.consumePeerSettings(t)
+
+	const N = 8
+	var fires int32
+	var wg sync.WaitGroup
+	startReg := make(chan struct{})
+
+	cancels := make([]func(), N)
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startReg
+			cancels[i] = l.RegisterGoAwayObserver(func() {
+				atomic.AddInt32(&fires, 1)
+			})
+		}()
+	}
+	close(startReg)
+	wg.Wait()
+
+	if err := peer.wr.WriteGoAway(0, ErrCodeNo, nil); err != nil {
+		t.Fatalf("write GOAWAY: %v", err)
+	}
+
+	// Each non-cancelled cb fires exactly once.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&fires) < N {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&fires); got != N {
+		t.Errorf("fan-out observer count = %d, want %d", got, N)
+	}
+
+	// Cancel all (post-fire) — must not panic.
+	for i := 0; i < N; i++ {
+		cancels[i]()
 	}
 }
 

--- a/internal/layer/http2/layer.go
+++ b/internal/layer/http2/layer.go
@@ -177,10 +177,18 @@ func WithStateReleaser(r pluginv2.StateReleaser) Option {
 // readerLoop hot path.
 //
 // nil cb is a no-op (the option may be passed unconditionally). The
-// callback is wrapped in sync.Once internally so a single Layer that
-// receives multiple GOAWAY frames (RFC 9113 §6.8 permits multiple
-// GOAWAYs with non-decreasing last_stream_id; a hostile peer can also
-// burst them) still fires cb exactly once.
+// callback fires at most once per Layer regardless of how many GOAWAY
+// frames the peer sends (RFC 9113 §6.8 permits multiple GOAWAYs with
+// non-decreasing last_stream_id; a hostile peer can also burst them):
+// the bootstrap registration installed by this Option is wrapped in
+// the same per-registration sync.Once as any caller of
+// RegisterGoAwayObserver.
+//
+// USK-994: WithGoAwayObserver is the construction-time bootstrap over
+// the runtime-attachable mechanism. Use RegisterGoAwayObserver when you
+// need to attach an observer to an already-constructed Layer (e.g. a
+// pooled Layer handed out by connector/h2_pool to a CONNECT that wants
+// to participate in proactive pre-warm).
 func WithGoAwayObserver(cb func()) Option {
 	return func(o *options) { o.goAwayObserver = cb }
 }
@@ -237,12 +245,28 @@ type Layer struct {
 	shutdown     chan struct{}
 	shutdownOnce sync.Once
 
-	// goAwayObserverOnce guards the observer registered via
-	// WithGoAwayObserver so it fires at most once per Layer even when the
-	// peer sends multiple GOAWAY frames (RFC 9113 §6.8 permits non-
-	// decreasing last_stream_id over multiple GOAWAYs; a hostile peer can
-	// also burst them). Wraps the call site in handleGoAwayFrame.
-	goAwayObserverOnce sync.Once
+	// goAwayObsMu protects goAwayObs and goAwayHit. Held only briefly:
+	//   - registration / cancellation: append / O(N) pointer-identity scan
+	//     over a list whose typical length is 1-4 (one per CONNECT sharing
+	//     the pooled Layer up to MaxStreamsPerConn).
+	//   - handleGoAwayFrame: snapshot the slice and set goAwayHit, drop the
+	//     lock, then fire each entry's per-registration sync.Once outside
+	//     the lock so a misbehaved observer cannot stall the readerLoop's
+	//     mutex.
+	//
+	// Each registration carries its own sync.Once (goAwayObsEntry.once) so
+	// concurrent CONNECTs sharing one pooled Layer each get exactly one
+	// observer fire per (Layer, registration) tuple — whether they
+	// registered before the first GOAWAY arrived (normal path) or after
+	// (fires synchronously inside RegisterGoAwayObserver).
+	//
+	// USK-994: see RegisterGoAwayObserver for the runtime-attachable API.
+	// WithGoAwayObserver remains the construction-time bootstrap; it
+	// installs itself via the same mechanism inside New so the two paths
+	// share one observer list.
+	goAwayObsMu sync.Mutex
+	goAwayObs   []*goAwayObsEntry
+	goAwayHit   bool
 
 	windowUpdated chan struct{}
 
@@ -304,6 +328,97 @@ func (l *Layer) GoAwayClosed() bool {
 		return true
 	}
 	return false
+}
+
+// goAwayObsEntry is one registration with the per-registration sync.Once
+// that gates the observer call. removed is set under goAwayObsMu when
+// the registration's cancel func runs so an in-flight handleGoAwayFrame
+// snapshot does not re-fire a cancelled entry (the snapshot still holds
+// a *goAwayObsEntry pointer, but checking entry.removed under once.Do is
+// not feasible — once already gates the second call. cancel atomically
+// removes the entry from the live slice so subsequent GOAWAYs and
+// re-registrations cannot reach it).
+type goAwayObsEntry struct {
+	cb   func()
+	once sync.Once
+}
+
+// RegisterGoAwayObserver attaches cb to fire exactly once when the Layer
+// observes a peer GOAWAY frame. Returns a cancel func the caller MUST
+// invoke at lifecycle end (e.g. CONNECT exit) to remove cb from the
+// Layer's observer list — Layers outlive any single CONNECT (they are
+// pooled), so leaving cb registered would (a) leak the per-CONNECT
+// closure capture across CONNECTs (memory) and (b) cause a GOAWAY in a
+// future CONNECT to tickle the dead CONNECT's wake channel
+// (correctness).
+//
+// If the Layer has ALREADY observed GOAWAY at registration time
+// (GoAwayClosed() reads true), cb fires synchronously before
+// RegisterGoAwayObserver returns. This closes the race between
+// Pool.Get returning a Layer that observed GOAWAY between the previous
+// CONNECT's release and this CONNECT's Get, and the caller installing
+// the observer.
+//
+// Each cb is independently wrapped in sync.Once so different CONNECTs
+// sharing the same pooled Layer each receive exactly one observer fire
+// per (Layer, registration) tuple — regardless of whether they
+// registered before or after the first GOAWAY arrived.
+//
+// Contract — non-blocking callback: inherits the WithGoAwayObserver
+// rules verbatim (see godoc on WithGoAwayObserver). The callback runs
+// on the readerLoop goroutine when a peer GOAWAY arrives during the
+// registration's lifetime, or synchronously on the caller's goroutine
+// when GOAWAY was observed before registration.
+//
+// nil cb is a no-op; the returned cancel func is also a no-op (safe to
+// defer unconditionally).
+//
+// The returned cancel func is idempotent — calling it more than once is
+// safe.
+//
+// USK-994: introduced to plumb proactive pre-warm wake signalling
+// through the pool-constructed chain[0] Layer in
+// internal/proxybuild/builder.go::buildOnHTTP2Stack.
+func (l *Layer) RegisterGoAwayObserver(cb func()) (cancel func()) {
+	if cb == nil {
+		return func() {}
+	}
+	entry := &goAwayObsEntry{cb: cb}
+
+	l.goAwayObsMu.Lock()
+	hit := l.goAwayHit
+	if !hit {
+		l.goAwayObs = append(l.goAwayObs, entry)
+	}
+	l.goAwayObsMu.Unlock()
+
+	if hit {
+		// GOAWAY already observed before this registration. Fire
+		// synchronously outside the lock so cb's contract (non-blocking)
+		// does not pin goAwayObsMu. Use the entry's own once so a
+		// pathological cancel + re-fire path stays single-fire.
+		entry.once.Do(cb)
+		// No live entry to remove; cancel is a no-op.
+		return func() {}
+	}
+
+	var cancelOnce sync.Once
+	return func() {
+		cancelOnce.Do(func() {
+			l.goAwayObsMu.Lock()
+			defer l.goAwayObsMu.Unlock()
+			// O(N) pointer-identity scan; N is typically 1-4.
+			for i, e := range l.goAwayObs {
+				if e == entry {
+					// Order-preserving removal — order does not matter
+					// for observer semantics, but keeps debug output
+					// stable.
+					l.goAwayObs = append(l.goAwayObs[:i], l.goAwayObs[i+1:]...)
+					return
+				}
+			}
+		})
+	}
 }
 
 // IsShutdown reports whether this Layer's shutdown channel has been closed.
@@ -465,6 +580,15 @@ func New(conn net.Conn, streamID string, role Role, opts ...Option) (*Layer, err
 	if err := l.runPreface(); err != nil {
 		_ = conn.Close()
 		return nil, err
+	}
+
+	// USK-994: install the WithGoAwayObserver bootstrap (if any) through
+	// the runtime-attachable mechanism so the single fire path is
+	// uniform with RegisterGoAwayObserver callers. The bootstrap
+	// observer lives for the Layer's lifetime, so we discard the cancel
+	// func — matches the pre-USK-994 single-slot semantics exactly.
+	if o.goAwayObserver != nil {
+		_ = l.RegisterGoAwayObserver(o.goAwayObserver)
 	}
 
 	go l.writerLoop()

--- a/internal/layer/http2/layer.go
+++ b/internal/layer/http2/layer.go
@@ -330,14 +330,23 @@ func (l *Layer) GoAwayClosed() bool {
 	return false
 }
 
-// goAwayObsEntry is one registration with the per-registration sync.Once
-// that gates the observer call. removed is set under goAwayObsMu when
-// the registration's cancel func runs so an in-flight handleGoAwayFrame
-// snapshot does not re-fire a cancelled entry (the snapshot still holds
-// a *goAwayObsEntry pointer, but checking entry.removed under once.Do is
-// not feasible — once already gates the second call. cancel atomically
-// removes the entry from the live slice so subsequent GOAWAYs and
-// re-registrations cannot reach it).
+// goAwayObsEntry is one registration with a per-registration sync.Once
+// that gates the observer call so each cb fires at most once per
+// (Layer, registration) tuple regardless of how many GOAWAY frames the
+// peer sends.
+//
+// Cancellation semantics: the registration's cancel func removes the
+// entry from l.goAwayObs under goAwayObsMu. An in-flight
+// handleGoAwayFrame snapshot taken before cancel may still hold a
+// *goAwayObsEntry pointer to a removed entry; if entry.once.Do has not
+// yet run on that pointer at the moment cancel completes, the cb still
+// fires once (the per-registration Once gates the call, not the live
+// slice membership). Subsequent GOAWAYs after cancel cannot re-fire
+// because the entry is no longer reachable from the live slice. The
+// pre-fire-versus-cancel race window is intrinsic to the snapshot-then-
+// fire-outside-the-lock design (chosen so a misbehaved cb cannot stall
+// the readerLoop's mutex) and is documented as acceptable: cb runs at
+// most one extra time beyond the cancel call.
 type goAwayObsEntry struct {
 	cb   func()
 	once sync.Once

--- a/internal/layer/http2/reader.go
+++ b/internal/layer/http2/reader.go
@@ -131,19 +131,33 @@ func (l *Layer) handleGoAwayFrame(f *frame.Frame) error {
 	}
 	slog.Warn("http2: peer sent GOAWAY", attrs...)
 
-	// USK-992: fire the optional WithGoAwayObserver callback exactly once
-	// before failStreamsAfterGoAway. Ordering matters: at this point
-	// l.conn has recorded GOAWAY-received, so GoAwayClosed() will read
-	// true for any subsequent IsStaleH2 check the observer's consumer
-	// performs. The observer is contracted to be non-blocking (godoc on
-	// WithGoAwayObserver) so this site does not stall the readerLoop.
-	// Wrapped in sync.Once via l.goAwayObserverOnce so multi-GOAWAY
-	// bursts (RFC 9113 §6.8) and any hostile-peer flood fire at most
-	// one observer call per Layer; downstream debouncing (e.g. the
-	// proxybuild pre-warm worker's cap=1 wake channel) is layered on
-	// top.
-	if l.opts.goAwayObserver != nil {
-		l.goAwayObserverOnce.Do(l.opts.goAwayObserver)
+	// USK-992 / USK-994: fire every registered GOAWAY observer exactly
+	// once before failStreamsAfterGoAway. Ordering matters: at this
+	// point l.conn has recorded GOAWAY-received, so GoAwayClosed() will
+	// read true for any subsequent IsStaleH2 check the observers'
+	// consumers perform.
+	//
+	// Observers are contracted to be non-blocking (godoc on
+	// WithGoAwayObserver / RegisterGoAwayObserver), but to defend
+	// against a misbehaved consumer we snapshot the list under
+	// goAwayObsMu and drop the lock BEFORE firing each cb. This both
+	// prevents the readerLoop's lock from being held across cb runtime
+	// and lets a cancel func called from another goroutine make
+	// progress concurrently with an in-flight cb.
+	//
+	// Per-registration sync.Once (entry.once) enforces single-fire per
+	// (Layer, registration) tuple — multi-GOAWAY bursts (RFC 9113 §6.8)
+	// and any hostile-peer flood fire each observer at most once;
+	// downstream debouncing (e.g. the proxybuild pre-warm worker's
+	// cap=1 wake channel) is layered on top.
+	l.goAwayObsMu.Lock()
+	l.goAwayHit = true
+	snapshot := make([]*goAwayObsEntry, len(l.goAwayObs))
+	copy(snapshot, l.goAwayObs)
+	l.goAwayObsMu.Unlock()
+	for _, entry := range snapshot {
+		e := entry
+		e.once.Do(e.cb)
 	}
 
 	// Notify all open streams with id > lastStreamID.

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -898,16 +898,18 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 		// draining under browser-equivalent semantics (RFC 9113 §6.8)
 		// and the chain has already moved on.
 		//
-		// Note: chain[0] (the pooled upstreamH2) is intentionally NOT
-		// wired with this observer. The pooled Layer is constructed in
-		// the connector pool's dialFn before buildOnHTTP2Stack runs and
-		// the chain therefore does not exist at that construction time.
-		// Adding a runtime setter to *http2.Layer to retroactively wire
-		// an observer was considered and rejected (design review Q15 —
-		// YAGNI, construction-only). The practical impact: the first
-		// GOAWAY in a CONNECT relies on the USK-991 reactive path; once
-		// any reactive redial has happened, every subsequent GOAWAY in
-		// the same CONNECT triggers proactive pre-warm.
+		// USK-994: chain[0] (the pooled upstreamH2) is wired with the
+		// observer via Layer.RegisterGoAwayObserver, the runtime-
+		// attachable counterpart of http2.WithGoAwayObserver. The pooled
+		// Layer is constructed in the connector pool's dialFn before
+		// buildOnHTTP2Stack runs, so the construction-time option cannot
+		// reach it (USK-992 design review Q15 deferred the runtime setter
+		// pending a concrete consumer; USK-994 is that consumer). See
+		// registerPooledChainHeadObserver for the head-comparison guard
+		// and cancel-lifecycle invariants.
+		unregisterPooledObserver := registerPooledChainHeadObserver(upstreamH2, chain)
+		defer unregisterPooledObserver()
+
 		redialFn := func(dctx context.Context, t string, stale *http2.Layer, generation int) (*http2.Layer, error) {
 			// firingLayerCell breaks the chicken-and-egg: the observer
 			// closure is passed to http2.New before the fresh Layer
@@ -1090,6 +1092,35 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 			}
 		}
 	}
+}
+
+// registerPooledChainHeadObserver attaches a GOAWAY observer onto the
+// pooled chain[0] Layer (the upstreamH2 *http2.Layer handed to
+// buildOnHTTP2Stack) so the first GOAWAY observed inside a CONNECT
+// also triggers the proactive pre-warm worker — closing the
+// chain[0]-only latency-distortion gap PR #67 (USK-992) explicitly
+// left open. See USK-994 for the design and the chain[1+] symmetry.
+//
+// The observer applies the head-comparison guard (design review Q5):
+// wake fires only while chain[0] is the current head. Once
+// selectUpstreamForDial or the pre-warm worker swaps chain.current to
+// chain[1+], subsequent GOAWAYs on chain[0] (RFC 9113 §6.8 multi-
+// GOAWAY permitted) are gated out — those streams are draining under
+// browser-equivalent semantics and the chain has moved on.
+//
+// The returned cancel func MUST run at CONNECT exit — the pooled Layer
+// outlives this CONNECT (it is returned to the pool by dispatchStack),
+// so leaving the registration in place would (a) leak the per-CONNECT
+// closure capture across CONNECTs and (b) cause a future CONNECT's
+// GOAWAY observation to tickle this CONNECT's already-stale wake
+// channel.
+func registerPooledChainHeadObserver(pooled *http2.Layer, chain *redialChain) (cancel func()) {
+	return pooled.RegisterGoAwayObserver(func() {
+		if chain.current.Load() != nil {
+			return
+		}
+		chain.tickleWake()
+	})
 }
 
 // redialFunc is the closure proxybuild hands to selectUpstreamForDial.

--- a/internal/proxybuild/h2_pool_observer_test.go
+++ b/internal/proxybuild/h2_pool_observer_test.go
@@ -1,0 +1,248 @@
+//go:build e2e
+
+// USK-994 smoke-tier integration coverage for the pool-constructed
+// chain[0] GOAWAY observer plumbing.
+//
+// The unit tests in h2_prewarm_test.go pin the layer-level invariants
+// deterministically (RegisterGoAwayObserver fires; head-comparison
+// guards drain-out chain steps). This file confirms the wiring runs
+// end-to-end through a real *pool.Pool.GetOrDial — a pool miss runs
+// dialFn (which constructs a Layer with NO observer, matching the
+// production connector pool's dialFn shape), and then a post-
+// construction RegisterGoAwayObserver attaches the wake-tickle closure.
+// A real GOAWAY frame from the peer triggers the readerLoop's
+// handleGoAwayFrame, which fires the observer, tickles wake, and the
+// pre-warm worker dials a fresh upstream before any subsequent
+// selectUpstreamForDial call.
+//
+// Why smoke tier (`//go:build e2e`, NOT `e2e && !e2e_smoke`): the
+// chain[0] first-GOAWAY browser-parity guarantee is part of the merge
+// gate. A regression that reverted to "first GOAWAY relies on reactive
+// redial" would land silently if this only ran nightly. See CLAUDE.md
+// "e2e test tiers" note and the design review's binding test plan.
+package proxybuild
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/pool"
+)
+
+// TestH2PoolObserver_PreWarmFiresOnPooledLayerGoAway is the canonical
+// smoke check: a Layer minted by pool.Pool.GetOrDial (no observer at
+// construction, as the connector pool does today) is wired with the
+// USK-994 observer post-construction, and a real GOAWAY on the peer
+// triggers the pre-warm worker before any second pool.Get call.
+//
+// Staging mirrors the production flow from buildOnHTTP2Stack:
+//  1. Construct a real pool.Pool.
+//  2. GetOrDial with a custom dialFn that mints a Layer + peer pair via
+//     net.Pipe and retains the peer end. The dialFn does NOT pass
+//     WithGoAwayObserver (matching production).
+//  3. Construct a redialChain + pre-warm worker.
+//  4. Register the observer on the pooled Layer via
+//     Layer.RegisterGoAwayObserver — the USK-994 production hook point.
+//  5. Inject GOAWAY on the retained peer end.
+//  6. Assert the worker dialed and chain.current swapped.
+func TestH2PoolObserver_PreWarmFiresOnPooledLayerGoAway(t *testing.T) {
+	// Build a real pool.
+	p := pool.New(pool.PoolOptions{})
+	defer p.Close()
+
+	// Pre-mint the fresh chain[1] Layer so the worker's dial returns
+	// deterministically.
+	freshLayer, freshPeer := dialPeerH2Layer(t)
+	defer freshLayer.Close()
+	defer freshPeer.Close()
+
+	// retained captures the peer end of the pooled Layer so the test
+	// can inject GOAWAY after Pool.GetOrDial returns.
+	var retainedPeer atomic.Pointer[net.Conn]
+
+	key := pool.PoolKey{HostPort: "example.test:443", TLSConfigHash: "test"}
+
+	// dialFn mints a *http2.Layer at the client end of a net.Pipe.
+	// Same shape as connector/h2_pool.go::makeDialFn (no observer).
+	dialFn := func() (*http2.Layer, error) {
+		cliConn, srvConn := net.Pipe()
+
+		// Read the client preface in a goroutine so http2.New can proceed.
+		go func() {
+			buf := make([]byte, len(http2.ClientPreface))
+			_, _ = io.ReadFull(srvConn, buf)
+		}()
+
+		l, err := http2.New(cliConn, "test-pool-peer", http2.ClientRole)
+		if err != nil {
+			_ = cliConn.Close()
+			_ = srvConn.Close()
+			return nil, err
+		}
+		retainedPeer.Store(&srvConn)
+		return l, nil
+	}
+
+	// Drive the pool to insert + return the pooled Layer.
+	ctx := context.Background()
+	pooled, err := p.GetOrDial(ctx, key, dialFn)
+	if err != nil {
+		t.Fatalf("Pool.GetOrDial: %v", err)
+	}
+	defer p.Put(key, pooled)
+
+	peer := retainedPeer.Load()
+	if peer == nil {
+		t.Fatal("dialFn did not retain peer end")
+	}
+	defer (*peer).Close()
+
+	// Construct the chain + worker shape buildOnHTTP2Stack produces.
+	chain := newRedialChain()
+
+	var dialCount int32
+	dialReady := make(chan struct{}, 1)
+	dialReleased := make(chan struct{})
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		atomic.AddInt32(&dialCount, 1)
+		select {
+		case dialReady <- struct{}{}:
+		default:
+		}
+		<-dialReleased
+		return freshLayer, nil
+	}
+
+	workerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain.startPrewarmWorker(workerCtx, key.HostPort, redialFn, nil, silentLogger())
+	defer chain.closeAll()
+
+	// USK-994 production wiring: attach the observer on the pooled
+	// Layer. This is the chain[0] case — chain.current is nil, so the
+	// head-comparison guard does NOT skip, and the observer tickles
+	// wake.
+	unregister := pooled.RegisterGoAwayObserver(func() {
+		if chain.current.Load() != nil {
+			return
+		}
+		chain.tickleWake()
+	})
+	defer unregister()
+
+	// Inject GOAWAY on the retained peer end. The pooled Layer's reader
+	// loop consumes it, runs handleGoAwayFrame, which fires the
+	// registered observer, which tickles wake, which the worker
+	// observes.
+	injectGoAwayFromPeer(t, *peer, 0, 0)
+	awaitGoAwayClosed(t, pooled)
+
+	// Worker enters dial.
+	select {
+	case <-dialReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not enter dial within 2s of injected pool-Layer GOAWAY")
+	}
+	close(dialReleased)
+
+	// chain.current should swap to freshLayer.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && chain.current.Load() != freshLayer {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if cur := chain.current.Load(); cur != freshLayer {
+		t.Fatalf("chain.current = %p, want freshLayer %p (pre-warm did not complete)", cur, freshLayer)
+	}
+	if got := atomic.LoadInt32(&dialCount); got != 1 {
+		t.Errorf("redialFn called %d times, want 1", got)
+	}
+}
+
+// TestH2PoolObserver_PoolHitFastPathAlsoWired covers the symmetry
+// between the buildOnHTTP2Stack first-CONNECT entry and the
+// buildPoolHitFastPath CONNECT entry: both paths receive a pool-
+// constructed Layer as upstreamH2, and both call into the same
+// buildOnHTTP2Stack body. The observer-registration site lives inside
+// buildOnHTTP2Stack, so the fast-path branch transparently receives
+// the same wiring — no separate code change required.
+//
+// This test verifies the property by registering observers on a pooled
+// Layer twice in succession (mirroring "second CONNECT to the same
+// host hits the fast path"). Both registrations must fire on GOAWAY,
+// confirming that the multi-observer support introduced by USK-994 is
+// exercised correctly across re-entry into the same Layer.
+func TestH2PoolObserver_PoolHitFastPathAlsoWired(t *testing.T) {
+	p := pool.New(pool.PoolOptions{})
+	defer p.Close()
+
+	var retainedPeer atomic.Pointer[net.Conn]
+	dialFn := func() (*http2.Layer, error) {
+		cliConn, srvConn := net.Pipe()
+		go func() {
+			buf := make([]byte, len(http2.ClientPreface))
+			_, _ = io.ReadFull(srvConn, buf)
+		}()
+		l, err := http2.New(cliConn, "test-pool-peer-fastpath", http2.ClientRole)
+		if err != nil {
+			_ = cliConn.Close()
+			_ = srvConn.Close()
+			return nil, err
+		}
+		retainedPeer.Store(&srvConn)
+		return l, nil
+	}
+
+	key := pool.PoolKey{HostPort: "example.test:443", TLSConfigHash: "fastpath"}
+	pooled, err := p.GetOrDial(context.Background(), key, dialFn)
+	if err != nil {
+		t.Fatalf("first GetOrDial: %v", err)
+	}
+
+	peer := retainedPeer.Load()
+	if peer == nil {
+		t.Fatal("dialFn did not retain peer end")
+	}
+	defer (*peer).Close()
+
+	// First CONNECT registers observer A.
+	var firesA int32
+	cancelA := pooled.RegisterGoAwayObserver(func() {
+		atomic.AddInt32(&firesA, 1)
+	})
+	defer cancelA()
+
+	// Simulate "second CONNECT hits fast path": the pool returns the
+	// same pooled Layer (no new dial). Register observer B on the same
+	// Layer pointer.
+	var firesB int32
+	cancelB := pooled.RegisterGoAwayObserver(func() {
+		atomic.AddInt32(&firesB, 1)
+	})
+	defer cancelB()
+
+	// Single GOAWAY frame must fire both observers exactly once.
+	injectGoAwayFromPeer(t, *peer, 0, 0)
+	awaitGoAwayClosed(t, pooled)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&firesA) == 1 && atomic.LoadInt32(&firesB) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&firesA); got != 1 {
+		t.Errorf("observer A fired %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&firesB); got != 1 {
+		t.Errorf("observer B fired %d times, want 1", got)
+	}
+
+	// Drop the pool reference so Close doesn't double-close the Layer.
+	p.Put(key, pooled)
+}

--- a/internal/proxybuild/h2_prewarm_test.go
+++ b/internal/proxybuild/h2_prewarm_test.go
@@ -774,6 +774,157 @@ func TestRedialChain_PrewarmAndReactiveCooperate(t *testing.T) {
 	}
 }
 
+// TestRedialChain_PrewarmFiresOnPooledChain0GoAway is the USK-994
+// invariant in test form: when the chain[0] Layer (i.e. the pool-
+// constructed Layer handed to buildOnHTTP2Stack as upstreamH2) observes
+// GOAWAY, the pre-warm worker dials a fresh upstream proactively. This
+// closes the latency-distortion gap PR #67 (USK-992) explicitly left
+// open: pre-USK-994, only chain[1+] observed GOAWAY via the
+// construction-time WithGoAwayObserver wired inside RedialUpstreamH2;
+// chain[0]'s first GOAWAY only triggered the reactive selectUpstream
+// path at the next user request, lumping the TCP+TLS handshake onto the
+// user-visible latency.
+//
+// Staging mirrors the production wiring in buildOnHTTP2Stack:
+//  1. Mint pooled (chain[0]) with NO observer — same as the connector
+//     pool's dialFn does today.
+//  2. Construct the chain, the redialFn, and the wake worker.
+//  3. Register the observer on pooled via Layer.RegisterGoAwayObserver
+//     (the production code path), with the head-comparison guard.
+//  4. Inject a real GOAWAY into pooled.
+//  5. Assert worker dials → chain.current swaps to fresh.
+func TestRedialChain_PrewarmFiresOnPooledChain0GoAway(t *testing.T) {
+	chain := newRedialChain()
+
+	// Pre-mint fresh up front so we don't race on assignment inside the
+	// worker goroutine.
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	var dialCount int32
+	dialReady := make(chan struct{}, 1)
+	dialReleased := make(chan struct{})
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		atomic.AddInt32(&dialCount, 1)
+		select {
+		case dialReady <- struct{}{}:
+		default:
+		}
+		<-dialReleased
+		return fresh, nil
+	}
+
+	// pooled is constructed without WithGoAwayObserver — same as the
+	// connector pool's dialFn shape pre-buildOnHTTP2Stack.
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+
+	// chain[0] is the pooled Layer in production. selectUpstreamForDial
+	// falls back to upstreamH2 when chain.current is nil; pre-USK-994
+	// the worker never saw chain[0]'s GOAWAY because it had no observer.
+	// We do NOT seed chain.layers or chain.current with pooled — that
+	// mirrors the production state at the start of buildOnHTTP2Stack
+	// (chain.current is nil; chain[0] is implicitly upstreamH2).
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain.startPrewarmWorker(ctx, "example.test:443", redialFn, nil, silentLogger())
+	defer chain.closeAll()
+
+	// USK-994 production wiring: attach the observer on the pooled Layer
+	// AFTER construction via the runtime-attachable RegisterGoAwayObserver.
+	// The closure mirrors the production head-comparison guard exactly.
+	unregister := pooled.RegisterGoAwayObserver(func() {
+		if chain.current.Load() != nil {
+			return // not the head (a reactive redial already swapped in)
+		}
+		chain.tickleWake()
+	})
+	defer unregister()
+
+	// Inject real GOAWAY → observer fires → wake tickled.
+	injectGoAwayFromPeer(t, pooledPeer, 0, 0)
+	awaitGoAwayClosed(t, pooled)
+
+	// Worker enters dial.
+	select {
+	case <-dialReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not enter dial within 2s of injected chain[0] GOAWAY")
+	}
+	close(dialReleased)
+
+	// Wait for the swap.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && chain.current.Load() != fresh {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cur := chain.current.Load()
+	if cur != fresh {
+		t.Fatalf("chain.current = %p, want fresh %p (worker did not swap)", cur, fresh)
+	}
+	if got := atomic.LoadInt32(&dialCount); got != 1 {
+		t.Errorf("redialFn called %d times, want 1", got)
+	}
+}
+
+// TestRedialChain_PrewarmPooledObserverGatedByHeadAfterSwap covers the
+// post-swap gating invariant for the USK-994 chain[0] observer: once
+// chain.current has been swapped to chain[1+] (e.g. by selectUpstream
+// or the pre-warm worker), subsequent GOAWAYs on the chain[0] pooled
+// Layer (RFC 9113 §6.8 multi-GOAWAY) must NOT trigger another
+// pre-warm dial — chain[0] is no longer the head; its streams are
+// draining out under browser-equivalent semantics.
+//
+// This mirrors TestRedialChain_ObserverGatesByCurrentHead but for the
+// chain[0] (pooled) observer closure produced by buildOnHTTP2Stack.
+func TestRedialChain_PrewarmPooledObserverGatedByHeadAfterSwap(t *testing.T) {
+	chain := newRedialChain()
+
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+	swapped, swappedPeer := dialPeerH2Layer(t)
+	defer swapped.Close()
+	defer swappedPeer.Close()
+
+	// Simulate a prior chain swap: chain.current points to a non-pooled
+	// (chain[1+]) Layer.
+	chain.layers = append(chain.layers, swapped)
+	chain.current.Store(swapped)
+
+	// Build the production observer closure for the pooled Layer.
+	var pooledObserverFires int32
+	unregister := pooled.RegisterGoAwayObserver(func() {
+		if chain.current.Load() != nil {
+			return
+		}
+		atomic.AddInt32(&pooledObserverFires, 1)
+		chain.tickleWake()
+	})
+	defer unregister()
+
+	// Inject GOAWAY into pooled. The observer fires but the head-comparison
+	// guard skips chain.tickleWake.
+	injectGoAwayFromPeer(t, pooledPeer, 0, 0)
+	awaitGoAwayClosed(t, pooled)
+
+	// wake must remain unbuffered.
+	select {
+	case <-chain.wake:
+		t.Error("pooled chain[0] GOAWAY tickled wake despite swapped layer being head")
+	case <-time.After(100 * time.Millisecond):
+		// expected: head-comparison guard tripped
+	}
+	// And the firing-counter is 0 (the gate returns before
+	// tickleWake increments the counter).
+	if got := atomic.LoadInt32(&pooledObserverFires); got != 0 {
+		t.Errorf("pooled observer fires past gate = %d, want 0", got)
+	}
+}
+
 // Compile-time sanity: confirm the test file compiles without unused
 // imports.
 var _ = sync.Once{}


### PR DESCRIPTION
## Summary

Closes the chain[0] (pooled Layer) first-GOAWAY browser-parity gap that PR #67 (USK-992) explicitly left open.

- New `Layer.RegisterGoAwayObserver(cb func()) (cancel func())` runtime-attachable extension on `*http2.Layer`
  - Multi-observer slice (1-4 typical, from CONNECTs sharing a pooled Layer)
  - Per-registration `sync.Once` (replaces the Layer-wide once for the multi-observer case)
  - Late registration after GOAWAY fires `cb` synchronously (closes the Pool.Get → register race)
  - Cancel func is required (Layer outlives any single CONNECT — pooled); idempotent
- `WithGoAwayObserver(cb)` preserved as construction-time bootstrap sugar (no API break)
- `buildOnHTTP2Stack` now attaches a per-CONNECT observer to the pooled chain[0] Layer via a small helper `registerPooledChainHeadObserver`
  - Head-comparison guard (`chain.current.Load() != nil` → no-op) keeps wake idempotent with chain[1+] observer
  - Deferred unregister at CONNECT exit (matches `defer chain.closeAll()` pattern)
- Inline chain[0]-hole comment removed from `buildOnHTTP2Stack`

## Design context

- USK-992 PR #67 design review Q15 YAGNI-rejected a runtime setter; USK-994 is the explicit consumer that justifies the reopen.
- Both proposed alternatives (Option A: `Pool.Get(opts)`, Option C: observer in dialFn signature) were rejected by the design review because they only let the FIRST CONNECT register an observer — subsequent CONNECTs sharing the same pooled Layer would silently get no observer. Option B (runtime setter) is forced by the per-host pool / per-CONNECT observer impedance mismatch.
- User-confirmed: (U1) defer-only unregister at CONNECT exit (simpler, head-comparison already gates redundant wakes), (U2) fire all N observers on shared pooled Layer GOAWAY (browser parity — per-chain wake cap=1 already debounces).
- Aligns with `feedback_mitm_browser_parity_north_star` and `feedback_shared_seam_hardcoded_flag` (per-CONNECT semantics live on Layer registration event, not on per-host Pool API).

## Test plan

- [x] `TestRegisterGoAwayObserver_FiresEachRegistration` — N observers each fire exactly once
- [x] `TestRegisterGoAwayObserver_FiresImmediatelyIfGoAwayAlreadySeen` — late registration fires synchronously
- [x] `TestRegisterGoAwayObserver_CancelFuncRemovesFromList` — cancelled cb does not fire
- [x] `TestRegisterGoAwayObserver_CancelIsIdempotent` — double-cancel safe
- [x] `TestRegisterGoAwayObserver_BootstrapWithGoAwayObserverStillWorks` — back-compat
- [x] `TestRegisterGoAwayObserver_NObserversFireConcurrentlySafe` — `-race` clean fan-out
- [x] `TestRegisterGoAwayObserver_NilObserverIsSafe` — nil cb / nil cancel safe
- [x] `TestRedialChain_PrewarmFiresOnPooledChain0GoAway` — proxybuild unit: pooled Layer GOAWAY → pre-warm fires
- [x] `TestRedialChain_PrewarmPooledObserverGatedByHeadAfterSwap` — head-comparison guard for chain[0] after swap
- [x] (smoke, `//go:build e2e`) `TestH2PoolObserver_PreWarmFiresOnPooledLayerGoAway` — `pool.GetOrDial`-constructed Layer GOAWAY → pre-warm fires
- [x] (smoke, `//go:build e2e`) `TestH2PoolObserver_PoolHitFastPathAlsoWired` — multi-register on shared pooled Layer fans out
- [x] USK-991 / USK-992 / USK-993 existing tests still pass
- [x] `make build` / `make test` / `make lint` / `make test-e2e-smoke` all green

Resolves USK-994
Linear: https://linear.app/usk6666/issue/USK-994

🤖 Generated with [Claude Code](https://claude.com/claude-code)