### PR TITLE
feat(connector): add parseClientHelloALPN extractor for sniff-first MITM

### DIFF
--- a/internal/connector/tls_clienthello.go
+++ b/internal/connector/tls_clienthello.go
@@ -33,6 +33,10 @@ const tlsExtensionServerName = 0x0000
 // server_name extension (RFC 6066 §3).
 const tlsServerNameTypeHostname = 0x00
 
+// tlsExtensionALPN is the ExtensionType value for the Application-Layer
+// Protocol Negotiation (ALPN) extension (RFC 7301 §3.1, IANA-assigned 16).
+const tlsExtensionALPN = 0x0010
+
 // parseClientHelloSNI extracts the SNI host_name value from a TLS
 // ClientHello carried at the start of buf. Returns an empty string with
 // nil error when the ClientHello does not include the SNI extension or
@@ -51,15 +55,53 @@ const tlsServerNameTypeHostname = 0x00
 // matches the L4-capable principle — the proxy must remain
 // passthrough-faithful even when the first record is junk.
 func parseClientHelloSNI(buf []byte) (string, error) {
-	hello, err := unwrapClientHelloBody(buf)
-	if err != nil {
-		return "", err
-	}
-	exts, err := skipToExtensions(hello)
+	exts, err := parseClientHelloExtensions(buf)
 	if err != nil {
 		return "", err
 	}
 	return findSNIInExtensions(exts)
+}
+
+// parseClientHelloALPN extracts the offered ALPN protocol name list from a
+// TLS ClientHello carried at the start of buf. Returns a nil slice with nil
+// error when the ClientHello does not include the ALPN extension or
+// includes it with an empty ProtocolNameList — both are legal per RFC 7301
+// §3.1 and must not cause the caller to abort the relay.
+//
+// The returned slice preserves the wire order of the client's preference
+// list so callers (e.g. sniff-first MITM upstream dial) can forward the
+// offered protocols unchanged.
+//
+// Returns errClientHelloIncomplete when buf truncates a length-prefixed
+// region; the caller should peek more bytes (up to the configured cap)
+// and retry. Returns errNotClientHello when the first byte is not a
+// Handshake record or the inner handshake type is not ClientHello — the
+// caller treats this as "no ALPN" and continues without retry.
+//
+// Other errors (legacy_version mismatch, malformed TLS record framing)
+// are surfaced verbatim for diagnostic logging but never fatal: the
+// caller's audit flow records ALPN=nil and relays the bytes anyway. This
+// matches the L4-capable principle — the proxy must remain
+// passthrough-faithful even when the first record is junk.
+func parseClientHelloALPN(buf []byte) ([]string, error) {
+	exts, err := parseClientHelloExtensions(buf)
+	if err != nil {
+		return nil, err
+	}
+	return findALPNInExtensions(exts)
+}
+
+// parseClientHelloExtensions is the shared prelude for the SNI and ALPN
+// entry points: it validates the TLS record + Handshake headers and
+// returns the extensions block slice. Both parseClientHelloSNI and
+// parseClientHelloALPN sit on top of this helper so the framing checks
+// stay in one place.
+func parseClientHelloExtensions(buf []byte) ([]byte, error) {
+	hello, err := unwrapClientHelloBody(buf)
+	if err != nil {
+		return nil, err
+	}
+	return skipToExtensions(hello)
 }
 
 // unwrapClientHelloBody validates the TLS record + Handshake headers and
@@ -229,4 +271,76 @@ func parseServerNameExtension(extData []byte) string {
 		}
 	}
 	return ""
+}
+
+// findALPNInExtensions scans an extensions block for the ALPN extension
+// and returns the offered ProtocolNameList in wire order. Returns a nil
+// slice + nil error when the ALPN extension is not present or when it
+// carries a zero-entry ProtocolNameList — both legal per RFC 7301 §3.1
+// (the spec does not forbid an empty list, only a zero-length name).
+//
+// The function is deliberately fail-soft: name entries with name_length
+// == 0 (which RFC 7301 forbids) are skipped rather than treated as a
+// hard error, matching the MITM principle of "do not crash on
+// attacker-controlled input". Truncation of the extension data or of an
+// entry's name bytes still returns errClientHelloIncomplete so the
+// caller knows to peek more bytes.
+func findALPNInExtensions(exts []byte) ([]string, error) {
+	for len(exts) >= 4 {
+		extType := int(exts[0])<<8 | int(exts[1])
+		extDataLen := int(exts[2])<<8 | int(exts[3])
+		exts = exts[4:]
+		if len(exts) < extDataLen {
+			return nil, errClientHelloIncomplete
+		}
+		extData := exts[:extDataLen]
+		exts = exts[extDataLen:]
+
+		if extType != tlsExtensionALPN {
+			continue
+		}
+		return parseALPNExtension(extData)
+	}
+	return nil, nil
+}
+
+// parseALPNExtension decodes the ProtocolNameList carried in the ALPN
+// extension data (RFC 7301 §3.1):
+//
+//	ProtocolNameList:
+//	  uint16 total_length          (covers the entries below)
+//	  ProtocolName entries:
+//	    uint8 name_length          (MUST be >= 1 per RFC)
+//	    opaque name[name_length]
+//
+// Returns a nil slice + nil error when the list is empty (zero entries).
+// Returns errClientHelloIncomplete when either the outer length prefix
+// or an individual entry's name bytes are truncated.
+func parseALPNExtension(extData []byte) ([]string, error) {
+	if len(extData) < 2 {
+		return nil, errClientHelloIncomplete
+	}
+	listLen := int(extData[0])<<8 | int(extData[1])
+	entries := extData[2:]
+	if len(entries) < listLen {
+		return nil, errClientHelloIncomplete
+	}
+	entries = entries[:listLen]
+	var offers []string
+	for len(entries) >= 1 {
+		nameLen := int(entries[0])
+		entries = entries[1:]
+		if len(entries) < nameLen {
+			return nil, errClientHelloIncomplete
+		}
+		name := entries[:nameLen]
+		entries = entries[nameLen:]
+		// RFC 7301 forbids zero-length names; skip rather than error
+		// to remain passthrough-faithful on malformed input.
+		if nameLen == 0 {
+			continue
+		}
+		offers = append(offers, string(name))
+	}
+	return offers, nil
 }

--- a/internal/connector/tls_clienthello_test.go
+++ b/internal/connector/tls_clienthello_test.go
@@ -16,6 +16,15 @@ import (
 // parseClientHelloSNI.
 func buildClientHello(t *testing.T, sni string) []byte {
 	t.Helper()
+	return buildClientHelloWithExts(t, sni, nil)
+}
+
+// buildClientHelloWithExts assembles a TLS ClientHello with optional SNI
+// host_name and optional ALPN protocol offer list. Either or both may be
+// supplied; passing "" for sni or nil/empty for alpnOffers omits that
+// extension entirely. The function returns the complete TLS record bytes.
+func buildClientHelloWithExts(t *testing.T, sni string, alpnOffers []string) []byte {
+	t.Helper()
 
 	// Random 32 bytes (legacy_random).
 	random := make([]byte, 32)
@@ -36,7 +45,7 @@ func buildClientHello(t *testing.T, sni string) []byte {
 	// legacy_compression_methods: null only (0x00), length 1
 	body = append(body, 0x01, 0x00)
 
-	// Extensions (only SNI when sni != ""):
+	// Extensions:
 	exts := []byte{}
 	if sni != "" {
 		// server_name extension data:
@@ -61,6 +70,9 @@ func buildClientHello(t *testing.T, sni string) []byte {
 		)
 		exts = append(exts, serverNameList...)
 	}
+	if alpnOffers != nil {
+		exts = append(exts, buildALPNExtension(t, alpnOffers)...)
+	}
 	// Extensions length prefix.
 	body = append(body,
 		byte(len(exts)>>8), byte(len(exts)),
@@ -81,6 +93,38 @@ func buildClientHello(t *testing.T, sni string) []byte {
 	)
 	record = append(record, handshake...)
 	return record
+}
+
+// buildALPNExtension returns the wire bytes for an ALPN extension carrying
+// the supplied ProtocolNameList. Layout follows RFC 7301 §3.1.
+//
+// Passing an empty (non-nil) offers slice produces a well-formed
+// extension with a zero-entry ProtocolNameList — legal per RFC 7301.
+func buildALPNExtension(t *testing.T, offers []string) []byte {
+	t.Helper()
+
+	// ProtocolNameList entries: each is uint8 length + name bytes.
+	var entries []byte
+	for _, name := range offers {
+		if len(name) > 0xff {
+			t.Fatalf("ALPN name %q too long for uint8 length prefix", name)
+		}
+		entries = append(entries, byte(len(name)))
+		entries = append(entries, []byte(name)...)
+	}
+	// ProtocolNameList: uint16 length + entries.
+	list := []byte{
+		byte(len(entries) >> 8), byte(len(entries)),
+	}
+	list = append(list, entries...)
+
+	// Extension header: type (2) + ext_data length (2) + ext_data.
+	ext := []byte{
+		byte(tlsExtensionALPN >> 8), byte(tlsExtensionALPN),
+		byte(len(list) >> 8), byte(len(list)),
+	}
+	ext = append(ext, list...)
+	return ext
 }
 
 func TestParseClientHelloSNI_PresentHostname(t *testing.T) {
@@ -165,4 +209,133 @@ func TestParseClientHelloSNI_TruncatedRecordBody(t *testing.T) {
 	if !errors.Is(err, errClientHelloIncomplete) {
 		t.Errorf("err = %v, want errClientHelloIncomplete", err)
 	}
+}
+
+func TestParseClientHelloALPN_OffersInWireOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		offers []string
+	}{
+		{name: "browser_shape_h2_http11", offers: []string{"h2", "http/1.1"}},
+		{name: "http11_only", offers: []string{"http/1.1"}},
+		{name: "h2_only_utls_repro", offers: []string{"h2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := buildClientHelloWithExts(t, "example.com", tc.offers)
+			got, err := parseClientHelloALPN(rec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !stringSlicesEqual(got, tc.offers) {
+				t.Errorf("ALPN offers = %v, want %v", got, tc.offers)
+			}
+		})
+	}
+}
+
+func TestParseClientHelloALPN_NoALPNExtension(t *testing.T) {
+	// SNI present, no ALPN extension at all.
+	rec := buildClientHello(t, "example.com")
+	got, err := parseClientHelloALPN(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ALPN offers = %v, want nil", got)
+	}
+}
+
+func TestParseClientHelloALPN_EmptyProtocolNameList(t *testing.T) {
+	// ALPN extension present but ProtocolNameList carries zero entries.
+	// Legal per RFC 7301 §3.1 — fail-soft to (nil, nil).
+	rec := buildClientHelloWithExts(t, "", []string{})
+	got, err := parseClientHelloALPN(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ALPN offers = %v, want nil", got)
+	}
+}
+
+func TestParseClientHelloALPN_TruncatedExtensionData(t *testing.T) {
+	// Hand-craft a ClientHello whose ALPN extension declares a longer
+	// ext_data length than the actual bytes present. We patch the ALPN
+	// extension's ext_data length field at the deterministic offset for
+	// a no-SNI / single-ALPN record produced by buildClientHelloWithExts.
+	rec := buildClientHelloWithExts(t, "", []string{"h2"})
+
+	// Layout of the produced record (no SNI, ALPN only):
+	//   [0..4]   TLS record header (5 bytes)
+	//   [5..8]   Handshake header (4 bytes)
+	//   [9..10]  legacy_version (2 bytes)
+	//   [11..42] random (32 bytes)
+	//   [43]     legacy_session_id length (1 byte; 0)
+	//   [44..47] cipher_suites length+payload (2+2 bytes)
+	//   [48..49] compression methods length+payload (1+1 bytes)
+	//   [50..51] extensions length (2 bytes)
+	//   [52..53] ALPN extension type (0x00 0x10)
+	//   [54..55] ALPN ext_data length (the field we patch)
+	const alpnExtDataLenOffset = 54
+	if len(rec) < alpnExtDataLenOffset+2 {
+		t.Fatalf("record too short: %d bytes", len(rec))
+	}
+	if rec[52] != byte(tlsExtensionALPN>>8) || rec[53] != byte(tlsExtensionALPN) {
+		t.Fatalf("ALPN extension not at expected offset; got %x %x", rec[52], rec[53])
+	}
+	// Inflate the ext_data length far beyond what trails it in the record.
+	rec[alpnExtDataLenOffset] = 0xff
+	rec[alpnExtDataLenOffset+1] = 0xff
+
+	_, err := parseClientHelloALPN(rec)
+	if !errors.Is(err, errClientHelloIncomplete) {
+		t.Errorf("err = %v, want errClientHelloIncomplete", err)
+	}
+}
+
+func TestParseClientHelloALPN_SNIAndALPNIndependent(t *testing.T) {
+	// Single ClientHello carries both SNI and ALPN; the two parsers must
+	// extract independent fields without interference.
+	wantSNI := "example.com"
+	wantALPN := []string{"h2", "http/1.1"}
+	rec := buildClientHelloWithExts(t, wantSNI, wantALPN)
+
+	gotSNI, err := parseClientHelloSNI(rec)
+	if err != nil {
+		t.Fatalf("parseClientHelloSNI: unexpected error: %v", err)
+	}
+	if gotSNI != wantSNI {
+		t.Errorf("SNI = %q, want %q", gotSNI, wantSNI)
+	}
+
+	gotALPN, err := parseClientHelloALPN(rec)
+	if err != nil {
+		t.Fatalf("parseClientHelloALPN: unexpected error: %v", err)
+	}
+	if !stringSlicesEqual(gotALPN, wantALPN) {
+		t.Errorf("ALPN offers = %v, want %v", gotALPN, wantALPN)
+	}
+}
+
+func TestParseClientHelloALPN_NotHandshake(t *testing.T) {
+	// Application data record (type 0x17) — propagated from
+	// parseClientHelloExtensions / unwrapClientHelloBody.
+	rec := []byte{0x17, 0x03, 0x03, 0x00, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x00}
+	_, err := parseClientHelloALPN(rec)
+	if !errors.Is(err, errNotClientHello) {
+		t.Errorf("err = %v, want errNotClientHello", err)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- Add `parseClientHelloALPN(buf []byte) ([]string, error)` to `internal/connector/tls_clienthello.go`, mirroring the fail-soft semantics of `parseClientHelloSNI`.
- Refactor: extract shared private helper `parseClientHelloExtensions(buf) ([]byte, error)` that combines `unwrapClientHelloBody` + `skipToExtensions`. Both SNI and ALPN entry points now sit on top of it.
- Add `findALPNInExtensions(exts) ([]string, error)` to decode RFC 7301 §3.1 `ProtocolNameList`.
- Add constant `tlsExtensionALPN = 0x0010`.
- Add table-driven tests covering all 6 cases from the Issue body: `[h2, http/1.1]`, `[http/1.1]`, `[h2]`, ext absent, truncation, cross-extension SNI+ALPN independence.

No callers; behavioral no-op. Prelude for USK-997 wire-up.

## Test plan
- [x] `make lint` clean
- [x] `make test` passes (race-enabled)
- [x] New tests for `parseClientHelloALPN` cover the 6 cases enumerated in the Issue body
- [x] `parseClientHelloSNI` tests still pass after the refactor (no regression in shared helper extraction)

Resolves USK-996
Linear: https://linear.app/usk6666/issue/USK-996

🤖 Generated with [Claude Code](https://claude.com/claude-code)