### PR TITLE
fix(layer/http1,connector,proxybuild): detect stale h1 upstream conn and redial before send (USK-998 Phase 1)

### DIFF
--- a/internal/connector/h1_redial.go
+++ b/internal/connector/h1_redial.go
@@ -1,0 +1,102 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
+)
+
+// RedialUpstreamH1 establishes a fresh upstream HTTP/1.x *Layer for target,
+// reusing the EnvelopeContext template carried by stale (so the new Layer
+// stamps envelopes with the same ConnID / TargetHost / TLS reality the
+// caller already recorded). The TLS knobs (per-host overlay, fingerprint,
+// upstream proxy) are resolved through cfg the same way the original
+// CONNECT path did — runtime-mutable overrides therefore reach the redial.
+//
+// generation identifies which step of the redial chain this dial is for
+// (USK-998 — mirroring the USK-991 h2 redial scheme): generation==1 is the
+// first redial (label suffix `/upstream-redial`); generation>=2 appends
+// `-N`. Callers pass len(chain)+1 (where chain is the slice of prior fresh
+// Layers, including the original).
+//
+// USK-998: invoked by proxybuild's h1 chain inside the per-exchange dial
+// closure when [http1.Layer.HealthCheck] reports the current Layer is
+// stale (peer FIN / RST during idle keep-alive, or RFC 9112 violation
+// during idle). HTTP/1 has no connection pool — the per-CONNECT
+// lifetime owns its single upstream Layer (and any redialed successors).
+//
+// ALPN: offers only "http/1.1". By definition the prior negotiation
+// produced http/1.1 (we were holding a *http1.Layer); re-negotiating to
+// h2 would invalidate the Layer type already wired into the client side
+// of the stack.
+//
+// Returned errors are upstream dial / TLS errors verbatim so the caller
+// can wrap them via fmt.Errorf("dial: %w", ...) the same way the regular
+// dial closure does, keeping ClassifyError taxonomy intact.
+//
+// Wire fidelity: the fresh Layer is constructed identically to the
+// original buildStackFromRoute "http1" upstream path (same options, same
+// EnvelopeContext template), so envelopes flowing through it round-trip
+// with the same wire shape.
+func RedialUpstreamH1(
+	ctx context.Context,
+	target string,
+	stale *http1.Layer,
+	cfg *BuildConfig,
+	generation int,
+) (*http1.Layer, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("connector: RedialUpstreamH1: cfg is nil")
+	}
+	if stale == nil {
+		return nil, fmt.Errorf("connector: RedialUpstreamH1: stale is nil")
+	}
+
+	host := extractHost(target)
+	if host == "" {
+		return nil, fmt.Errorf("connector: RedialUpstreamH1: invalid target %q", target)
+	}
+
+	hostTLS, err := resolvePerHostTLS(target, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Offer only http/1.1: the prior negotiation produced http/1.1 and the
+	// stack's client side is wired for an *http1.Layer. Re-negotiating to
+	// h2 would force a Layer type swap upstream-side that the per-CONNECT
+	// stack is not prepared for.
+	upstreamConn, _, err := dialUpstreamWithALPN(ctx, target, host,
+		[]string{ALPNProtocolHTTP11},
+		hostTLS.insecureSkip, hostTLS.clientCert, hostTLS.rootCAs, cfg,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reuse the original Layer's EnvelopeContext template (mirroring h2:
+	// the older TLS snapshot is kept on the template; Pipeline / RecordStep
+	// already snapshotted the original handshake on prior envelopes, so
+	// keeping the template coherent for the CONNECT's lifetime is more
+	// useful than re-recording TLS here).
+	envCtx := stale.EnvelopeContextTemplate()
+	connID := redialConnIDLabel(envCtx.ConnID, generation)
+
+	fresh := http1.New(upstreamConn, connID, envelope.Receive,
+		http1.WithScheme("https"),
+		http1.WithEnvelopeContext(envCtx),
+		http1.WithBodySpillDir(cfg.BodySpillDir),
+		http1.WithBodySpillThreshold(cfg.BodySpillThreshold),
+		http1.WithMaxBodySize(cfg.MaxBodySize),
+		http1.WithMaxRawCaptureSize(cfg.MaxRawCaptureSize),
+		http1.WithStateReleaser(cfg.PluginV2Engine),
+		// USK-655: bypass body draining for SSE responses so the swap
+		// orchestrator (session.runUpgradeSSE) can hand the still-open
+		// body to sse.Wrap without blocking on a never-ending drain.
+		// Matches the option set used in buildStackFromRoute "http1".
+		http1.WithStreamingResponseDetect(http1.IsSSEResponse),
+	)
+	return fresh, nil
+}

--- a/internal/connector/h1_redial_test.go
+++ b/internal/connector/h1_redial_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 )
 
+// These guards lock RedialUpstreamH1's defensive preconditions so callers
+// surface a structured error instead of silently nil-dereferencing.
+
 // TestRedialUpstreamH1_NilCfg locks the defensive guard so callers never
 // silently dial with a half-built BuildConfig.
 func TestRedialUpstreamH1_NilCfg(t *testing.T) {
@@ -34,16 +37,15 @@ func TestRedialUpstreamH1_NilStale(t *testing.T) {
 	}
 }
 
-// TestRedialUpstreamH1_InvalidTarget asserts that an empty or invalid
-// target surfaces as a structured error rather than reaching the dial.
-func TestRedialUpstreamH1_InvalidTarget(t *testing.T) {
-	cfg := &BuildConfig{}
-	// nil stale would short-circuit first, so we need a non-nil
-	// placeholder *http1.Layer. Reaching the target-check branch is
-	// impossible without a real Layer, so instead assert via direct
-	// extractHost (the helper RedialUpstreamH1 calls).
+// TestExtractHost_EmptyReturnsEmpty locks the upstream contract that
+// RedialUpstreamH1 relies on: an empty target string yields an empty
+// host, which RedialUpstreamH1 then surfaces as a structured
+// `invalid target %q` error rather than reaching the dial. Reaching
+// RedialUpstreamH1's target-check branch directly requires a non-nil
+// stale Layer (constructed over a live conn), which is exercised by the
+// e2e integration test; this unit guard checks the helper boundary only.
+func TestExtractHost_EmptyReturnsEmpty(t *testing.T) {
 	if got := extractHost(""); got != "" {
 		t.Errorf("extractHost(\"\") = %q, want empty (so RedialUpstreamH1 surfaces invalid target)", got)
 	}
-	_ = cfg
 }

--- a/internal/connector/h1_redial_test.go
+++ b/internal/connector/h1_redial_test.go
@@ -1,0 +1,49 @@
+package connector
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestRedialUpstreamH1_NilCfg locks the defensive guard so callers never
+// silently dial with a half-built BuildConfig.
+func TestRedialUpstreamH1_NilCfg(t *testing.T) {
+	_, err := RedialUpstreamH1(context.Background(), "example.com:443", nil, nil, 1)
+	if err == nil {
+		t.Fatal("RedialUpstreamH1(nil cfg, nil stale): got nil err, want guard message")
+	}
+	// nil stale check would also fire before reaching the dial — accept
+	// either guard message as long as the helper bailed out cleanly.
+	if !strings.Contains(err.Error(), "RedialUpstreamH1") {
+		t.Errorf("RedialUpstreamH1: error %q should mention RedialUpstreamH1 helper name", err.Error())
+	}
+}
+
+// TestRedialUpstreamH1_NilStale locks the second defensive guard. The
+// stale Layer is the source of the EnvelopeContext template, so a nil
+// stale would otherwise nil-dereference inside the helper.
+func TestRedialUpstreamH1_NilStale(t *testing.T) {
+	cfg := &BuildConfig{}
+	_, err := RedialUpstreamH1(context.Background(), "example.com:443", nil, cfg, 1)
+	if err == nil {
+		t.Fatal("RedialUpstreamH1(non-nil cfg, nil stale): got nil err, want guard message")
+	}
+	if !strings.Contains(err.Error(), "stale is nil") {
+		t.Errorf("RedialUpstreamH1: error %q should mention 'stale is nil'", err.Error())
+	}
+}
+
+// TestRedialUpstreamH1_InvalidTarget asserts that an empty or invalid
+// target surfaces as a structured error rather than reaching the dial.
+func TestRedialUpstreamH1_InvalidTarget(t *testing.T) {
+	cfg := &BuildConfig{}
+	// nil stale would short-circuit first, so we need a non-nil
+	// placeholder *http1.Layer. Reaching the target-check branch is
+	// impossible without a real Layer, so instead assert via direct
+	// extractHost (the helper RedialUpstreamH1 calls).
+	if got := extractHost(""); got != "" {
+		t.Errorf("extractHost(\"\") = %q, want empty (so RedialUpstreamH1 surfaces invalid target)", got)
+	}
+	_ = cfg
+}

--- a/internal/layer/http1/healthcheck_test.go
+++ b/internal/layer/http1/healthcheck_test.go
@@ -37,11 +37,19 @@ func TestHealthCheck_PeerClosed_ReturnsErr(t *testing.T) {
 	// reset (varies by platform; both classify as stale).
 	_ = client.Close()
 
-	// Give the OS a moment to surface the FIN through the loopback.
-	time.Sleep(20 * time.Millisecond)
-
-	if err := l.HealthCheck(); err == nil {
-		t.Fatal("HealthCheck on peer-closed conn: got nil, want non-nil (stale)")
+	// Poll HealthCheck until the FIN propagates through the loopback
+	// (bounded; flake-resistant on slow CI). HealthCheck itself is sub-
+	// millisecond so a tight polling loop is cheap.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = l.HealthCheck(); lastErr != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if lastErr == nil {
+		t.Fatal("HealthCheck on peer-closed conn: got nil after polling, want non-nil (stale)")
 	}
 }
 
@@ -173,12 +181,19 @@ func TestHealthCheck_IdleByteFromUpstream_TreatedAsStale(t *testing.T) {
 	if _, err := client.Write([]byte("Z")); err != nil {
 		t.Fatalf("write idle byte: %v", err)
 	}
-	// Give the loopback a moment to deliver.
-	time.Sleep(20 * time.Millisecond)
-
-	err := l.HealthCheck()
-	if err == nil {
-		t.Fatal("HealthCheck on idle-byte conn: got nil, want non-nil (stale)")
+	// Poll HealthCheck until the byte reaches the netpoller (bounded;
+	// flake-resistant on slow CI). HealthCheck itself is sub-millisecond
+	// so a tight polling loop is cheap.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = l.HealthCheck(); lastErr != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if lastErr == nil {
+		t.Fatal("HealthCheck on idle-byte conn: got nil after polling, want non-nil (stale)")
 	}
 }
 

--- a/internal/layer/http1/healthcheck_test.go
+++ b/internal/layer/http1/healthcheck_test.go
@@ -1,0 +1,217 @@
+package http1
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+)
+
+// TestHealthCheck_Alive_ReturnsNil exercises the happy path: an open,
+// idle upstream connection with an empty pendingQ reports alive.
+func TestHealthCheck_Alive_ReturnsNil(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-alive", envelope.Receive)
+	defer l.Close()
+
+	if err := l.HealthCheck(); err != nil {
+		t.Fatalf("HealthCheck on fresh idle conn: got %v, want nil", err)
+	}
+}
+
+// TestHealthCheck_PeerClosed_ReturnsErr confirms that a peer-closed conn
+// is surfaced as a stale signal (io.EOF) rather than treated as alive.
+func TestHealthCheck_PeerClosed_ReturnsErr(t *testing.T) {
+	client, server := testConn(t)
+	defer server.Close()
+
+	l := New(server, "stream-hc-eof", envelope.Receive)
+	defer l.Close()
+
+	// Close the peer end so HealthCheck's read sees EOF / connection
+	// reset (varies by platform; both classify as stale).
+	_ = client.Close()
+
+	// Give the OS a moment to surface the FIN through the loopback.
+	time.Sleep(20 * time.Millisecond)
+
+	if err := l.HealthCheck(); err == nil {
+		t.Fatal("HealthCheck on peer-closed conn: got nil, want non-nil (stale)")
+	}
+}
+
+// TestHealthCheck_LayerClosed_ReturnsErr asserts that a Layer that was
+// already explicitly Closed reports stale rather than racing the
+// underlying conn's lifetime.
+func TestHealthCheck_LayerClosed_ReturnsErr(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-closed", envelope.Receive)
+	_ = l.Close()
+
+	err := l.HealthCheck()
+	if err == nil {
+		t.Fatal("HealthCheck on closed Layer: got nil, want net.ErrClosed")
+	}
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("HealthCheck on closed Layer: got %v, want net.ErrClosed", err)
+	}
+}
+
+// TestHealthCheck_SendDirection_ReturnsNil asserts the Send-direction
+// (client-facing) Layer short-circuits to nil — that side is always
+// actively read by spawnLoopSend so the proactive peek does not apply.
+func TestHealthCheck_SendDirection_ReturnsNil(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-send", envelope.Send)
+	defer l.Close()
+
+	if err := l.HealthCheck(); err != nil {
+		t.Fatalf("HealthCheck on Send-direction Layer: got %v, want nil", err)
+	}
+}
+
+// TestHealthCheck_PendingNonEmpty_TreatedAsAlive asserts the defensive
+// short-circuit when pendingQ is non-empty — the parser goroutine will
+// observe any FIN naturally as part of its parseResponse; HealthCheck
+// must not steal reads from it.
+//
+// The conn stays open so the parser parks waiting for bytes; the
+// assertion is that even with the peer alive but quiet, HealthCheck
+// returns nil immediately (without touching the conn) because pendingQ
+// is non-empty. Calling HealthCheck mid-exchange is a caller-broken
+// invariant; defensive nil prevents racing the parser's read.
+func TestHealthCheck_PendingNonEmpty_TreatedAsAlive(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-pending", envelope.Receive)
+	defer l.Close()
+
+	// Open an exchange — that creates a channel but does NOT register it
+	// in pendingQ yet (registration happens on Send via appendPending).
+	upCh := l.OpenExchange()
+	if upCh == nil {
+		t.Fatal("OpenExchange returned nil")
+	}
+	// Manually invoke appendPending to simulate an in-flight exchange so
+	// HealthCheck observes a non-empty pendingQ.
+	c, ok := upCh.(*channel)
+	if !ok {
+		t.Fatalf("OpenExchange returned %T, want *channel", upCh)
+	}
+	l.appendPending(c)
+
+	if err := l.HealthCheck(); err != nil {
+		t.Fatalf("HealthCheck with non-empty pendingQ: got %v, want nil (defer to parser)", err)
+	}
+}
+
+// TestHealthCheck_DeadlineRestored confirms that after HealthCheck
+// returns alive on an idle conn, a subsequent legitimate read on the
+// same conn (driven by spawnLoopReceive style usage) is NOT pre-poisoned
+// by the past deadline. We exercise this by reading directly from the
+// underlying conn after HealthCheck — successful blocking read proves
+// the deadline was restored.
+func TestHealthCheck_DeadlineRestored(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-deadline", envelope.Receive)
+	defer l.Close()
+
+	if err := l.HealthCheck(); err != nil {
+		t.Fatalf("HealthCheck: got %v, want nil", err)
+	}
+
+	// Drive a real byte across the wire and verify the read succeeds with
+	// a generous timeout (would fail with os.ErrDeadlineExceeded if the
+	// past deadline survived).
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_, _ = client.Write([]byte("X"))
+	}()
+	_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer server.SetReadDeadline(time.Time{})
+
+	var buf [1]byte
+	n, err := server.Read(buf[:])
+	if err != nil {
+		t.Fatalf("post-HealthCheck Read: got err=%v, want successful read", err)
+	}
+	if n != 1 || buf[0] != 'X' {
+		t.Fatalf("post-HealthCheck Read: got n=%d byte=%q, want 1/'X'", n, buf[0])
+	}
+}
+
+// TestHealthCheck_IdleByteFromUpstream_TreatedAsStale exercises the RFC
+// 9112 §9.6 violation case: the upstream sent a byte while pendingQ was
+// empty (no exchange in flight). The byte cannot be attributed to any
+// HTTP transaction, so HealthCheck reports stale and the surplus byte is
+// dropped — accepting the 1-byte fidelity loss to avoid propagating a
+// corrupt connection.
+func TestHealthCheck_IdleByteFromUpstream_TreatedAsStale(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	l := New(server, "stream-hc-idlebyte", envelope.Receive)
+	defer l.Close()
+
+	if _, err := client.Write([]byte("Z")); err != nil {
+		t.Fatalf("write idle byte: %v", err)
+	}
+	// Give the loopback a moment to deliver.
+	time.Sleep(20 * time.Millisecond)
+
+	err := l.HealthCheck()
+	if err == nil {
+		t.Fatal("HealthCheck on idle-byte conn: got nil, want non-nil (stale)")
+	}
+}
+
+// TestEnvelopeContextTemplate_ValueCopy locks the value-copy semantic
+// the proxybuild h1 redial chain depends on (USK-998): mutating the
+// returned EnvelopeContext must NOT affect the Layer's internal template.
+func TestEnvelopeContextTemplate_ValueCopy(t *testing.T) {
+	client, server := testConn(t)
+	defer client.Close()
+	defer server.Close()
+
+	want := envelope.EnvelopeContext{
+		ConnID:     "conn-template-test",
+		TargetHost: "example.com:443",
+	}
+	l := New(server, "stream-tmpl", envelope.Receive, WithEnvelopeContext(want))
+	defer l.Close()
+
+	got := l.EnvelopeContextTemplate()
+	if got.ConnID != want.ConnID {
+		t.Errorf("EnvelopeContextTemplate ConnID: got %q, want %q", got.ConnID, want.ConnID)
+	}
+	if got.TargetHost != want.TargetHost {
+		t.Errorf("EnvelopeContextTemplate TargetHost: got %q, want %q", got.TargetHost, want.TargetHost)
+	}
+
+	// Mutate the returned copy; the second fetch must be untouched.
+	got.ConnID = "mutated"
+	got.TargetHost = "evil.example.com:443"
+
+	second := l.EnvelopeContextTemplate()
+	if second.ConnID != want.ConnID || second.TargetHost != want.TargetHost {
+		t.Errorf("EnvelopeContextTemplate returned shared state: second fetch has ConnID=%q TargetHost=%q after mutation",
+			second.ConnID, second.TargetHost)
+	}
+}

--- a/internal/layer/http1/layer.go
+++ b/internal/layer/http1/layer.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +18,12 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http1/parser"
 	"github.com/usk6666/yorishiro-proxy/internal/pluginv2"
 )
+
+// healthCheckProbeDeadline bounds the one-byte probe read in
+// [Layer.HealthCheck]. Long enough for the Go netpoller to surface a
+// queued peer FIN / RST (typically sub-millisecond); short enough that
+// a healthy connection's dial is not visibly delayed.
+const healthCheckProbeDeadline = 1 * time.Millisecond
 
 // Layer wraps a net.Conn in an HTTP/1.x Layer. It yields one Channel per
 // HTTP request-response exchange (RFC-001 §3.3 — Channel granularity is the
@@ -606,6 +614,119 @@ func (l *Layer) Close() error {
 		}
 	})
 	return err
+}
+
+// EnvelopeContextTemplate returns a value copy of the EnvelopeContext stamped
+// onto envelopes produced by this Layer. Used by the proxybuild h1 redial
+// chain (USK-998) to give a freshly redialed Layer the same ConnID /
+// TargetHost / TLS provenance for wire-log continuity. Mirrors
+// [http2.Layer.EnvelopeContextTemplate].
+func (l *Layer) EnvelopeContextTemplate() envelope.EnvelopeContext {
+	return l.envCtx
+}
+
+// HealthCheck performs a non-blocking peek on the underlying conn to detect
+// a stale upstream connection (USK-998). It is intended for the
+// Receive-direction (upstream-facing) Layer when no exchange is currently
+// in flight — typically called by the proxybuild h1 redial chain inside
+// the per-exchange dial closure, before the next request is registered.
+//
+// Returns nil when the connection is alive (or when this Layer is
+// Send-direction, or when pendingQ is non-empty — in which case
+// spawnLoopReceive will observe any FIN naturally as part of the next
+// parseResponse). Returns a non-nil error when the connection is stale
+// (peer-closed, RST, or any non-timeout read error). The caller should
+// Close this Layer and redial when stale.
+//
+// Mechanism: a 1ms read deadline is set on the conn, then a one-byte
+// peek read runs against it. The 1ms window is long enough for Go's
+// netpoller cycle to surface a peer FIN / RST that the kernel has
+// already queued on the socket, but short enough that the proactive
+// probe does not visibly stall the per-exchange dial when the connection
+// is healthy. The deadline is restored on defer so subsequent legitimate
+// reads from spawnLoopReceive are not pre-poisoned. Errors classified:
+//   - net.Error.Timeout / os.ErrDeadlineExceeded → alive (no FIN observed)
+//   - any other read error (io.EOF / net.ErrClosed / ECONNRESET / …) → stale
+//   - n > 0 (server wrote a byte during idle) → stale; the surplus byte is
+//     dropped (see Trade-off below)
+//
+// Invariant: the caller must arrange that no in-flight exchange is
+// registered on this Layer when calling HealthCheck. The proxybuild h1
+// chain calls it only from the dial closure, before any Send is dispatched
+// for the new exchange. As a defence in depth, if pendingQ is non-empty
+// HealthCheck short-circuits with nil (treating the connection as alive)
+// rather than disrupting an in-flight exchange.
+//
+// Concurrency: HealthCheck holds pendingMu for the duration of the read.
+// spawnLoopReceive parks on pendingNotify (without holding pendingMu)
+// while pendingQ is empty, so the deadline-driven read does not race
+// with the parser goroutine in the expected use case.
+//
+// Trade-off (wire fidelity): if the upstream wrote one or more bytes
+// during idle when pendingQ is empty, those bytes cannot be attributed to
+// any HTTP transaction. RFC 9112 forbids idle keep-alive connections from
+// carrying data between exchanges, so any such byte is either a
+// wire-protocol violation by the peer or a TLS close_notify alert. Either
+// way the connection is being terminated, so HealthCheck treats this as a
+// stale signal and the surplus byte is dropped — accepting a single-byte
+// fidelity loss in exchange for not propagating a corrupt connection into
+// the next exchange.
+func (l *Layer) HealthCheck() error {
+	if l == nil {
+		return nil
+	}
+	// Send-direction (client-facing) is driven by spawnLoopSend which is
+	// always actively reading; the proactive peek does not apply.
+	if l.direction != envelope.Receive {
+		return nil
+	}
+
+	// Already-closed Layers are stale by definition.
+	select {
+	case <-l.closed:
+		return net.ErrClosed
+	default:
+	}
+
+	l.pendingMu.Lock()
+	defer l.pendingMu.Unlock()
+	if len(l.pendingQ) > 0 {
+		// In-flight exchange: spawnLoopReceive is responsible for observing
+		// FIN as part of its parseResponse. Treat as alive — the caller
+		// must not call HealthCheck mid-exchange.
+		return nil
+	}
+
+	if l.conn == nil {
+		return nil
+	}
+
+	// 1ms deadline lets the netpoller surface a queued FIN/RST without
+	// stalling the dial on a healthy conn (the proxy is already paying
+	// for the round trip to upstream a moment later). Using a strictly
+	// past deadline (time.Now()) would short-circuit before the runtime
+	// could observe the kernel's RDHUP state on some platforms.
+	_ = l.conn.SetReadDeadline(time.Now().Add(healthCheckProbeDeadline))
+	defer func() { _ = l.conn.SetReadDeadline(time.Time{}) }()
+
+	var buf [1]byte
+	n, err := l.conn.Read(buf[:])
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return nil
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			return nil
+		}
+		return err
+	}
+	if n > 0 {
+		// RFC 9112 violation by the upstream, or TLS alert. Either way
+		// the connection is unusable; report stale and drop the byte.
+		return fmt.Errorf("http1: unexpected idle byte from upstream (n=%d)", n)
+	}
+	return nil
 }
 
 // activeChannel returns the most-recently-yielded Channel for Layer-level

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -742,6 +742,12 @@ func runHTTP1ExchangeLoop(
 	logger *slog.Logger,
 ) {
 	grpcwebOpts := connector.GRPCWebOptionsFromBuildConfig(deps.BuildConfig)
+	// USK-998: wrap the per-CONNECT upstream Layer in a chain so each
+	// per-exchange dial closure can detect a stale keep-alive conn
+	// (server idle FIN / RST) and transparently redial. closeAll on
+	// CONNECT exit tears down every redial step (original + successors).
+	chain := newH1Chain(upstreamH1, target, deps.BuildConfig)
+	defer chain.closeAll()
 	var wg sync.WaitGroup
 	for {
 		select {
@@ -756,7 +762,7 @@ func runHTTP1ExchangeLoop(
 			wg.Add(1)
 			go func(ch layer.Channel) {
 				defer wg.Done()
-				runHTTP1Exchange(ctx, stack, ch, upstreamH1, p, sessOpts, target, grpcwebOpts, logger)
+				runHTTP1Exchange(ctx, stack, ch, chain, p, sessOpts, target, grpcwebOpts, logger)
 			}(clientCh)
 		}
 	}
@@ -780,7 +786,7 @@ func runHTTP1Exchange(
 	ctx context.Context,
 	stack *connector.ConnectionStack,
 	clientCh layer.Channel,
-	upstreamH1 *http1.Layer,
+	chain *h1Chain,
 	p *pipeline.Pipeline,
 	sessOpts session.SessionOptions,
 	target string,
@@ -815,7 +821,14 @@ func runHTTP1Exchange(
 		return
 	}
 
-	dial := func(_ context.Context, env *envelope.Envelope) (layer.Channel, error) {
+	dial := func(dctx context.Context, env *envelope.Envelope) (layer.Channel, error) {
+		// USK-998: probe the current upstream Layer for staleness (peer
+		// idle-FIN / RST during keep-alive) and transparently redial when
+		// stale. Returns the same Layer fast when alive.
+		upstreamH1, err := chain.EnsureFresh(dctx)
+		if err != nil {
+			return nil, fmt.Errorf("dial: %w", err)
+		}
 		upCh := upstreamH1.OpenExchange()
 		if upCh == nil {
 			return nil, fmt.Errorf("proxybuild: upstream http1 layer closed before opening exchange for %s", target)

--- a/internal/proxybuild/h1_chain.go
+++ b/internal/proxybuild/h1_chain.go
@@ -1,0 +1,94 @@
+package proxybuild
+
+import (
+	"context"
+	"sync"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
+)
+
+// h1Chain owns the per-CONNECT chain of upstream HTTP/1.x Layers (USK-998).
+//
+// HTTP/1 has no connection pool — each CONNECT tunnel owns its single
+// upstream Layer. When the upstream peer closes its keep-alive connection
+// during idle (Keep-Alive: timeout expiry, RFC 9112 §9.6), the parser
+// goroutine in [http1.Layer] does not observe the FIN until the next
+// response read; meanwhile the next request's wire Write hits EPIPE.
+//
+// The chain wraps the per-CONNECT upstream Layer and, on each per-exchange
+// dial, calls [http1.Layer.HealthCheck] to detect the stale state proactively
+// and transparently redial via [connector.RedialUpstreamH1] when needed.
+//
+// Shape vs h2's redialChain (USK-991/992):
+//   - Thinner: HTTP/1 has no pool, no GOAWAY observer, no pre-warm worker.
+//   - Layer slice retains every layer (the original + every redial) so
+//     closeAll on CONNECT exit reliably terminates every parser goroutine
+//     and underlying conn.
+//   - Single sync.Mutex serialises EnsureFresh with closeAll. EnsureFresh
+//     calls do not overlap meaningfully in HTTP/1 — the wire is strictly
+//     serial per RFC 9112 §9.5 and the per-exchange goroutines pulling
+//     from the client Channel are time-sliced by the spawn loop anyway —
+//     but the mutex defends against concurrent dial closures from
+//     pipelined exchanges and against a racing CONNECT teardown.
+type h1Chain struct {
+	mu      sync.Mutex
+	current *http1.Layer
+	layers  []*http1.Layer
+	target  string
+	cfg     *connector.BuildConfig
+}
+
+// newH1Chain wraps the initial upstream Layer (the one constructed at
+// CONNECT-time by buildStackFromRoute) so subsequent dial-time stale checks
+// can redial transparently.
+func newH1Chain(initial *http1.Layer, target string, cfg *connector.BuildConfig) *h1Chain {
+	return &h1Chain{
+		current: initial,
+		layers:  []*http1.Layer{initial},
+		target:  target,
+		cfg:     cfg,
+	}
+}
+
+// EnsureFresh returns a Layer guaranteed to have passed a HealthCheck. If
+// the current Layer is stale, it is replaced with a freshly redialed Layer;
+// the stale Layer is Closed synchronously. Returns the dial error verbatim
+// on redial failure — the caller surfaces it through the per-exchange
+// session as state="error" (same shape as the original dial closure's
+// error path) and the next exchange retries via this same EnsureFresh.
+//
+// Concurrency: a single mutex serialises with concurrent EnsureFresh and
+// closeAll. HealthCheck holds [http1.Layer.pendingMu] briefly during its
+// 1-byte SetReadDeadline read; that mutex does not race with the parser
+// goroutine in the expected (pendingQ empty) case.
+func (c *h1Chain) EnsureFresh(ctx context.Context) (*http1.Layer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.current.HealthCheck(); err == nil {
+		return c.current, nil
+	}
+	fresh, err := connector.RedialUpstreamH1(ctx, c.target, c.current, c.cfg, len(c.layers))
+	if err != nil {
+		return nil, err
+	}
+	// Close the stale Layer synchronously. HTTP/1 is wire-serial and
+	// HealthCheck's contract requires an empty pendingQ on call, so by
+	// construction there is no in-flight Channel reader to disrupt. Close
+	// is sync.Once-guarded inside the Layer.
+	_ = c.current.Close()
+	c.current = fresh
+	c.layers = append(c.layers, fresh)
+	return fresh, nil
+}
+
+// closeAll closes every Layer in the chain. Called from the CONNECT-exit
+// deferred cleanup in runHTTP1ExchangeLoop so every redial step's parser
+// goroutine and underlying conn is torn down.
+func (c *h1Chain) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, l := range c.layers {
+		_ = l.Close()
+	}
+}

--- a/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
+++ b/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
@@ -1,0 +1,284 @@
+//go:build e2e && !e2e_smoke
+
+package proxybuild
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
+)
+
+// TestHTTP1StaleConnRecovery_AfterIdleClose simulates the live USK-998
+// bug: an upstream HTTPS server closes its keep-alive connection during
+// idle (matching the Apache / nginx Keep-Alive: timeout=N expiry); the
+// proxy's parser goroutine parks on pendingNotify with pendingQ empty
+// and never observes the FIN; the next request's Write hits EPIPE in
+// the legacy code path.
+//
+// With USK-998's h1Chain + RedialUpstreamH1 wired into the dial
+// closure, the next exchange's EnsureFresh detects the stale state
+// via HealthCheck and transparently redials. The integration test
+// asserts:
+//
+//  1. The first request succeeds.
+//  2. The upstream then closes the keep-alive conn during idle.
+//  3. EnsureFresh detects the stale state via HealthCheck.
+//  4. A fresh dial succeeds; the second request lands on the new conn.
+//  5. The chain's len(layers) advanced to 2 (original + redial step).
+//  6. The fresh Layer's EnvelopeContext carries the redial label.
+//
+// This exercises the integration surface of HealthCheck → RedialUpstreamH1
+// → h1Chain → Layer-construction-time options. The full proxybuild
+// data-path stack (Pipeline / RecordStep / flow store) is exercised by
+// the canonical mitm_integration_test.go harness; this test focuses on
+// the staleness-recovery loop itself.
+//
+// The upstream is a real TLS listener (matching production CONNECT-MITM
+// where the upstream-facing wire is always TLS); cfg uses
+// InsecureSkipVerify for the self-signed test cert.
+func TestHTTP1StaleConnRecovery_AfterIdleClose(t *testing.T) {
+	cert := generateSelfSignedCert(t)
+	tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	var gotReqs atomic.Int32
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				_ = req.Body.Close()
+				resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nOK"
+				_, _ = c.Write([]byte(resp))
+				gotReqs.Add(1)
+				// Close eagerly to simulate Keep-Alive: timeout
+				// expiry on the upstream side. The peer FIN is
+				// invisible to the proxy's http1.Layer parser
+				// (parked on pendingNotify); HealthCheck must
+				// surface it on the next EnsureFresh.
+				time.Sleep(50 * time.Millisecond)
+			}(c)
+		}
+	}()
+
+	target := ln.Addr().String()
+
+	// BuildConfig with InsecureSkipVerify so the self-signed cert
+	// passes the redial dial. We resolve per-host via a synthetic
+	// PerHostTLS entry so RedialUpstreamH1's resolvePerHostTLS finds
+	// the insecure-skip flag.
+	cfg := buildTestBuildConfig(target)
+
+	// Initial Layer is constructed by dialing once through the same
+	// helper the chain uses on redial (so the test exercises real TLS
+	// for both legs, matching the production CONNECT-MITM shape).
+	envCtxTmpl := envelope.EnvelopeContext{
+		ConnID:     "test-conn-998",
+		TargetHost: target,
+	}
+	initial, err := dialInitialUpstream(t, target, cfg, envCtxTmpl)
+	if err != nil {
+		t.Fatalf("initial dial: %v", err)
+	}
+	defer initial.Close()
+
+	chain := newH1Chain(initial, target, cfg)
+	defer chain.closeAll()
+
+	// First exchange: HealthCheck on a freshly dialed conn returns
+	// alive; EnsureFresh returns the initial Layer.
+	got1, err := chain.EnsureFresh(context.Background())
+	if err != nil {
+		t.Fatalf("first EnsureFresh: %v", err)
+	}
+	if got1 != initial {
+		t.Fatalf("first EnsureFresh returned a redial; expected the original Layer")
+	}
+
+	// Send the first request.
+	if err := sendRequestAndDrain(got1, target); err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+
+	// Wait for the upstream to close (the server goroutine closes
+	// after responding + a small sleep). Then a second EnsureFresh
+	// must observe the stale state and redial.
+	deadline := time.Now().Add(3 * time.Second)
+	var got2 *http1.Layer
+	for time.Now().Before(deadline) {
+		got2, err = chain.EnsureFresh(context.Background())
+		if err != nil {
+			t.Fatalf("second EnsureFresh: %v", err)
+		}
+		if got2 != initial {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got2 == initial {
+		t.Fatal("second EnsureFresh never redialed; HealthCheck did not surface the idle FIN")
+	}
+
+	// Second request lands on the fresh Layer.
+	if err := sendRequestAndDrain(got2, target); err != nil {
+		t.Fatalf("second request on redialed Layer: %v", err)
+	}
+
+	if got := gotReqs.Load(); got < 2 {
+		t.Fatalf("upstream got %d requests, want >= 2", got)
+	}
+
+	// Chain bookkeeping: the original + redial step both retained for
+	// closeAll on CONNECT exit.
+	if got := len(chain.layers); got != 2 {
+		t.Errorf("chain.layers length = %d, want 2 (original + 1 redial)", got)
+	}
+
+	// EnvelopeContext continuity: the fresh Layer's template carries
+	// the SAME ConnID as the stale (so the CONNECT's wire-log story
+	// stays unified across redial steps — the redial-label suffix is
+	// applied to the Layer's diagnostic streamID, not the envelope
+	// ConnID; mirrors the h2 redial chain's wire-log shape).
+	freshCtx := got2.EnvelopeContextTemplate()
+	if freshCtx.ConnID != "test-conn-998" {
+		t.Errorf("fresh Layer envCtx ConnID = %q, want %q (continuity)", freshCtx.ConnID, "test-conn-998")
+	}
+	if freshCtx.TargetHost != target {
+		t.Errorf("fresh Layer TargetHost = %q, want %q", freshCtx.TargetHost, target)
+	}
+}
+
+// dialInitialUpstream constructs the initial upstream Layer by going
+// through the same dial path the redial uses — keeps the integration
+// test honest (the test fails the same way the production redial would
+// if RedialUpstreamH1 ever diverged).
+func dialInitialUpstream(t *testing.T, target string, cfg *connector.BuildConfig, envCtxTmpl envelope.EnvelopeContext) (*http1.Layer, error) {
+	t.Helper()
+	stale := http1.New(nopConn{}, "stream-998-bootstrap", envelope.Receive,
+		http1.WithEnvelopeContext(envCtxTmpl),
+	)
+	defer stale.Close()
+	return connector.RedialUpstreamH1(context.Background(), target, stale, cfg, 0)
+}
+
+// buildTestBuildConfig returns a BuildConfig that lets the redial
+// helper accept the test's self-signed TLS cert via the boot-time
+// InsecureSkipVerify fallback.
+func buildTestBuildConfig(_ string) *connector.BuildConfig {
+	return &connector.BuildConfig{
+		InsecureSkipVerify: true,
+	}
+}
+
+// sendRequestAndDrain writes a minimal GET via the upstream Layer's
+// per-exchange Channel and waits for the response Envelope to verify
+// the round trip landed on the wire.
+func sendRequestAndDrain(l *http1.Layer, target string) error {
+	upCh := l.OpenExchange()
+	if upCh == nil {
+		return errors.New("OpenExchange returned nil")
+	}
+
+	reqMsg := &envelope.HTTPMessage{
+		Method:    "GET",
+		Scheme:    "https",
+		Authority: target,
+		Path:      "/",
+		Headers: []envelope.KeyValue{
+			{Name: "Host", Value: target},
+			{Name: "User-Agent", Value: "usk-998-test"},
+		},
+	}
+	reqEnv := &envelope.Envelope{
+		Protocol:  envelope.ProtocolHTTP,
+		Direction: envelope.Send,
+		Message:   reqMsg,
+	}
+	if err := upCh.Send(context.Background(), reqEnv); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := upCh.Next(ctx)
+	_ = upCh.Close()
+	return err
+}
+
+// generateSelfSignedCert produces a throwaway ECDSA cert good enough
+// for the in-process TLS listener used by this test.
+func generateSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ECDSA generate: %v", err)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"127.0.0.1"},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  priv,
+	}
+}
+
+// nopConn is a placeholder net.Conn used so we can construct a stale
+// *http1.Layer purely as a carrier for an EnvelopeContext template.
+// The test never reads / writes through it; the bootstrap Layer is
+// Closed immediately after RedialUpstreamH1 returns.
+type nopConn struct{}
+
+func (nopConn) Read([]byte) (int, error)         { return 0, errors.New("nopConn") }
+func (nopConn) Write([]byte) (int, error)        { return 0, errors.New("nopConn") }
+func (nopConn) Close() error                     { return nil }
+func (nopConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (nopConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (nopConn) SetDeadline(time.Time) error      { return nil }
+func (nopConn) SetReadDeadline(time.Time) error  { return nil }
+func (nopConn) SetWriteDeadline(time.Time) error { return nil }
+
+var _ = sync.Mutex{}

--- a/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
+++ b/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"math/big"
 	"net"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -184,6 +183,15 @@ func TestHTTP1StaleConnRecovery_AfterIdleClose(t *testing.T) {
 // through the same dial path the redial uses — keeps the integration
 // test honest (the test fails the same way the production redial would
 // if RedialUpstreamH1 ever diverged).
+//
+// Test-only quirk: the bootstrap reuses RedialUpstreamH1, which stamps
+// the produced Layer's streamID with the redial-label suffix
+// (`/upstream-redial`). The test's assertions are scoped to the
+// EnvelopeContext template (ConnID / TargetHost set via
+// WithEnvelopeContext), not the streamID, so this does not affect
+// correctness — but production callers should not use generation==0 on
+// a real initial dial path; that branch is reserved for the chain's
+// own bootstrap-via-redial pattern in this test harness.
 func dialInitialUpstream(t *testing.T, target string, cfg *connector.BuildConfig, envCtxTmpl envelope.EnvelopeContext) (*http1.Layer, error) {
 	t.Helper()
 	stale := http1.New(nopConn{}, "stream-998-bootstrap", envelope.Receive,
@@ -280,5 +288,3 @@ func (nopConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
 func (nopConn) SetDeadline(time.Time) error      { return nil }
 func (nopConn) SetReadDeadline(time.Time) error  { return nil }
 func (nopConn) SetWriteDeadline(time.Time) error { return nil }
-
-var _ = sync.Mutex{}

--- a/internal/proxybuild/h1_chain_test.go
+++ b/internal/proxybuild/h1_chain_test.go
@@ -75,14 +75,24 @@ func TestH1Chain_EnsureFresh_RedialFailureSurfaced(t *testing.T) {
 
 	// Close the peer to make HealthCheck observe a stale state.
 	_ = client.Close()
-	time.Sleep(20 * time.Millisecond)
 
 	chain := newH1Chain(initial, "127.0.0.1:1", nil) // nil cfg + invalid target
 	defer chain.closeAll()
 
-	_, err := chain.EnsureFresh(context.Background())
+	// Poll EnsureFresh until the loopback FIN propagates and HealthCheck
+	// flips to stale; once stale the nil cfg surfaces a dial error.
+	// Bounded; flake-resistant on slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	var err error
+	for time.Now().Before(deadline) {
+		_, err = chain.EnsureFresh(context.Background())
+		if err != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err == nil {
-		t.Fatal("EnsureFresh on stale Layer with nil cfg: got nil, want dial error")
+		t.Fatal("EnsureFresh on stale Layer with nil cfg: got nil after polling, want dial error")
 	}
 }
 

--- a/internal/proxybuild/h1_chain_test.go
+++ b/internal/proxybuild/h1_chain_test.go
@@ -1,0 +1,128 @@
+package proxybuild
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
+)
+
+// testTCPPair returns a connected TCP pair; the caller closes both sides.
+// We use real loopback TCP rather than net.Pipe so SetReadDeadline
+// behaves the same way the production code path observes (net.Pipe is
+// strictly synchronous and does not surface a queued FIN through the
+// netpoller cycle the health probe relies on).
+func testTCPPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	ch := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		ch <- c
+	}()
+	client, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	server = <-ch
+	return client, server
+}
+
+// TestH1Chain_EnsureFresh_PassThroughWhenAlive verifies the happy path:
+// HealthCheck returns nil on a fresh idle conn, so EnsureFresh returns
+// the same Layer pointer without dialing anything (cfg is nil — a real
+// redial would panic before reaching the dial code).
+func TestH1Chain_EnsureFresh_PassThroughWhenAlive(t *testing.T) {
+	_, server := testTCPPair(t)
+	defer server.Close()
+
+	initial := http1.New(server, "stream-passthru", envelope.Receive)
+	defer initial.Close()
+
+	chain := newH1Chain(initial, "example.com:443", nil)
+	defer chain.closeAll()
+
+	got, err := chain.EnsureFresh(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if got != initial {
+		t.Errorf("EnsureFresh returned a new Layer when the current was alive (no redial expected)")
+	}
+}
+
+// TestH1Chain_EnsureFresh_RedialFailureSurfaced asserts that when the
+// current Layer is stale (peer-closed) and the BuildConfig is nil so the
+// redial cannot succeed, the dial error is returned to the caller (it
+// surfaces through the per-exchange session as state="error" — same
+// shape as the original dial closure's error path).
+func TestH1Chain_EnsureFresh_RedialFailureSurfaced(t *testing.T) {
+	client, server := testTCPPair(t)
+
+	initial := http1.New(server, "stream-redial-fail", envelope.Receive)
+	defer initial.Close()
+
+	// Close the peer to make HealthCheck observe a stale state.
+	_ = client.Close()
+	time.Sleep(20 * time.Millisecond)
+
+	chain := newH1Chain(initial, "127.0.0.1:1", nil) // nil cfg + invalid target
+	defer chain.closeAll()
+
+	_, err := chain.EnsureFresh(context.Background())
+	if err == nil {
+		t.Fatal("EnsureFresh on stale Layer with nil cfg: got nil, want dial error")
+	}
+}
+
+// TestH1Chain_CloseAll_ClosesEveryLayer verifies that closeAll Closes
+// every layer registered in the chain, including the original. The
+// underlying conn close is observable via a Read on the peer side.
+func TestH1Chain_CloseAll_ClosesEveryLayer(t *testing.T) {
+	client1, server1 := testTCPPair(t)
+	defer client1.Close()
+	client2, server2 := testTCPPair(t)
+	defer client2.Close()
+
+	layer1 := http1.New(server1, "stream-close-1", envelope.Receive)
+	layer2 := http1.New(server2, "stream-close-2", envelope.Receive)
+
+	chain := newH1Chain(layer1, "example.com:443", nil)
+	// Simulate a prior successful redial by injecting the second Layer
+	// into the chain by hand. The real path appends through EnsureFresh's
+	// dial; here we exercise closeAll's iteration shape directly without
+	// needing a working dial.
+	chain.layers = append(chain.layers, layer2)
+	chain.current = layer2
+
+	chain.closeAll()
+
+	// After closeAll, the peer side observes EOF (the server-side conn
+	// owned by each Layer is closed).
+	_ = client1.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_ = client2.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	var buf [1]byte
+	if _, err := client1.Read(buf[:]); err == nil {
+		t.Error("closeAll: layer1 conn still readable; expected EOF after Close")
+	}
+	if _, err := client2.Read(buf[:]); err == nil {
+		t.Error("closeAll: layer2 conn still readable; expected EOF after Close")
+	}
+}
+
+// _ guards against the linter pruning the connector import when none of
+// the cfg-driven dial paths are exercised in this file (the chain tests
+// use a nil cfg + invalid target path). The import is required for
+// chain construction via newH1Chain's *connector.BuildConfig parameter.
+var _ = connector.BuildConfig{}


### PR DESCRIPTION
## Summary

Brings HTTP/1.x to functional parity with HTTP/2 for stale-upstream-connection recovery, fixing a live browser-parity bug observed against `try.nextcloud.com` / `demo1.nextcloud.com` after browser idle.

- `http1.Layer.HealthCheck()` — non-blocking 1ms-deadline 1-byte peek; treats timeouts as alive and EOF/RST/idle-byte as stale.
- `http1.Layer.EnvelopeContextTemplate()` — value-copy accessor mirroring `http2.Layer`.
- `connector.RedialUpstreamH1` — mirrors `h2_redial.go`; offers ALPN `http/1.1` only; constructs the fresh Layer with the exact `buildStackFromRoute` option list; reuses `redialConnIDLabel` for wire-log continuity.
- `proxybuild.h1Chain` — thinner than h2's `redialChain` (no pool, no GOAWAY observer, no pre-warm).
- `runHTTP1Exchange` dial closure rewired to `chain.EnsureFresh(ctx)`.
- 13 unit tests + 1 e2e integration test (`//go:build e2e && !e2e_smoke`, exhaustive tier).

## Live bug reproduced

Chrome → `https://try.nextcloud.com/access` → idle ~4 min → re-navigate yields `write: broken pipe` in 14ms because `spawnLoopReceive` (`internal/layer/http1/layer.go:516`) parks on `pendingNotify` with `pendingQ` empty and never observes the upstream FIN after `Keep-Alive: timeout=5`. The next `sendRequestOpaque` zero-copy `Write` (`internal/layer/http1/channel.go:1034-1036`) hits EPIPE on the dead conn, recorded as `state=error` with no retry.

## Scope: Phase 1 only

Per the Issue body's rollout plan, Phase 1 (案 C: proactive healthcheck + redial) absorbs ~95% of the symptom with localized changes and minimal blast radius on the wire path. Phase 2 (案 A: `StaleUpstreamError` + replay-safe retry for the healthcheck-miss race) and Phase 3 (metrics) are explicitly out of scope and will be filed as separate follow-up Issues.

## MITM principle adherence

- Wire fidelity: HealthCheck may drop one idle byte from a misbehaving upstream — documented in its godoc. The byte cannot be attributed to any HTTP transaction (RFC 9112 §9.6 forbids data on idle keep-alive conns), and the conn is being terminated either way.
- ALPN: `http/1.1`-only offer on redial avoids inadvertent Layer-type mismatch via h2 upgrade.
- No new `net/http` imports in data-path packages.
- No header dedup / Host=URL enforcement / casing normalization introduced.

## Test plan

- [x] `make lint` passes (gofmt + vet + staticcheck + ineffassign + gocyclo)
- [x] `make test` passes (48 packages, includes the 13 new unit tests under `-race`)
- [ ] `make test-e2e` passes (includes `TestHTTP1Forward_StaleConnRecovery_AfterIdleClose`) — verified to compile; run nightly
- [ ] Manual: confirm h2 redial machinery untouched (no regression in USK-991/992/993 territory)

Resolves USK-998 (Phase 1)
Linear: https://linear.app/usk6666/issue/USK-998

🤖 Generated with [Claude Code](https://claude.com/claude-code)