### PR TITLE
feat(proxybuild,mcp): h1 upstream redial metrics + MCP status surface (USK-998 Phase 3)

### DIFF
--- a/internal/mcp/components.go
+++ b/internal/mcp/components.go
@@ -272,6 +272,12 @@ type proxyManager interface {
 	// Boot-time only; no setter.
 	SSEMaxEventsPerStream() int
 	StartTCPForwardsNamedAny(ctx context.Context, name string, params any) error
+	// H1UpstreamMetrics surfaces the USK-998 / USK-999 / USK-1000
+	// HTTP/1.x upstream redial / replay counter snapshot. Returns the
+	// zero snapshot when no Manager is bound. The MCP
+	// query(resource:"status") tool consumes this to populate the
+	// `h1_upstream` field on the status result.
+	H1UpstreamMetrics() proxybuild.H1UpstreamMetricsSnapshot
 }
 
 // ListenerStatus is the mcp-package shape of per-listener status used by

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -21,6 +21,7 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/encoding/protoschema"
 	"github.com/usk6666/yorishiro-proxy/internal/envelope"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
 	"github.com/usk6666/yorishiro-proxy/internal/rules/common"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -2105,25 +2106,33 @@ type queryListenerStatusEntry struct {
 }
 
 // queryStatusResult is the response for the status resource.
+//
+// H1Upstream (USK-1000) carries the HTTP/1.x upstream redial / replay
+// counters maintained by the bound proxybuild.Manager. The pointer is
+// nil when no manager is bound; otherwise the embedded snapshot is
+// always populated (zero counters when nothing has happened yet).
+// omitempty keeps the field absent for test runs that don't wire a
+// Manager.
 type queryStatusResult struct {
-	Running           bool                       `json:"running"`
-	ListenAddr        string                     `json:"listen_addr"`
-	Listeners         []queryListenerStatusEntry `json:"listeners,omitempty"`
-	ListenerCount     int                        `json:"listener_count"`
-	UpstreamProxy     string                     `json:"upstream_proxy"`
-	ActiveConnections int                        `json:"active_connections"`
-	MaxConnections    int                        `json:"max_connections"`
-	PeekTimeoutMs     int64                      `json:"peek_timeout_ms"`
-	RequestTimeoutMs  int64                      `json:"request_timeout_ms"`
-	TotalFlows        int                        `json:"total_flows"`
-	DBSizeBytes       int64                      `json:"db_size_bytes"`
-	UptimeSeconds     int64                      `json:"uptime_seconds"`
-	CAInitialized     bool                       `json:"ca_initialized"`
-	SOCKS5Enabled     bool                       `json:"socks5_enabled"`
-	SOCKS5Auth        string                     `json:"socks5_auth,omitempty"`
-	TLSFingerprint    string                     `json:"tls_fingerprint"`
-	RateLimits        *queryRateLimitStatus      `json:"rate_limits,omitempty"`
-	Budget            *queryBudgetStatus         `json:"budget,omitempty"`
+	Running           bool                                  `json:"running"`
+	ListenAddr        string                                `json:"listen_addr"`
+	Listeners         []queryListenerStatusEntry            `json:"listeners,omitempty"`
+	ListenerCount     int                                   `json:"listener_count"`
+	UpstreamProxy     string                                `json:"upstream_proxy"`
+	ActiveConnections int                                   `json:"active_connections"`
+	MaxConnections    int                                   `json:"max_connections"`
+	PeekTimeoutMs     int64                                 `json:"peek_timeout_ms"`
+	RequestTimeoutMs  int64                                 `json:"request_timeout_ms"`
+	TotalFlows        int                                   `json:"total_flows"`
+	DBSizeBytes       int64                                 `json:"db_size_bytes"`
+	UptimeSeconds     int64                                 `json:"uptime_seconds"`
+	CAInitialized     bool                                  `json:"ca_initialized"`
+	SOCKS5Enabled     bool                                  `json:"socks5_enabled"`
+	SOCKS5Auth        string                                `json:"socks5_auth,omitempty"`
+	TLSFingerprint    string                                `json:"tls_fingerprint"`
+	RateLimits        *queryRateLimitStatus                 `json:"rate_limits,omitempty"`
+	Budget            *queryBudgetStatus                    `json:"budget,omitempty"`
+	H1Upstream        *proxybuild.H1UpstreamMetricsSnapshot `json:"h1_upstream,omitempty"`
 }
 
 // queryRateLimitStatus holds rate limit information for the status response.
@@ -2154,6 +2163,13 @@ func (s *Server) populateManagerStatus(result *queryStatusResult) {
 	result.PeekTimeoutMs = s.connector.manager.PeekTimeout().Milliseconds()
 	result.UptimeSeconds = int64(s.connector.manager.Uptime().Seconds())
 	result.ListenerCount = s.connector.manager.ListenerCount()
+
+	// USK-1000: surface the HTTP/1.x upstream redial / replay counters.
+	// The snapshot is a value type — the pointer wraps it so JSON
+	// `omitempty` semantics let test runs without a Manager-backed
+	// implementation omit the field entirely.
+	h1Snap := s.connector.manager.H1UpstreamMetrics()
+	result.H1Upstream = &h1Snap
 
 	// Populate per-listener statuses.
 	statuses := listenerStatuses(s.connector.manager)

--- a/internal/mcp/query_tool_test.go
+++ b/internal/mcp/query_tool_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/cert"
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
+	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
 )
 
 // setupQueryTestSession creates an MCP client session for query tool tests.
@@ -836,6 +837,62 @@ func TestQuery_Status_WithSessions(t *testing.T) {
 
 	if out.TotalFlows != 2 {
 		t.Errorf("total_flows = %d, want 2", out.TotalFlows)
+	}
+}
+
+// TestQuery_Status_H1UpstreamMetrics_Empty asserts the status
+// resource surfaces the USK-1000 h1_upstream counter snapshot. With
+// no upstream activity the embedded counters are all zero but the
+// field itself is populated (i.e. a Manager IS bound) so the AI
+// agent can distinguish "no Manager wired" (field absent) from
+// "Manager wired, no churn yet" (field present, counters zero).
+func TestQuery_Status_H1UpstreamMetrics_Empty(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	manager := newTestProxybuildManager(t)
+	if err := manager.Start(context.Background(), "127.0.0.1:0"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cs := setupQueryStatusTestSession(t, store, manager)
+
+	result := callQuery(t, cs, queryInput{Resource: "status"})
+	if result.IsError {
+		t.Fatalf("expected success: %v", result.Content)
+	}
+
+	var out queryStatusResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.H1Upstream == nil {
+		t.Fatal("h1_upstream = nil; want non-nil snapshot when Manager is bound")
+	}
+	// Every counter should be zero until a CONNECT redials.
+	want := proxybuild.H1UpstreamMetricsSnapshot{}
+	if *out.H1Upstream != want {
+		t.Errorf("h1_upstream = %+v, want %+v (all zero)", *out.H1Upstream, want)
+	}
+}
+
+// TestQuery_Status_H1UpstreamMetrics_NoManager asserts the
+// h1_upstream field is OMITTED from the status payload when no
+// Manager is bound. omitempty + nil pointer ensures the JSON
+// surface stays clean for the "no Manager wired" case.
+func TestQuery_Status_H1UpstreamMetrics_NoManager(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{Resource: "status"})
+	if result.IsError {
+		t.Fatalf("expected success: %v", result.Content)
+	}
+
+	var out queryStatusResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.H1Upstream != nil {
+		t.Errorf("h1_upstream = %+v, want nil (no Manager bound)", *out.H1Upstream)
 	}
 }
 

--- a/internal/mcpserver/init.go
+++ b/internal/mcpserver/init.go
@@ -571,6 +571,13 @@ func NewLiveManager(
 	// blocked-recording AC). socks5Negotiator is the process-singleton
 	// owned by the caller (USK-770) so MCP socks5_auth runtime mutations
 	// reach every listener built from this factory.
+	// h1Metrics is constructed before NewManager so the same pointer is
+	// captured by both: the Manager exposes it via H1UpstreamMetrics()
+	// (consumed by the MCP query(resource:"status") tool), and the
+	// factory closure threads it into every per-listener Deps so every
+	// h1Chain / retryingUpstreamChannel updates the same Manager-level
+	// counter set. USK-1000.
+	h1Metrics := proxybuild.NewH1UpstreamMetrics()
 	factory := func(ctx context.Context, name, addr string) (*proxybuild.Stack, error) {
 		return proxybuild.BuildLiveStack(ctx, proxybuild.Deps{
 			Logger:                  logger,
@@ -605,6 +612,8 @@ func NewLiveManager(
 			// every listener built by this factory.
 			RecordGRPCMaxMessagesPerStream: buildCfg.GRPCMaxMessagesPerStream,
 			RecordSSEMaxEventsPerStream:    buildCfg.SSEMaxEventsPerStream,
+			// USK-1000: shared HTTP/1.x upstream redial / replay counters.
+			H1UpstreamMetrics: h1Metrics,
 		})
 	}
 	mgr, err := proxybuild.NewManager(proxybuild.ManagerConfig{
@@ -615,6 +624,9 @@ func NewLiveManager(
 		// lets Manager.SetUpstreamProxy mutate the live dial-path's
 		// dynamic upstream-proxy slot at runtime (USK-734).
 		BuildConfig: buildCfg,
+		// USK-1000: bind the metrics counters so Manager.H1UpstreamMetrics
+		// returns the same counters every Deps update.
+		H1UpstreamMetrics: h1Metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init proxybuild manager: %w", err)

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -244,6 +244,15 @@ type Deps struct {
 	// dispatch.
 	RecordGRPCLPMFrameMaxPerStream int
 
+	// H1UpstreamMetrics aggregates USK-998 Phase 1 + USK-999 Phase 2 +
+	// USK-1000 HTTP/1.x upstream redial / replay counters. nil-safe —
+	// every emit point inside h1Chain / retryingUpstreamChannel
+	// short-circuits on a nil pointer. The production wiring
+	// (internal/mcpserver/init.go) constructs a single h1UpstreamMetrics
+	// on Manager and threads the same pointer through Deps so all
+	// per-CONNECT chains under one Manager share the counter set.
+	H1UpstreamMetrics *H1UpstreamMetrics
+
 	// RecordGRPCWebBase64MaxPerStream caps the number of gRPC-Web
 	// text-variant body wire envelopes (WireLevel=grpcweb-base64,
 	// pre-decode base64 body bytes captured by the grpcweb Layer's
@@ -746,7 +755,7 @@ func runHTTP1ExchangeLoop(
 	// per-exchange dial closure can detect a stale keep-alive conn
 	// (server idle FIN / RST) and transparently redial. closeAll on
 	// CONNECT exit tears down every redial step (original + successors).
-	chain := newH1Chain(upstreamH1, target, deps.BuildConfig)
+	chain := newH1Chain(upstreamH1, target, deps.BuildConfig, logger, deps.H1UpstreamMetrics)
 	defer chain.closeAll()
 	var wg sync.WaitGroup
 	for {
@@ -762,7 +771,7 @@ func runHTTP1ExchangeLoop(
 			wg.Add(1)
 			go func(ch layer.Channel) {
 				defer wg.Done()
-				runHTTP1Exchange(ctx, stack, ch, chain, p, sessOpts, target, grpcwebOpts, logger)
+				runHTTP1Exchange(ctx, stack, ch, chain, p, sessOpts, target, grpcwebOpts, logger, deps.H1UpstreamMetrics)
 			}(clientCh)
 		}
 	}
@@ -792,6 +801,7 @@ func runHTTP1Exchange(
 	target string,
 	baseGRPCWebOpts []grpcweb.Option,
 	logger *slog.Logger,
+	metrics *H1UpstreamMetrics,
 ) {
 	// Per-exchange wire-record Option for the gRPC-Web text-variant
 	// base64 wire bytes. The same closure is installed on both the
@@ -854,7 +864,7 @@ func runHTTP1Exchange(
 		// ~5% race window left by USK-998 Phase 1 (server FIN between
 		// HealthCheck and Write). On *http1.StaleUpstreamError{ReplaySafe:true}
 		// the wrapper force-redials the chain and replays the Send once.
-		return newRetryingUpstreamChannel(dispatched, chain, dispatchWrap, logger, target), nil
+		return newRetryingUpstreamChannel(dispatched, chain, dispatchWrap, logger, target, metrics), nil
 	}
 	if err := session.RunStackSessionExchange(ctx, stack, dispatchedCh, dial, p, sessOpts); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Debug("proxybuild: http1 exchange ended with error", "target", target, "error", err)

--- a/internal/proxybuild/h1_chain.go
+++ b/internal/proxybuild/h1_chain.go
@@ -2,6 +2,7 @@ package proxybuild
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 
 	"github.com/usk6666/yorishiro-proxy/internal/connector"
@@ -31,23 +32,59 @@ import (
 //     from the client Channel are time-sliced by the spawn loop anyway —
 //     but the mutex defends against concurrent dial closures from
 //     pipelined exchanges and against a racing CONNECT teardown.
+//
+// USK-1000: chains carry a back-reference to the Manager-level
+// [h1UpstreamMetrics] so each stale-detect / redial / close-all event
+// updates the manager-wide counters. metrics may be nil for tests that
+// construct an h1Chain directly without a Manager; every counter call
+// is nil-safe.
 type h1Chain struct {
 	mu      sync.Mutex
 	current *http1.Layer
 	layers  []*http1.Layer
 	target  string
 	cfg     *connector.BuildConfig
+
+	// logger is used for stale-detect / redial-success / redial-failure
+	// observability per CLAUDE.md Log Level Guidelines. Debug for normal
+	// detect/success, Warn for dial failures (matches h2's
+	// `proxybuild: upstream h2 redial failed` Warn).
+	logger *slog.Logger
+
+	// metrics receives counter updates for stale_detected_total,
+	// redial_total, redial_failed_total, and the chain_generation
+	// gauge family. Nil-safe.
+	metrics *H1UpstreamMetrics
+
+	// liveGen is the number of redial steps this chain currently
+	// contributes to the manager-wide chainGenerationLive gauge. Bumped
+	// under c.mu on every redial-append; consumed by closeAll so the
+	// manager's live counter is decremented by the exact contribution
+	// of this chain. Tracking the contribution here (rather than
+	// recomputing from len(c.layers) at close time) keeps the counter
+	// stable if future evolutions change how layers are accounted.
+	liveGen int64
 }
 
 // newH1Chain wraps the initial upstream Layer (the one constructed at
 // CONNECT-time by buildStackFromRoute) so subsequent dial-time stale checks
-// can redial transparently.
-func newH1Chain(initial *http1.Layer, target string, cfg *connector.BuildConfig) *h1Chain {
+// can redial transparently. logger and metrics are USK-1000 plumbing
+// (see h1UpstreamMetrics); both may be nil — the chain operates
+// identically minus the observability emit.
+func newH1Chain(
+	initial *http1.Layer,
+	target string,
+	cfg *connector.BuildConfig,
+	logger *slog.Logger,
+	metrics *H1UpstreamMetrics,
+) *h1Chain {
 	return &h1Chain{
 		current: initial,
 		layers:  []*http1.Layer{initial},
 		target:  target,
 		cfg:     cfg,
+		logger:  logger,
+		metrics: metrics,
 	}
 }
 
@@ -62,14 +99,29 @@ func newH1Chain(initial *http1.Layer, target string, cfg *connector.BuildConfig)
 // closeAll. HealthCheck holds [http1.Layer.pendingMu] briefly during its
 // 1-byte SetReadDeadline read; that mutex does not race with the parser
 // goroutine in the expected (pendingQ empty) case.
+//
+// USK-1000 metrics: HealthCheck-err → incStaleDetectedHealthcheck.
+// RedialUpstreamH1 success → incRedialHealthcheck + observeChainGeneration.
+// RedialUpstreamH1 error → incRedialFailedHealthcheck.
 func (c *h1Chain) EnsureFresh(ctx context.Context) (*http1.Layer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := c.current.HealthCheck(); err == nil {
 		return c.current, nil
 	}
+	// HealthCheck failed: stale upstream observed.
+	c.metrics.incStaleDetectedHealthcheck()
+	if c.logger != nil {
+		c.logger.Debug("proxybuild: http1 stale detected, redialing",
+			"target", c.target, "trigger", "healthcheck", "generation", len(c.layers))
+	}
 	fresh, err := connector.RedialUpstreamH1(ctx, c.target, c.current, c.cfg, len(c.layers))
 	if err != nil {
+		c.metrics.incRedialFailedHealthcheck()
+		if c.logger != nil {
+			c.logger.Warn("proxybuild: http1 redial failed",
+				"target", c.target, "trigger", "healthcheck", "error", err)
+		}
 		return nil, err
 	}
 	// Close the stale Layer synchronously. HTTP/1 is wire-serial and
@@ -79,6 +131,8 @@ func (c *h1Chain) EnsureFresh(ctx context.Context) (*http1.Layer, error) {
 	_ = c.current.Close()
 	c.current = fresh
 	c.layers = append(c.layers, fresh)
+	c.bumpGenerationLocked()
+	c.metrics.incRedialHealthcheck()
 	return fresh, nil
 }
 
@@ -102,11 +156,19 @@ func (c *h1Chain) EnsureFresh(ctx context.Context) (*http1.Layer, error) {
 // Returns the fresh Layer on success or the dial error verbatim on
 // failure; the caller surfaces the failure as state="error" on the
 // session (matching the EnsureFresh dial-failure shape).
+//
+// USK-1000 metrics: success → incRedialWriteEpipe + observeChainGeneration.
+// Failure → incRedialFailedWriteEpipe.
 func (c *h1Chain) Redial(ctx context.Context) (*http1.Layer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	fresh, err := connector.RedialUpstreamH1(ctx, c.target, c.current, c.cfg, len(c.layers))
 	if err != nil {
+		c.metrics.incRedialFailedWriteEpipe()
+		if c.logger != nil {
+			c.logger.Warn("proxybuild: http1 redial failed",
+				"target", c.target, "trigger", "write_epipe", "error", err)
+		}
 		return nil, err
 	}
 	// Close the stale Layer synchronously. The retry wrapper is the
@@ -116,16 +178,43 @@ func (c *h1Chain) Redial(ctx context.Context) (*http1.Layer, error) {
 	_ = c.current.Close()
 	c.current = fresh
 	c.layers = append(c.layers, fresh)
+	c.bumpGenerationLocked()
+	c.metrics.incRedialWriteEpipe()
+	if c.logger != nil {
+		c.logger.Debug("proxybuild: http1 redialed after write EPIPE",
+			"target", c.target, "trigger", "write_epipe", "generation", len(c.layers)-1)
+	}
 	return fresh, nil
+}
+
+// bumpGenerationLocked updates the chain-generation gauges after a
+// successful redial-append. Caller MUST hold c.mu — both the layer
+// slice and the local liveGen are mutated. The generation value
+// reported to the metrics struct is the number of redial steps
+// (len(layers) - 1) so the implicit initial Layer is generation 0
+// and the first redial is generation 1, matching the
+// RedialUpstreamH1(generation=N) ConnID suffix convention.
+func (c *h1Chain) bumpGenerationLocked() {
+	gen := int64(len(c.layers) - 1)
+	c.liveGen = gen
+	c.metrics.observeChainGeneration(gen)
 }
 
 // closeAll closes every Layer in the chain. Called from the CONNECT-exit
 // deferred cleanup in runHTTP1ExchangeLoop so every redial step's parser
 // goroutine and underlying conn is torn down.
+//
+// USK-1000: releases this chain's contribution to the manager-wide
+// chainGenerationLive gauge so the gauge stays meaningful across many
+// CONNECTs (otherwise it would grow monotonically forever).
 func (c *h1Chain) closeAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, l := range c.layers {
 		_ = l.Close()
+	}
+	if c.liveGen > 0 {
+		c.metrics.releaseChainGeneration(c.liveGen)
+		c.liveGen = 0
 	}
 }

--- a/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
+++ b/internal/proxybuild/h1_chain_stale_recovery_integration_test.go
@@ -113,7 +113,7 @@ func TestHTTP1StaleConnRecovery_AfterIdleClose(t *testing.T) {
 	}
 	defer initial.Close()
 
-	chain := newH1Chain(initial, target, cfg)
+	chain := newH1Chain(initial, target, cfg, nil, nil)
 	defer chain.closeAll()
 
 	// First exchange: HealthCheck on a freshly dialed conn returns

--- a/internal/proxybuild/h1_chain_test.go
+++ b/internal/proxybuild/h1_chain_test.go
@@ -50,7 +50,7 @@ func TestH1Chain_EnsureFresh_PassThroughWhenAlive(t *testing.T) {
 	initial := http1.New(server, "stream-passthru", envelope.Receive)
 	defer initial.Close()
 
-	chain := newH1Chain(initial, "example.com:443", nil)
+	chain := newH1Chain(initial, "example.com:443", nil, nil, nil)
 	defer chain.closeAll()
 
 	got, err := chain.EnsureFresh(context.Background())
@@ -76,7 +76,7 @@ func TestH1Chain_EnsureFresh_RedialFailureSurfaced(t *testing.T) {
 	// Close the peer to make HealthCheck observe a stale state.
 	_ = client.Close()
 
-	chain := newH1Chain(initial, "127.0.0.1:1", nil) // nil cfg + invalid target
+	chain := newH1Chain(initial, "127.0.0.1:1", nil, nil, nil) // nil cfg + invalid target
 	defer chain.closeAll()
 
 	// Poll EnsureFresh until the loopback FIN propagates and HealthCheck
@@ -108,7 +108,7 @@ func TestH1Chain_CloseAll_ClosesEveryLayer(t *testing.T) {
 	layer1 := http1.New(server1, "stream-close-1", envelope.Receive)
 	layer2 := http1.New(server2, "stream-close-2", envelope.Receive)
 
-	chain := newH1Chain(layer1, "example.com:443", nil)
+	chain := newH1Chain(layer1, "example.com:443", nil, nil, nil)
 	// Simulate a prior successful redial by injecting the second Layer
 	// into the chain by hand. The real path appends through EnsureFresh's
 	// dial; here we exercise closeAll's iteration shape directly without

--- a/internal/proxybuild/h1_metrics.go
+++ b/internal/proxybuild/h1_metrics.go
@@ -1,0 +1,375 @@
+package proxybuild
+
+import "sync/atomic"
+
+// H1UpstreamMetrics aggregates per-Manager counters that observe the
+// USK-998 Phase 1 (stale-conn HealthCheck + redial) and USK-999 Phase 2
+// (replay-safe retry on EPIPE) live-wire surface. Each counter is an
+// atomic.Int64 so increment-from-multiple-goroutines is safe; readers
+// use [H1UpstreamMetrics.Snapshot] which loads each field with
+// atomic.Load semantics.
+//
+// Scope: one struct instance per [Manager] (Manager-level singleton),
+// shared by every per-CONNECT [h1Chain] and every per-exchange
+// [retryingUpstreamChannel] built under that manager. Multi-listener
+// isolation is provided by Manager-per-listener — each Manager has its
+// own metrics struct, never shared across managers.
+//
+// The struct is exported (vs the internal increment methods) so the
+// production wiring (internal/mcpserver/init.go) can construct one
+// instance before NewManager and thread the same pointer into
+// [ManagerConfig.H1UpstreamMetrics] (status accessor) and
+// [Deps.H1UpstreamMetrics] (per-listener instrumentation). Increment
+// methods remain package-private — only h1Chain / retryingUpstreamChannel
+// emit.
+//
+// Counter convention: established by internal/connector/budget.go's
+// requestCount field + RequestCount() accessor. No new dependencies —
+// sync/atomic is stdlib. There is no Prometheus exporter or HTTP
+// listener in this repo; the MCP `status` resource is the single
+// surface (see CLAUDE.md and design review Q1/Q2).
+//
+// h2 parity is deferred. After h2 grows an identical-shape
+// H2UpstreamMetrics in a follow-up Issue, both can be lifted into a
+// shared internal/proxybuild/upstream_metrics.go (memory:
+// feedback_shared_seam_hardcoded_flag — don't extract shared infra at
+// N=1).
+type H1UpstreamMetrics struct {
+	// staleDetectedHealthcheck counts the number of times
+	// [h1Chain.EnsureFresh] observed a non-nil HealthCheck error and
+	// proceeded to redial. Each increment maps to one
+	// "trigger=healthcheck" stale-detection event on the wire.
+	staleDetectedHealthcheck atomic.Int64
+
+	// writeEpipe counts the number of times the retry wrapper observed
+	// a *http1.StaleUpstreamError returned from the FIRST Send on a
+	// per-exchange Channel — the race window between Phase 1's
+	// HealthCheck and the wire Write where the server FINs in flight.
+	// Every increment indicates a HealthCheck "miss" — Phase 1 cleared
+	// the conn but the peer dropped it before our bytes landed.
+	writeEpipe atomic.Int64
+
+	// redialHealthcheck counts successful redials triggered by
+	// [h1Chain.EnsureFresh] (HealthCheck err -> RedialUpstreamH1
+	// success). The post-dial Layer-append and chain.current swap
+	// happened.
+	redialHealthcheck atomic.Int64
+
+	// redialWriteEpipe counts successful redials triggered by
+	// [h1Chain.Redial] (called from the retry wrapper after observing
+	// a *http1.StaleUpstreamError on first Send). The post-dial
+	// Layer-append and chain.current swap happened.
+	redialWriteEpipe atomic.Int64
+
+	// redialFailedHealthcheck counts dial failures inside
+	// [h1Chain.EnsureFresh] (HealthCheck err -> RedialUpstreamH1
+	// returned a non-nil error). The current Layer is unchanged in
+	// this branch; the caller surfaces the dial error as
+	// state="error" on the session.
+	redialFailedHealthcheck atomic.Int64
+
+	// redialFailedWriteEpipe counts dial failures inside
+	// [h1Chain.Redial] (force-redial from the retry wrapper).
+	// Symmetric to redialFailedHealthcheck.
+	redialFailedWriteEpipe atomic.Int64
+
+	// replaySuccess counts retry wrapper replays that landed (the
+	// post-redial fresh-inner Send returned nil — the request reached
+	// the upstream on the second try).
+	replaySuccess atomic.Int64
+
+	// replayFailNonidempotent counts retries refused because
+	// [http1.StaleUpstreamError.ReplaySafe] was false at the header
+	// stage (Stage=="header") — typically a non-idempotent method
+	// (POST, PATCH) with no body buffer.
+	replayFailNonidempotent atomic.Int64
+
+	// replayFailBodyConsumed counts retries refused because
+	// [http1.StaleUpstreamError.ReplaySafe] was false at the body
+	// stage (Stage=="body") — the body has already been streamed and
+	// cannot be replayed without a buffer.
+	replayFailBodyConsumed atomic.Int64
+
+	// replayFailRedial counts retries that aborted because
+	// [h1Chain.Redial] itself returned a dial error. The original
+	// stale error is wrapped + joined for diagnostics; the
+	// post-redial Send was never attempted.
+	replayFailRedial atomic.Int64
+
+	// replayFailRedialReplay counts retries where [h1Chain.Redial]
+	// succeeded but the post-redial replay Send still returned a
+	// non-nil error (the fresh upstream broke again on the second
+	// attempt). The retry budget is consumed; no second retry.
+	replayFailRedialReplay atomic.Int64
+
+	// chainGenerationMax is the high-water mark of the redial chain
+	// depth observed across the manager's lifetime. Updated under
+	// chain.mu in [h1Chain.EnsureFresh] / [h1Chain.Redial] right after
+	// the layer-append. Never decreases — diagnostic "worst case" for
+	// upstream churn.
+	chainGenerationMax atomic.Int64
+
+	// chainGenerationLive is the sum of redial-step counts across
+	// every currently-live h1Chain. Each chain contributes the number
+	// of redial steps it has executed (chain.layers length minus the
+	// implicit initial Layer). Incremented on redial-append,
+	// decremented on [h1Chain.closeAll] (CONNECT exit). Keeps the
+	// gauge meaningful across many CONNECTs.
+	chainGenerationLive atomic.Int64
+}
+
+// NewH1UpstreamMetrics returns a fresh zero-valued counter struct.
+// Production wiring (internal/mcpserver/init.go) constructs one
+// instance and threads it into both [ManagerConfig.H1UpstreamMetrics]
+// and [Deps.H1UpstreamMetrics] so all per-listener instrumentation
+// updates a single Manager-level counter set.
+//
+// Tests that need to read counters in isolation can construct one
+// directly via &H1UpstreamMetrics{} or via this constructor — both
+// produce identically-zeroed instances.
+func NewH1UpstreamMetrics() *H1UpstreamMetrics {
+	return &H1UpstreamMetrics{}
+}
+
+// incStaleDetectedHealthcheck increments the
+// http1_upstream_stale_detected_total{trigger="healthcheck"} counter.
+// Called from [h1Chain.EnsureFresh] on HealthCheck err.
+func (m *H1UpstreamMetrics) incStaleDetectedHealthcheck() {
+	if m == nil {
+		return
+	}
+	m.staleDetectedHealthcheck.Add(1)
+}
+
+// incWriteEpipe increments the http1_upstream_write_epipe_total
+// counter. Called from [retryingUpstreamChannel.Send] when the FIRST
+// Send returns a *http1.StaleUpstreamError (race-window-after-Phase-1
+// failure).
+func (m *H1UpstreamMetrics) incWriteEpipe() {
+	if m == nil {
+		return
+	}
+	m.writeEpipe.Add(1)
+}
+
+// incRedialHealthcheck increments the
+// http1_upstream_redial_total{trigger="healthcheck"} counter on
+// successful EnsureFresh-triggered redial. Pairs with the
+// chainGenerationLive/Max gauge bump in [h1Chain.bumpGenerationLocked].
+func (m *H1UpstreamMetrics) incRedialHealthcheck() {
+	if m == nil {
+		return
+	}
+	m.redialHealthcheck.Add(1)
+}
+
+// incRedialWriteEpipe increments the
+// http1_upstream_redial_total{trigger="write_epipe"} counter on
+// successful retry-wrapper-triggered redial.
+func (m *H1UpstreamMetrics) incRedialWriteEpipe() {
+	if m == nil {
+		return
+	}
+	m.redialWriteEpipe.Add(1)
+}
+
+// incRedialFailedHealthcheck increments the
+// http1_upstream_redial_failed_total{trigger="healthcheck"} counter
+// (scope-adjustment #1) — captures EnsureFresh dial failures that the
+// retry wrapper's replay path cannot cover.
+func (m *H1UpstreamMetrics) incRedialFailedHealthcheck() {
+	if m == nil {
+		return
+	}
+	m.redialFailedHealthcheck.Add(1)
+}
+
+// incRedialFailedWriteEpipe increments the
+// http1_upstream_redial_failed_total{trigger="write_epipe"} counter
+// (scope-adjustment #1) — symmetric to incRedialFailedHealthcheck
+// for the retry wrapper's force-redial path.
+func (m *H1UpstreamMetrics) incRedialFailedWriteEpipe() {
+	if m == nil {
+		return
+	}
+	m.redialFailedWriteEpipe.Add(1)
+}
+
+// incReplaySuccess increments the
+// http1_upstream_replay_total{outcome="success"} counter on a
+// successful retry-wrapper replay.
+func (m *H1UpstreamMetrics) incReplaySuccess() {
+	if m == nil {
+		return
+	}
+	m.replaySuccess.Add(1)
+}
+
+// incReplayFailNonidempotent increments the
+// http1_upstream_replay_total{outcome="fail_nonidempotent"} counter
+// when ReplaySafe=false at the header stage.
+func (m *H1UpstreamMetrics) incReplayFailNonidempotent() {
+	if m == nil {
+		return
+	}
+	m.replayFailNonidempotent.Add(1)
+}
+
+// incReplayFailBodyConsumed increments the
+// http1_upstream_replay_total{outcome="fail_body_consumed"} counter
+// when ReplaySafe=false at the body stage.
+func (m *H1UpstreamMetrics) incReplayFailBodyConsumed() {
+	if m == nil {
+		return
+	}
+	m.replayFailBodyConsumed.Add(1)
+}
+
+// incReplayFailRedial increments the
+// http1_upstream_replay_total{outcome="fail_redial"} counter when the
+// retry-wrapper's chain.Redial itself returned a dial error.
+func (m *H1UpstreamMetrics) incReplayFailRedial() {
+	if m == nil {
+		return
+	}
+	m.replayFailRedial.Add(1)
+}
+
+// incReplayFailRedialReplay increments the
+// http1_upstream_replay_total{outcome="fail_redial_replay"} counter
+// (scope-adjustment #3) when chain.Redial succeeded but the
+// post-redial replay Send still returned an error.
+func (m *H1UpstreamMetrics) incReplayFailRedialReplay() {
+	if m == nil {
+		return
+	}
+	m.replayFailRedialReplay.Add(1)
+}
+
+// observeChainGeneration updates the chain-generation gauges after a
+// redial-append. gen is the chain's redial-step count after the
+// append (1 for the first redial, 2 for the second, etc.). Callers
+// hold chain.mu so the relative ordering of Add(+1) on live and Max
+// update is consistent within a single chain — the manager-wide
+// chainGenerationMax is read-modify-write via CAS to track the
+// process-wide high-water mark across all live chains.
+func (m *H1UpstreamMetrics) observeChainGeneration(gen int64) {
+	if m == nil {
+		return
+	}
+	m.chainGenerationLive.Add(1)
+	for {
+		cur := m.chainGenerationMax.Load()
+		if gen <= cur {
+			return
+		}
+		if m.chainGenerationMax.CompareAndSwap(cur, gen) {
+			return
+		}
+	}
+}
+
+// releaseChainGeneration drops the live gauge by gen, called from
+// [h1Chain.closeAll] at CONNECT exit. Without this, chainGenerationLive
+// would grow monotonically with every CONNECT that redialed and the
+// gauge becomes meaningless after enough churn.
+func (m *H1UpstreamMetrics) releaseChainGeneration(gen int64) {
+	if m == nil || gen <= 0 {
+		return
+	}
+	m.chainGenerationLive.Add(-gen)
+}
+
+// H1UpstreamMetricsSnapshot is the immutable read-only view returned
+// by [H1UpstreamMetrics.Snapshot] and [Manager.H1UpstreamMetrics]. JSON
+// tags mirror the MCP query(resource:"status") field names so the same
+// struct can be serialised on the MCP surface without an extra
+// conversion. Counters are int64 (Prometheus convention "total");
+// gauges are int64.
+//
+// The label-enum structure ({trigger=healthcheck|write_epipe} and
+// {outcome=success|fail_nonidempotent|fail_body_consumed|fail_redial|fail_redial_replay})
+// is expressed as named fields rather than a map so the schema is
+// statically typed and the MCP surface is stable across versions.
+type H1UpstreamMetricsSnapshot struct {
+	// StaleDetectedHealthcheck is
+	// http1_upstream_stale_detected_total{trigger="healthcheck"}.
+	StaleDetectedHealthcheck int64 `json:"stale_detected_healthcheck"`
+
+	// WriteEpipe is http1_upstream_write_epipe_total.
+	WriteEpipe int64 `json:"write_epipe"`
+
+	// RedialHealthcheck is
+	// http1_upstream_redial_total{trigger="healthcheck"}.
+	RedialHealthcheck int64 `json:"redial_healthcheck"`
+
+	// RedialWriteEpipe is
+	// http1_upstream_redial_total{trigger="write_epipe"}.
+	RedialWriteEpipe int64 `json:"redial_write_epipe"`
+
+	// RedialFailedHealthcheck is
+	// http1_upstream_redial_failed_total{trigger="healthcheck"}
+	// (scope-adjustment #1).
+	RedialFailedHealthcheck int64 `json:"redial_failed_healthcheck"`
+
+	// RedialFailedWriteEpipe is
+	// http1_upstream_redial_failed_total{trigger="write_epipe"}
+	// (scope-adjustment #1).
+	RedialFailedWriteEpipe int64 `json:"redial_failed_write_epipe"`
+
+	// ReplaySuccess is http1_upstream_replay_total{outcome="success"}.
+	ReplaySuccess int64 `json:"replay_success"`
+
+	// ReplayFailNonidempotent is
+	// http1_upstream_replay_total{outcome="fail_nonidempotent"}.
+	ReplayFailNonidempotent int64 `json:"replay_fail_nonidempotent"`
+
+	// ReplayFailBodyConsumed is
+	// http1_upstream_replay_total{outcome="fail_body_consumed"}.
+	ReplayFailBodyConsumed int64 `json:"replay_fail_body_consumed"`
+
+	// ReplayFailRedial is
+	// http1_upstream_replay_total{outcome="fail_redial"}.
+	ReplayFailRedial int64 `json:"replay_fail_redial"`
+
+	// ReplayFailRedialReplay is
+	// http1_upstream_replay_total{outcome="fail_redial_replay"}
+	// (scope-adjustment #3).
+	ReplayFailRedialReplay int64 `json:"replay_fail_redial_replay"`
+
+	// ChainGenerationMax is the all-time high-water mark of redial
+	// chain depth (CONNECT-scoped: each CONNECT's chain is reported
+	// individually, the max across CONNECTs is reported here).
+	ChainGenerationMax int64 `json:"chain_generation_max"`
+
+	// ChainGenerationLive is the current sum of redial-step counts
+	// across all live h1Chains. Decremented on CONNECT exit.
+	ChainGenerationLive int64 `json:"chain_generation_live"`
+}
+
+// Snapshot returns the current values atomically-loaded from each
+// counter. Safe to call concurrently with increments — each Load is
+// independent, so the snapshot is a "tear-able" view (no global
+// barrier across counters). This matches Prometheus scrape semantics
+// (counters are independently scraped) and the connector.BudgetManager
+// precedent. Returns the zero snapshot when m is nil.
+func (m *H1UpstreamMetrics) Snapshot() H1UpstreamMetricsSnapshot {
+	if m == nil {
+		return H1UpstreamMetricsSnapshot{}
+	}
+	return H1UpstreamMetricsSnapshot{
+		StaleDetectedHealthcheck: m.staleDetectedHealthcheck.Load(),
+		WriteEpipe:               m.writeEpipe.Load(),
+		RedialHealthcheck:        m.redialHealthcheck.Load(),
+		RedialWriteEpipe:         m.redialWriteEpipe.Load(),
+		RedialFailedHealthcheck:  m.redialFailedHealthcheck.Load(),
+		RedialFailedWriteEpipe:   m.redialFailedWriteEpipe.Load(),
+		ReplaySuccess:            m.replaySuccess.Load(),
+		ReplayFailNonidempotent:  m.replayFailNonidempotent.Load(),
+		ReplayFailBodyConsumed:   m.replayFailBodyConsumed.Load(),
+		ReplayFailRedial:         m.replayFailRedial.Load(),
+		ReplayFailRedialReplay:   m.replayFailRedialReplay.Load(),
+		ChainGenerationMax:       m.chainGenerationMax.Load(),
+		ChainGenerationLive:      m.chainGenerationLive.Load(),
+	}
+}

--- a/internal/proxybuild/h1_metrics_test.go
+++ b/internal/proxybuild/h1_metrics_test.go
@@ -1,0 +1,479 @@
+package proxybuild
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
+)
+
+// h1MetricsStub is a layer.Channel test double that returns a caller-
+// configured error from Send and io.EOF from Next. Used by the metrics
+// unit tests so each emit point can be exercised in isolation without
+// staging a real TLS handshake.
+type h1MetricsStub struct {
+	mu      sync.Mutex
+	sendErr error
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func (s *h1MetricsStub) StreamID() string { return "stub" }
+func (s *h1MetricsStub) Next(_ context.Context) (*envelope.Envelope, error) {
+	return nil, io.EOF
+}
+func (s *h1MetricsStub) Send(_ context.Context, _ *envelope.Envelope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendErr
+}
+func (s *h1MetricsStub) Close() error {
+	s.once.Do(func() {
+		s.closed = make(chan struct{})
+		close(s.closed)
+	})
+	return nil
+}
+func (s *h1MetricsStub) Closed() <-chan struct{} {
+	s.once.Do(func() {
+		s.closed = make(chan struct{})
+	})
+	return s.closed
+}
+func (s *h1MetricsStub) Err() error { return io.EOF }
+
+func newSendEnv() *envelope.Envelope {
+	return &envelope.Envelope{
+		Protocol:  envelope.ProtocolHTTP,
+		Direction: envelope.Send,
+		Message:   &envelope.HTTPMessage{Method: "GET", Path: "/", Authority: "example.com"},
+	}
+}
+
+// TestH1Metrics_NewIsZero asserts a fresh counter set returns the
+// zero snapshot.
+func TestH1Metrics_NewIsZero(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+	snap := m.Snapshot()
+	if snap != (H1UpstreamMetricsSnapshot{}) {
+		t.Errorf("NewH1UpstreamMetrics: snapshot = %+v, want zero", snap)
+	}
+}
+
+// TestH1Metrics_NilSafe asserts every emit method short-circuits on
+// a nil receiver. Production callers do not check for nil — the
+// emit-site doc-comment promises nil-safety.
+func TestH1Metrics_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *H1UpstreamMetrics // nil pointer
+	// All emit methods must not panic on nil. Snapshot returns the
+	// zero value.
+	m.incStaleDetectedHealthcheck()
+	m.incWriteEpipe()
+	m.incRedialHealthcheck()
+	m.incRedialWriteEpipe()
+	m.incRedialFailedHealthcheck()
+	m.incRedialFailedWriteEpipe()
+	m.incReplaySuccess()
+	m.incReplayFailNonidempotent()
+	m.incReplayFailBodyConsumed()
+	m.incReplayFailRedial()
+	m.incReplayFailRedialReplay()
+	m.observeChainGeneration(5)
+	m.releaseChainGeneration(5)
+	snap := m.Snapshot()
+	if snap != (H1UpstreamMetricsSnapshot{}) {
+		t.Errorf("nil-receiver Snapshot: %+v, want zero", snap)
+	}
+}
+
+// TestH1Metrics_DirectIncrements asserts each emit helper increments
+// the corresponding atomic.Int64 exactly once. This pins the
+// 1:1-emit-to-counter mapping the design review schema documents.
+func TestH1Metrics_DirectIncrements(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		emit func(*H1UpstreamMetrics)
+		want func(H1UpstreamMetricsSnapshot) int64
+	}{
+		{
+			name: "stale_detected_healthcheck",
+			emit: (*H1UpstreamMetrics).incStaleDetectedHealthcheck,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.StaleDetectedHealthcheck },
+		},
+		{
+			name: "write_epipe",
+			emit: (*H1UpstreamMetrics).incWriteEpipe,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.WriteEpipe },
+		},
+		{
+			name: "redial_healthcheck",
+			emit: (*H1UpstreamMetrics).incRedialHealthcheck,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.RedialHealthcheck },
+		},
+		{
+			name: "redial_write_epipe",
+			emit: (*H1UpstreamMetrics).incRedialWriteEpipe,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.RedialWriteEpipe },
+		},
+		{
+			name: "redial_failed_healthcheck",
+			emit: (*H1UpstreamMetrics).incRedialFailedHealthcheck,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.RedialFailedHealthcheck },
+		},
+		{
+			name: "redial_failed_write_epipe",
+			emit: (*H1UpstreamMetrics).incRedialFailedWriteEpipe,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.RedialFailedWriteEpipe },
+		},
+		{
+			name: "replay_success",
+			emit: (*H1UpstreamMetrics).incReplaySuccess,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.ReplaySuccess },
+		},
+		{
+			name: "replay_fail_nonidempotent",
+			emit: (*H1UpstreamMetrics).incReplayFailNonidempotent,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.ReplayFailNonidempotent },
+		},
+		{
+			name: "replay_fail_body_consumed",
+			emit: (*H1UpstreamMetrics).incReplayFailBodyConsumed,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.ReplayFailBodyConsumed },
+		},
+		{
+			name: "replay_fail_redial",
+			emit: (*H1UpstreamMetrics).incReplayFailRedial,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.ReplayFailRedial },
+		},
+		{
+			name: "replay_fail_redial_replay",
+			emit: (*H1UpstreamMetrics).incReplayFailRedialReplay,
+			want: func(s H1UpstreamMetricsSnapshot) int64 { return s.ReplayFailRedialReplay },
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewH1UpstreamMetrics()
+			tc.emit(m)
+			tc.emit(m)
+			snap := m.Snapshot()
+			if got := tc.want(snap); got != 2 {
+				t.Errorf("%s after 2 increments = %d, want 2", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestH1Metrics_ChainGeneration asserts the gauge family: observe
+// increments Live and updates Max; release decrements Live but does
+// not touch Max. Max records the high-water mark across the lifetime.
+func TestH1Metrics_ChainGeneration(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+
+	// First chain redials twice -> generations 1, 2.
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 2 || snap.ChainGenerationMax != 2 {
+		t.Errorf("after 2 observes (1,2): live=%d max=%d, want live=2 max=2",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// Second chain redials thrice -> generations 1, 2, 3.
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	m.observeChainGeneration(3)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 5 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after second chain (1,2,3): live=%d max=%d, want live=5 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// First chain closes (released gen=2). Live drops by 2; max
+	// stays at 3.
+	m.releaseChainGeneration(2)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 3 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after release(2): live=%d max=%d, want live=3 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// Second chain closes (released gen=3). Live -> 0, max stays.
+	m.releaseChainGeneration(3)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 0 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after release(3): live=%d max=%d, want live=0 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// release(0) is a no-op.
+	m.releaseChainGeneration(0)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 0 {
+		t.Errorf("release(0): live=%d, want 0", snap.ChainGenerationLive)
+	}
+}
+
+// TestH1Retry_Metrics_WriteEpipe_NonReplaySafe_Header asserts the
+// retry wrapper increments writeEpipe + replayFailNonidempotent when
+// the inner returns a header-stage non-replay-safe stale error
+// (typically POST). The wrapper must NOT call chain.Redial.
+func TestH1Retry_Metrics_WriteEpipe_NonReplaySafe_Header(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+	chain := &h1Chain{metrics: m} // dummy chain — Redial must not fire
+	stale := &http1.StaleUpstreamError{
+		Underlying: syscall.EPIPE,
+		ReplaySafe: false,
+		Stage:      "header",
+	}
+	stub := &h1MetricsStub{sendErr: stale}
+	wrapper := newRetryingUpstreamChannel(stub, chain, func(c layer.Channel) layer.Channel { return c },
+		discardLogger(), "127.0.0.1:0", m)
+
+	err := wrapper.Send(context.Background(), newSendEnv())
+	if err == nil {
+		t.Fatal("Send: got nil, want StaleUpstreamError surfaced")
+	}
+	snap := m.Snapshot()
+	if snap.WriteEpipe != 1 {
+		t.Errorf("write_epipe = %d, want 1", snap.WriteEpipe)
+	}
+	if snap.ReplayFailNonidempotent != 1 {
+		t.Errorf("replay_fail_nonidempotent = %d, want 1", snap.ReplayFailNonidempotent)
+	}
+	// No redial was attempted -> no redial counters fired.
+	if snap.RedialHealthcheck != 0 || snap.RedialWriteEpipe != 0 ||
+		snap.RedialFailedHealthcheck != 0 || snap.RedialFailedWriteEpipe != 0 {
+		t.Errorf("non-replay-safe path should not increment redial counters; got snap=%+v", snap)
+	}
+	if snap.ReplaySuccess != 0 {
+		t.Errorf("replay_success = %d, want 0", snap.ReplaySuccess)
+	}
+}
+
+// TestH1Retry_Metrics_WriteEpipe_NonReplaySafe_Body asserts the
+// body-stage non-replay-safe path increments replayFailBodyConsumed
+// (a body already streamed cannot be replayed).
+func TestH1Retry_Metrics_WriteEpipe_NonReplaySafe_Body(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+	chain := &h1Chain{metrics: m}
+	stale := &http1.StaleUpstreamError{
+		Underlying: syscall.EPIPE,
+		ReplaySafe: false,
+		Stage:      "body",
+	}
+	stub := &h1MetricsStub{sendErr: stale}
+	wrapper := newRetryingUpstreamChannel(stub, chain, func(c layer.Channel) layer.Channel { return c },
+		discardLogger(), "127.0.0.1:0", m)
+
+	err := wrapper.Send(context.Background(), newSendEnv())
+	if err == nil {
+		t.Fatal("Send: got nil, want StaleUpstreamError surfaced")
+	}
+	snap := m.Snapshot()
+	if snap.WriteEpipe != 1 {
+		t.Errorf("write_epipe = %d, want 1", snap.WriteEpipe)
+	}
+	if snap.ReplayFailBodyConsumed != 1 {
+		t.Errorf("replay_fail_body_consumed = %d, want 1", snap.ReplayFailBodyConsumed)
+	}
+	if snap.ReplayFailNonidempotent != 0 {
+		t.Errorf("replay_fail_nonidempotent = %d, want 0 (Stage=body should NOT count as header)",
+			snap.ReplayFailNonidempotent)
+	}
+}
+
+// TestH1Retry_Metrics_NonStaleError_NoCount asserts that a non-stale
+// error from the inner does NOT increment any retry counter. The
+// wrapper surfaces the error verbatim; no replay decision is made.
+func TestH1Retry_Metrics_NonStaleError_NoCount(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+	chain := &h1Chain{metrics: m}
+	stub := &h1MetricsStub{sendErr: errors.New("synthetic-non-stale")}
+	wrapper := newRetryingUpstreamChannel(stub, chain, func(c layer.Channel) layer.Channel { return c },
+		discardLogger(), "127.0.0.1:0", m)
+
+	err := wrapper.Send(context.Background(), newSendEnv())
+	if err == nil {
+		t.Fatal("Send: got nil, want synthetic error")
+	}
+	snap := m.Snapshot()
+	if snap != (H1UpstreamMetricsSnapshot{}) {
+		t.Errorf("non-stale error should not increment any counter; got snap=%+v", snap)
+	}
+}
+
+// TestH1Retry_Metrics_BudgetExhausted asserts a SECOND retry attempt
+// (after the first replay consumed the one-shot budget) does NOT
+// increment write_epipe or any redial counter. The first attempt
+// already fired all the counters; the second is surfaced verbatim.
+//
+// We force the budget consumed by pre-setting wrapper.retried, then
+// drive a fresh ReplaySafe=true stale error and assert the wrapper
+// returns it verbatim without further counter activity.
+func TestH1Retry_Metrics_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+	m := NewH1UpstreamMetrics()
+	chain := &h1Chain{metrics: m}
+	stale := &http1.StaleUpstreamError{
+		Underlying: syscall.EPIPE,
+		ReplaySafe: true,
+		Stage:      "header",
+	}
+	stub := &h1MetricsStub{sendErr: stale}
+	wrapper := newRetryingUpstreamChannel(stub, chain, func(c layer.Channel) layer.Channel { return c },
+		discardLogger(), "127.0.0.1:0", m)
+	// Consume the budget.
+	wrapper.retried.Store(true)
+
+	err := wrapper.Send(context.Background(), newSendEnv())
+	if err == nil {
+		t.Fatal("Send: got nil, want stale verbatim after budget exhaustion")
+	}
+	snap := m.Snapshot()
+	// write_epipe still fires (it counts every observed stale, not
+	// every "retry attempted"). But redial/replay-success counters
+	// stay zero — the budget gate short-circuited before any redial
+	// or replay attempt.
+	if snap.WriteEpipe != 1 {
+		t.Errorf("write_epipe = %d, want 1 (every stale is observed)", snap.WriteEpipe)
+	}
+	if snap.RedialWriteEpipe != 0 {
+		t.Errorf("redial_write_epipe = %d, want 0 (budget consumed before Redial)",
+			snap.RedialWriteEpipe)
+	}
+	if snap.ReplaySuccess != 0 || snap.ReplayFailRedial != 0 || snap.ReplayFailRedialReplay != 0 {
+		t.Errorf("replay counters fired after budget exhaustion: %+v", snap)
+	}
+}
+
+// TestH1Chain_Metrics_HealthcheckPass asserts the happy-path
+// EnsureFresh (HealthCheck nil) increments NO counters.
+func TestH1Chain_Metrics_HealthcheckPass(t *testing.T) {
+	t.Parallel()
+	_, server := testTCPPair(t)
+	defer server.Close()
+
+	initial := http1.New(server, "stream-pass", envelope.Receive)
+	defer initial.Close()
+
+	m := NewH1UpstreamMetrics()
+	chain := newH1Chain(initial, "example.com:443", nil, discardLogger(), m)
+	defer chain.closeAll()
+
+	got, err := chain.EnsureFresh(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if got != initial {
+		t.Errorf("EnsureFresh returned a new Layer on alive conn")
+	}
+	if snap := m.Snapshot(); snap != (H1UpstreamMetricsSnapshot{}) {
+		t.Errorf("alive-conn EnsureFresh should not increment counters; snap=%+v", snap)
+	}
+}
+
+// TestH1Chain_Metrics_EnsureFreshDialFail asserts that when the
+// current Layer is stale AND the dial cannot succeed (nil cfg +
+// invalid target), the stale_detected and redial_failed counters
+// both fire. The stale Layer is NOT closed in this branch — the
+// next EnsureFresh retries cleanly.
+func TestH1Chain_Metrics_EnsureFreshDialFail(t *testing.T) {
+	t.Parallel()
+	client, server := testTCPPair(t)
+
+	initial := http1.New(server, "stream-fail", envelope.Receive)
+	defer initial.Close()
+
+	// Close peer so HealthCheck observes stale.
+	_ = client.Close()
+
+	m := NewH1UpstreamMetrics()
+	chain := newH1Chain(initial, "127.0.0.1:1", nil, discardLogger(), m) // nil cfg trips defensive guard
+	defer chain.closeAll()
+
+	// Poll until HealthCheck flips to stale.
+	var err error
+	for i := 0; i < 200; i++ {
+		_, err = chain.EnsureFresh(context.Background())
+		if err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatal("EnsureFresh on stale + nil-cfg: never observed dial failure")
+	}
+	snap := m.Snapshot()
+	if snap.StaleDetectedHealthcheck < 1 {
+		t.Errorf("stale_detected_healthcheck = %d, want >= 1", snap.StaleDetectedHealthcheck)
+	}
+	if snap.RedialFailedHealthcheck < 1 {
+		t.Errorf("redial_failed_healthcheck = %d, want >= 1", snap.RedialFailedHealthcheck)
+	}
+	// Successful redial did NOT fire.
+	if snap.RedialHealthcheck != 0 {
+		t.Errorf("redial_healthcheck = %d, want 0 on dial-failure path", snap.RedialHealthcheck)
+	}
+}
+
+// TestH1Chain_Metrics_CloseAllReleasesGauge asserts closeAll
+// decrements chainGenerationLive by this chain's contribution but
+// leaves chainGenerationMax intact. Multi-chain scoping is exercised
+// by manually injecting a second chain's contribution into the same
+// metrics struct.
+func TestH1Chain_Metrics_CloseAllReleasesGauge(t *testing.T) {
+	t.Parallel()
+	_, server := testTCPPair(t)
+
+	initial := http1.New(server, "stream-close-gauge", envelope.Receive)
+	// Don't defer initial.Close() — chain.closeAll handles it.
+
+	m := NewH1UpstreamMetrics()
+	chain := newH1Chain(initial, "example.com:443", nil, discardLogger(), m)
+
+	// Simulate 2 successful redials by directly bumping the gauge
+	// under c.mu (avoids needing a working dial).
+	chain.mu.Lock()
+	chain.liveGen = 2
+	chain.mu.Unlock()
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	// Add a second chain's contribution to verify isolation.
+	m.observeChainGeneration(1)
+
+	beforeMax := m.Snapshot().ChainGenerationMax
+	beforeLive := m.Snapshot().ChainGenerationLive
+	if beforeLive != 3 || beforeMax != 2 {
+		t.Fatalf("setup: live=%d max=%d, want live=3 max=2", beforeLive, beforeMax)
+	}
+
+	chain.closeAll()
+
+	snap := m.Snapshot()
+	if snap.ChainGenerationLive != 1 {
+		t.Errorf("closeAll: live=%d, want 1 (second chain's contribution remains)",
+			snap.ChainGenerationLive)
+	}
+	if snap.ChainGenerationMax != 2 {
+		t.Errorf("closeAll: max=%d, want 2 (Max never decreases)", snap.ChainGenerationMax)
+	}
+}
+
+// discardLogger returns a slog.Logger that drops every record so unit
+// tests don't spew metrics-emit logs into the test output. The same
+// pattern is used by other proxybuild unit tests that exercise
+// Debug/Warn paths.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/proxybuild/h1_replay_retry_integration_test.go
+++ b/internal/proxybuild/h1_replay_retry_integration_test.go
@@ -130,6 +130,21 @@ func (s *dummyUpstreamServer) handle(c net.Conn) {
 // then dials a fresh HTTP/1.1 conn to s.addr through RedialUpstreamH1.
 func buildFlakyChain(t *testing.T, s *dummyUpstreamServer, failCount int32) (*h1Chain, *http1.Layer, *flakyConn) {
 	t.Helper()
+	return buildFlakyChainWithMetrics(t, s, failCount, nil)
+}
+
+// buildFlakyChainWithMetrics is the metrics-aware form: callers
+// supplying a non-nil [H1UpstreamMetrics] can read counter values
+// after the retry path runs to assert end-to-end instrumentation.
+// Tests that don't care about counters use [buildFlakyChain] which
+// delegates here with nil.
+func buildFlakyChainWithMetrics(
+	t *testing.T,
+	s *dummyUpstreamServer,
+	failCount int32,
+	metrics *H1UpstreamMetrics,
+) (*h1Chain, *http1.Layer, *flakyConn) {
+	t.Helper()
 	// Dial the upstream once via raw TCP and wrap with flakyConn.
 	rawConn, err := net.Dial("tcp", s.addr)
 	if err != nil {
@@ -150,7 +165,7 @@ func buildFlakyChain(t *testing.T, s *dummyUpstreamServer, failCount int32) (*h1
 	// CONNECT-MITM shape.
 	cfg := &connector.BuildConfig{InsecureSkipVerify: true}
 
-	chain := newH1Chain(initial, s.addr, cfg)
+	chain := newH1Chain(initial, s.addr, cfg, nil, metrics)
 	t.Cleanup(func() { chain.closeAll() })
 
 	return chain, initial, flaky
@@ -217,7 +232,7 @@ func TestHTTP1_StaleConn_GET_RetryPath(t *testing.T) {
 		t.Fatal("OpenExchange returned nil")
 	}
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	if err := sendOneRequest(t, wrapper, "GET", "/replayed", nil, false); err != nil {
 		t.Fatalf("Send (GET, expected retry-success): %v", err)
@@ -241,6 +256,58 @@ func TestHTTP1_StaleConn_GET_RetryPath(t *testing.T) {
 	}
 }
 
+// TestHTTP1_StaleConn_GET_RetryPath_Metrics is the USK-1000 mirror of
+// TestHTTP1_StaleConn_GET_RetryPath: same retry-path-success scenario
+// but with a non-nil [H1UpstreamMetrics] threaded through the chain
+// and wrapper so the counter snapshot can be asserted end-to-end.
+// Pins the chain→retry→success counter triplet
+// (write_epipe + redial_write_epipe + replay_success).
+func TestHTTP1_StaleConn_GET_RetryPath_Metrics(t *testing.T) {
+	s := startDummyUpstream(t)
+
+	metrics := NewH1UpstreamMetrics()
+	chain, _, _ := buildFlakyChainWithMetrics(t, s, 1, metrics)
+
+	upCh := chain.current.OpenExchange()
+	if upCh == nil {
+		t.Fatal("OpenExchange returned nil")
+	}
+	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, metrics)
+
+	if err := sendOneRequest(t, wrapper, "GET", "/metric-replayed", nil, false); err != nil {
+		t.Fatalf("Send (GET, expected retry-success): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := wrapper.Next(ctx); err != nil {
+		t.Fatalf("Next after retry: %v", err)
+	}
+
+	snap := metrics.Snapshot()
+	if snap.WriteEpipe != 1 {
+		t.Errorf("write_epipe = %d, want 1", snap.WriteEpipe)
+	}
+	if snap.RedialWriteEpipe != 1 {
+		t.Errorf("redial_write_epipe = %d, want 1", snap.RedialWriteEpipe)
+	}
+	if snap.ReplaySuccess != 1 {
+		t.Errorf("replay_success = %d, want 1", snap.ReplaySuccess)
+	}
+	// The healthcheck-triggered path did NOT fire on this exchange
+	// (the wrapper used force-redial after EPIPE).
+	if snap.StaleDetectedHealthcheck != 0 || snap.RedialHealthcheck != 0 {
+		t.Errorf("healthcheck-trigger counters fired unexpectedly: %+v", snap)
+	}
+	if snap.ChainGenerationMax != 1 {
+		t.Errorf("chain_generation_max = %d, want 1 (one redial step)", snap.ChainGenerationMax)
+	}
+	if snap.ChainGenerationLive != 1 {
+		t.Errorf("chain_generation_live = %d, want 1 (chain still open)", snap.ChainGenerationLive)
+	}
+}
+
 // TestHTTP1_StaleConn_POST_NoRetry: POST → first Write EPIPE → wrapper
 // observes ReplaySafe=false → returns the StaleUpstreamError to the
 // caller. No retry, no chain.Redial.
@@ -254,7 +321,7 @@ func TestHTTP1_StaleConn_POST_NoRetry(t *testing.T) {
 		t.Fatal("OpenExchange returned nil")
 	}
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	err := sendOneRequest(t, wrapper, "POST", "/no-replay", []byte("payload"), false)
 	if err == nil {
@@ -285,7 +352,7 @@ func TestHTTP1_StaleConn_PUT_WithBuffer_Retry(t *testing.T) {
 		t.Fatal("OpenExchange returned nil")
 	}
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	if err := sendOneRequest(t, wrapper, "PUT", "/put-replay", []byte("put-payload"), true); err != nil {
 		t.Fatalf("Send (PUT with buffered body, expected retry-success): %v", err)
@@ -319,7 +386,7 @@ func TestHTTP1_NoEnvelopeLossOnRetry(t *testing.T) {
 		t.Fatal("OpenExchange returned nil")
 	}
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	if err := sendOneRequest(t, wrapper, "GET", "/observable", nil, false); err != nil {
 		t.Fatalf("Send (GET): %v", err)
@@ -364,7 +431,7 @@ func TestHTTP1_StaleConn_RetryBudgetOneShot(t *testing.T) {
 		t.Fatal("OpenExchange returned nil")
 	}
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	// First Send: GET → EPIPE → retry → succeed.
 	if err := sendOneRequest(t, wrapper, "GET", "/first", nil, false); err != nil {
@@ -419,7 +486,7 @@ func TestHTTP1_StaleConn_NonReplaySafe_ReturnsErrorVerbatim(t *testing.T) {
 
 	upCh := chain.current.OpenExchange()
 	dispatchWrap := func(ch layer.Channel) layer.Channel { return ch }
-	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr)
+	wrapper := newRetryingUpstreamChannel(dispatchWrap(upCh), chain, dispatchWrap, slog.Default(), s.addr, nil)
 
 	err := sendOneRequest(t, wrapper, "POST", "/no-retry", []byte("p"), false)
 	if err == nil {
@@ -458,6 +525,7 @@ func TestHTTP1_FlakyConn_NonStaleErrorNotRetried(t *testing.T) {
 		func(ch layer.Channel) layer.Channel { return ch },
 		slog.Default(),
 		"127.0.0.1:0",
+		nil,
 	)
 
 	msg := &envelope.HTTPMessage{Method: "GET", Path: "/", Authority: "example.com"}

--- a/internal/proxybuild/h1_retry.go
+++ b/internal/proxybuild/h1_retry.go
@@ -56,6 +56,12 @@ type retryingUpstreamChannel struct {
 	retried atomic.Bool
 	logger  *slog.Logger
 	target  string
+
+	// metrics (USK-1000) is the Manager-level h1UpstreamMetrics shared
+	// across every per-CONNECT chain and every per-exchange retry
+	// wrapper built under the same Manager. May be nil — every counter
+	// call is nil-safe.
+	metrics *H1UpstreamMetrics
 }
 
 // newRetryingUpstreamChannel constructs the wrapper around an already-
@@ -65,18 +71,25 @@ type retryingUpstreamChannel struct {
 // SAME dispatch closure (typically `connector.WrapH1UpstreamForDispatch(_,
 // reqProto, streamGRPCWebOpts)`) so the retry leg is dispatched
 // identically.
+//
+// USK-1000: metrics is the Manager-level h1UpstreamMetrics. nil is
+// safe — every counter call is nil-safe — but production callers
+// thread the same pointer through every retry wrapper so the counters
+// aggregate across exchanges.
 func newRetryingUpstreamChannel(
 	inner layer.Channel,
 	chain *h1Chain,
 	wrapper func(layer.Channel) layer.Channel,
 	logger *slog.Logger,
 	target string,
+	metrics *H1UpstreamMetrics,
 ) *retryingUpstreamChannel {
 	r := &retryingUpstreamChannel{
 		chain:   chain,
 		wrapper: wrapper,
 		logger:  logger,
 		target:  target,
+		metrics: metrics,
 	}
 	r.inner.Store(&inner)
 	return r
@@ -119,7 +132,28 @@ func (r *retryingUpstreamChannel) Send(ctx context.Context, env *envelope.Envelo
 	}
 
 	var stale *http1.StaleUpstreamError
-	if !errors.As(err, &stale) || !stale.ReplaySafe {
+	if !errors.As(err, &stale) {
+		return err
+	}
+	// USK-1000: every observed stale Send (regardless of ReplaySafe)
+	// is a HealthCheck race-window miss. Count first so the
+	// fail_nonidempotent / fail_body_consumed counters below stay a
+	// strict subset (caller can verify: write_epipe >= replay_fail_*).
+	r.metrics.incWriteEpipe()
+
+	if !stale.ReplaySafe {
+		// Phase 2's truth-table refuses replay; classify by stage so
+		// operators can tell non-idempotent (header) apart from
+		// body-already-consumed (body). The Stage values are pinned
+		// by internal/layer/http1/replay_safe_test.go.
+		switch stale.Stage {
+		case "body":
+			r.metrics.incReplayFailBodyConsumed()
+		default:
+			// "header" — and any future Stage values default here
+			// rather than silently skipping the counter.
+			r.metrics.incReplayFailNonidempotent()
+		}
 		return err
 	}
 	// Budget claim. CompareAndSwap is the single source of truth for the
@@ -134,6 +168,10 @@ func (r *retryingUpstreamChannel) Send(ctx context.Context, env *envelope.Envelo
 
 	freshLayer, derr := r.chain.Redial(ctx)
 	if derr != nil {
+		// USK-1000: chain.Redial dial-failure path. incRedialFailedWriteEpipe
+		// already fired inside h1Chain.Redial; we additionally count the
+		// retry-wrapper-observable "could not redial" outcome.
+		r.metrics.incReplayFailRedial()
 		// Surface the original stale error AND the dial error so callers
 		// using errors.As(_, &*http1.StaleUpstreamError{}) can still
 		// reach the original Stage/ReplaySafe diagnostic. errors.Join
@@ -144,6 +182,7 @@ func (r *retryingUpstreamChannel) Send(ctx context.Context, env *envelope.Envelo
 
 	freshCh := freshLayer.OpenExchange()
 	if freshCh == nil {
+		r.metrics.incReplayFailRedialReplay()
 		return fmt.Errorf("http1: stale-conn replay: fresh layer closed before OpenExchange: %w", err)
 	}
 
@@ -158,10 +197,19 @@ func (r *retryingUpstreamChannel) Send(ctx context.Context, env *envelope.Envelo
 	// Write (sendRequest holds writeMu). On a second EPIPE the wrapper
 	// returns it verbatim — budget already consumed.
 	if rerr := wrapped.Send(ctx, env); rerr != nil {
-		r.logger.Debug("proxybuild: http1 stale-conn replay failed",
+		// USK-1000 (scope-adjustment #3): the post-redial Send still
+		// errored — distinct outcome from "could not redial".
+		r.metrics.incReplayFailRedialReplay()
+		// Per CLAUDE.md Log Level Guidelines a replay-failure is a
+		// retry-attempt that didn't help — Warn so operators see it
+		// (matches h2's "upstream h2 redial failed" Warn precedent).
+		r.logger.Warn("proxybuild: http1 stale-conn replay failed",
 			"target", r.target, "original_stage", stale.Stage, "replay_error", rerr)
 		return rerr
 	}
+	r.metrics.incReplaySuccess()
+	r.logger.Debug("proxybuild: http1 stale-conn replay succeeded",
+		"target", r.target, "original_stage", stale.Stage)
 	return nil
 }
 

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -69,6 +69,16 @@ type ManagerConfig struct {
 	// historical pre-USK-734 behaviour, retained for tests and adapters
 	// that do not own the live BuildConfig).
 	BuildConfig *connector.BuildConfig
+
+	// H1UpstreamMetrics is the Manager-level USK-1000 counter set.
+	// When non-nil, [Manager.H1UpstreamMetrics] returns a snapshot of
+	// these counters; production wiring threads the SAME pointer into
+	// every [Deps.H1UpstreamMetrics] so all per-CONNECT chains emit
+	// into the same struct. nil constructs a fresh empty counter set
+	// inside NewManager — callers that omit the field still get a
+	// working snapshot accessor; they just won't see counters from any
+	// listener built via a Deps that omitted the matching field.
+	H1UpstreamMetrics *H1UpstreamMetrics
 }
 
 // Manager orchestrates one or more named live Stacks. It exposes
@@ -111,6 +121,18 @@ type Manager struct {
 
 	mu        sync.Mutex
 	listeners map[string]*listenerEntry
+
+	// h1Upstream collects USK-998 Phase 1 + USK-999 Phase 2 + USK-1000
+	// observability counters for the HTTP/1.x upstream redial / replay
+	// surface. One struct per Manager (each Manager has its own;
+	// multi-listener isolation is provided by Manager-per-listener).
+	// The pointer is threaded through every per-CONNECT h1Chain and
+	// per-exchange retryingUpstreamChannel via the Deps that
+	// BuildLiveStack consumes, so counter updates aggregate across
+	// every CONNECT under this Manager. See
+	// [Manager.H1UpstreamMetrics] for the snapshot accessor and
+	// internal/proxybuild/h1_metrics.go for the schema.
+	h1Upstream *H1UpstreamMetrics
 }
 
 // upstreamProxyRotationEntry pairs the operator-supplied template
@@ -134,12 +156,43 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// USK-1000: prefer the operator-supplied counter pointer so it can
+	// be shared with Deps.H1UpstreamMetrics; fall back to a fresh
+	// empty set when omitted (tests that don't care about counters
+	// still get a working snapshot accessor).
+	h1Metrics := cfg.H1UpstreamMetrics
+	if h1Metrics == nil {
+		h1Metrics = NewH1UpstreamMetrics()
+	}
 	return &Manager{
-		logger:    logger,
-		factory:   cfg.StackFactory,
-		buildCfg:  cfg.BuildConfig,
-		listeners: make(map[string]*listenerEntry),
+		logger:     logger,
+		factory:    cfg.StackFactory,
+		buildCfg:   cfg.BuildConfig,
+		listeners:  make(map[string]*listenerEntry),
+		h1Upstream: h1Metrics,
 	}, nil
+}
+
+// H1UpstreamMetrics returns a snapshot of the USK-998 / USK-999 /
+// USK-1000 HTTP/1.x upstream redial counters maintained under this
+// Manager. The snapshot is a value type so callers may retain it
+// safely; subsequent increments do not back-mutate the returned
+// struct.
+//
+// The MCP query(resource:"status") tool surfaces these counters to
+// AI agents under the `h1_upstream` field. The counter set matches
+// the design review schema (5 counters + 6th redial_failed counter
+// from scope-adjustment #1 + replay outcome split from
+// scope-adjustment #3 + chain_generation gauge family).
+//
+// h2-parity counters are tracked in a follow-up Issue per memory
+// `feedback_shared_seam_hardcoded_flag` — once both protocols have
+// counters in this shape, both can move to a shared file.
+func (m *Manager) H1UpstreamMetrics() H1UpstreamMetricsSnapshot {
+	// h1Upstream is set at construction by NewManager and never
+	// reassigned, so a lock is unnecessary for the pointer read. The
+	// snapshot itself uses atomic Loads inside.
+	return m.h1Upstream.Snapshot()
 }
 
 // Start is shorthand for StartNamed(ctx, DefaultListenerName, listenAddr).


### PR DESCRIPTION
## Summary
- Add `H1UpstreamMetrics` (`internal/proxybuild/h1_metrics.go`) — atomic.Int64 counters + per-chain `chain_generation` gauge family. No new deps; sync/atomic stdlib only.
- Instrument `h1Chain.EnsureFresh` / `h1Chain.Redial` / `h1Chain.closeAll` / `retryingUpstreamChannel.Send` per the design-review emit-point map. Counter set covers all 5 metrics in the Issue + 6th `redial_failed{trigger=...}` from scope-adjustment #1 + `replay{outcome=fail_redial_replay}` split from scope-adjustment #3.
- Surface via MCP `query(resource:"status")` — new `H1Upstream` `*H1UpstreamMetricsSnapshot` sub-struct on `queryStatusResult`. Per-listener exposure stays at the Manager level (single counter set shared across listeners, mirroring how budget counters are surfaced).
- Adjust slog levels per CLAUDE.md — Debug for stale-detect/redial-success/replay-success; Warn for redial-failure/replay-failure (matches h2's existing `proxybuild: upstream h2 redial failed` Warn at builder.go:1447).

**Scope adjustments adopted from Phase 1.5 design review** (justified in commit body):
1. Added 6th counter `redial_failed{trigger=...}` covering `EnsureFresh`/`Redial` dial-failure paths the replay outcome cannot catch.
2. Replaced "grafana / ダッシュボードへの追加" criterion with MCP `query(resource:"status")` assertion test — no grafana exists in this repo.
3. Split `replay{outcome="fail_redial"}` into `fail_redial` (dial err) and `fail_redial_replay` (post-redial Send err) — two distinct failure sites in the code.

h2 counter parity is **deferred to a follow-up Issue** per memory `feedback_shared_seam_hardcoded_flag` — h2 today has only per-event slog (builder.go:1297/1316/1447/1459). Once h2 has its own counters in identical shape, both can move to a shared `internal/proxybuild/upstream_metrics.go`. This PR establishes the convention.

## Test plan
- [x] `make lint` clean
- [x] `make build` succeeds
- [x] `make test` passes (fast tier, including new `TestH1Metrics_*` / `TestH1Retry_Metrics_*` / `TestH1Chain_Metrics_*` / `TestQuery_Status_H1UpstreamMetrics_*` tests)
- [x] `make test-e2e-smoke` passes
- [x] Unit: each emit point increments the correct counter — table-driven `TestH1Metrics_DirectIncrements` covers all 11 counter helpers + `TestH1Metrics_ChainGeneration` covers the gauge family with 2-chain isolation
- [x] Unit: `chain_generation` gauge bumps on Redial-append (observeChainGeneration) and decrements on closeAll (releaseChainGeneration); Max never decreases
- [x] Unit: `query(resource:"status")` returns `H1Upstream` sub-struct with the documented schema; nil when no Manager bound (omitempty), zero-valued when Manager bound but no churn
- [x] Integration (`//go:build e2e && !e2e_smoke`): existing USK-999 retry tests still pass; new `TestHTTP1_StaleConn_GET_RetryPath_Metrics` asserts write_epipe + redial_write_epipe + replay_success + chain_generation counters end-to-end through a real flakyConn → RedialUpstreamH1 → fresh upstream path
- [x] Nil-safety: `TestH1Metrics_NilSafe` confirms every emit method short-circuits on a nil receiver — production callers do not check for nil

Resolves USK-1000
Linear: https://linear.app/usk6666/issue/USK-1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)