### PR TITLE
feat(proxybuild,mcp): h2 upstream redial metrics + MCP status surface (USK-1001)

### DIFF
--- a/internal/mcp/components.go
+++ b/internal/mcp/components.go
@@ -278,6 +278,13 @@ type proxyManager interface {
 	// query(resource:"status") tool consumes this to populate the
 	// `h1_upstream` field on the status result.
 	H1UpstreamMetrics() proxybuild.H1UpstreamMetricsSnapshot
+
+	// H2UpstreamMetrics surfaces the USK-991 / USK-992 / USK-993 /
+	// USK-1001 HTTP/2 upstream redial / refused-retry counter snapshot
+	// (h1 parity). Returns the zero snapshot when no Manager is bound.
+	// The MCP query(resource:"status") tool consumes this to populate
+	// the `h2_upstream` field on the status result.
+	H2UpstreamMetrics() proxybuild.H2UpstreamMetricsSnapshot
 }
 
 // ListenerStatus is the mcp-package shape of per-listener status used by

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -2113,6 +2113,10 @@ type queryListenerStatusEntry struct {
 // always populated (zero counters when nothing has happened yet).
 // omitempty keeps the field absent for test runs that don't wire a
 // Manager.
+//
+// H2Upstream (USK-1001) is the h1-parity field for the HTTP/2 redial
+// surface (prewarm worker / reactive GOAWAY-driven redial / OpenStream
+// Refused retry). Same nil-vs-populated semantics as H1Upstream.
 type queryStatusResult struct {
 	Running           bool                                  `json:"running"`
 	ListenAddr        string                                `json:"listen_addr"`
@@ -2133,6 +2137,7 @@ type queryStatusResult struct {
 	RateLimits        *queryRateLimitStatus                 `json:"rate_limits,omitempty"`
 	Budget            *queryBudgetStatus                    `json:"budget,omitempty"`
 	H1Upstream        *proxybuild.H1UpstreamMetricsSnapshot `json:"h1_upstream,omitempty"`
+	H2Upstream        *proxybuild.H2UpstreamMetricsSnapshot `json:"h2_upstream,omitempty"`
 }
 
 // queryRateLimitStatus holds rate limit information for the status response.
@@ -2170,6 +2175,12 @@ func (s *Server) populateManagerStatus(result *queryStatusResult) {
 	// implementation omit the field entirely.
 	h1Snap := s.connector.manager.H1UpstreamMetrics()
 	result.H1Upstream = &h1Snap
+
+	// USK-1001: surface the HTTP/2 upstream redial / refused-retry
+	// counters (h1 parity). Same nil-vs-populated semantics as
+	// H1Upstream above.
+	h2Snap := s.connector.manager.H2UpstreamMetrics()
+	result.H2Upstream = &h2Snap
 
 	// Populate per-listener statuses.
 	statuses := listenerStatuses(s.connector.manager)

--- a/internal/mcp/query_tool_test.go
+++ b/internal/mcp/query_tool_test.go
@@ -896,6 +896,59 @@ func TestQuery_Status_H1UpstreamMetrics_NoManager(t *testing.T) {
 	}
 }
 
+// TestQuery_Status_H2UpstreamMetrics_Empty mirrors the H1 test for
+// the USK-1001 h2 counter snapshot. With no upstream activity all
+// counters are zero but the field itself is populated (Manager IS
+// bound) so the AI agent can distinguish "no Manager wired" (field
+// absent) from "Manager wired, no churn yet" (field present, counters
+// zero).
+func TestQuery_Status_H2UpstreamMetrics_Empty(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	manager := newTestProxybuildManager(t)
+	if err := manager.Start(context.Background(), "127.0.0.1:0"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cs := setupQueryStatusTestSession(t, store, manager)
+
+	result := callQuery(t, cs, queryInput{Resource: "status"})
+	if result.IsError {
+		t.Fatalf("expected success: %v", result.Content)
+	}
+
+	var out queryStatusResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.H2Upstream == nil {
+		t.Fatal("h2_upstream = nil; want non-nil snapshot when Manager is bound")
+	}
+	want := proxybuild.H2UpstreamMetricsSnapshot{}
+	if *out.H2Upstream != want {
+		t.Errorf("h2_upstream = %+v, want %+v (all zero)", *out.H2Upstream, want)
+	}
+}
+
+// TestQuery_Status_H2UpstreamMetrics_NoManager mirrors the H1 test —
+// the h2_upstream field is OMITTED when no Manager is bound.
+func TestQuery_Status_H2UpstreamMetrics_NoManager(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	cs := setupQueryTestSession(t, store)
+
+	result := callQuery(t, cs, queryInput{Resource: "status"})
+	if result.IsError {
+		t.Fatalf("expected success: %v", result.Content)
+	}
+
+	var out queryStatusResult
+	unmarshalQueryResult(t, result, &out)
+
+	if out.H2Upstream != nil {
+		t.Errorf("h2_upstream = %+v, want nil (no Manager bound)", *out.H2Upstream)
+	}
+}
+
 // --- Test: config resource ---
 
 func TestQuery_Config_Default(t *testing.T) {

--- a/internal/mcpserver/init.go
+++ b/internal/mcpserver/init.go
@@ -578,6 +578,11 @@ func NewLiveManager(
 	// h1Chain / retryingUpstreamChannel updates the same Manager-level
 	// counter set. USK-1000.
 	h1Metrics := proxybuild.NewH1UpstreamMetrics()
+	// h2Metrics is the USK-1001 h1-parity counter set for the HTTP/2
+	// upstream redial / refused-retry surface. Same construction +
+	// dual-plumb pattern as h1Metrics — one struct per Manager, shared
+	// by every per-CONNECT redialChain via Deps.
+	h2Metrics := proxybuild.NewH2UpstreamMetrics()
 	factory := func(ctx context.Context, name, addr string) (*proxybuild.Stack, error) {
 		return proxybuild.BuildLiveStack(ctx, proxybuild.Deps{
 			Logger:                  logger,
@@ -614,6 +619,9 @@ func NewLiveManager(
 			RecordSSEMaxEventsPerStream:    buildCfg.SSEMaxEventsPerStream,
 			// USK-1000: shared HTTP/1.x upstream redial / replay counters.
 			H1UpstreamMetrics: h1Metrics,
+			// USK-1001: shared HTTP/2 upstream redial / refused-retry
+			// counters (h1 parity). Same shared-singleton pattern.
+			H2UpstreamMetrics: h2Metrics,
 		})
 	}
 	mgr, err := proxybuild.NewManager(proxybuild.ManagerConfig{
@@ -627,6 +635,10 @@ func NewLiveManager(
 		// USK-1000: bind the metrics counters so Manager.H1UpstreamMetrics
 		// returns the same counters every Deps update.
 		H1UpstreamMetrics: h1Metrics,
+		// USK-1001: bind the h2 metrics counters so
+		// Manager.H2UpstreamMetrics returns the same counters every
+		// Deps update.
+		H2UpstreamMetrics: h2Metrics,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init proxybuild manager: %w", err)

--- a/internal/proxybuild/builder.go
+++ b/internal/proxybuild/builder.go
@@ -253,6 +253,16 @@ type Deps struct {
 	// per-CONNECT chains under one Manager share the counter set.
 	H1UpstreamMetrics *H1UpstreamMetrics
 
+	// H2UpstreamMetrics aggregates USK-991 (reactive redial) + USK-992
+	// (pre-warm) + USK-993 (Refused retry) + USK-1001 HTTP/2 upstream
+	// counters. nil-safe — every emit point inside redialChain /
+	// openUpstreamStreamWithRetryFn short-circuits on a nil pointer.
+	// The production wiring (internal/mcpserver/init.go) constructs a
+	// single H2UpstreamMetrics on Manager and threads the same pointer
+	// through Deps so all per-CONNECT chains under one Manager share
+	// the counter set.
+	H2UpstreamMetrics *H2UpstreamMetrics
+
 	// RecordGRPCWebBase64MaxPerStream caps the number of gRPC-Web
 	// text-variant body wire envelopes (WireLevel=grpcweb-base64,
 	// pre-decode base64 body bytes captured by the grpcweb Layer's
@@ -916,7 +926,7 @@ func buildOnHTTP2Stack(p *pipeline.Pipeline, deps Deps, logger *slog.Logger) con
 		// Layers are retained for the CONNECT's lifetime so in-flight
 		// streams on them drain naturally up to GOAWAY's last_stream_id
 		// (RFC 9113 §6.8) — close-on-CONNECT-exit, not close-on-swap.
-		chain := newRedialChain()
+		chain := newRedialChain(deps.H2UpstreamMetrics)
 		// USK-992: the observer closure tickled when a fresh chain step
 		// observes peer GOAWAY. Wired onto each fresh Layer minted by
 		// RedialUpstreamH2 via http2.WithGoAwayObserver. The non-blocking
@@ -1207,12 +1217,36 @@ type redialChain struct {
 	wake        chan struct{}
 	prewarmDone chan struct{}
 	closeOnce   sync.Once
+
+	// metrics receives counter updates for the USK-1001 h2 upstream
+	// redial / refused-retry surface. Mirrors h1Chain.metrics — nil-safe
+	// (every emit helper guards on a nil receiver) so tests that
+	// construct a redialChain directly without a Manager continue to
+	// work unchanged.
+	metrics *H2UpstreamMetrics
+
+	// liveGen is the number of redial steps this chain currently
+	// contributes to the manager-wide chainGenerationLive gauge. Bumped
+	// under c.mu on every redial-append (both the reactive
+	// selectUpstreamForDial slow path and the pre-warm worker);
+	// consumed by closeAll so the manager's live counter is decremented
+	// by the exact contribution of this chain. Tracking the
+	// contribution here (rather than recomputing from len(c.layers) at
+	// close time) keeps the counter stable if future evolutions change
+	// how layers are accounted.
+	liveGen int64
 }
 
-func newRedialChain() *redialChain {
+// newRedialChain constructs a redialChain. metrics may be nil — every
+// counter emit helper short-circuits on a nil receiver. Production
+// callers thread the Manager-level [H2UpstreamMetrics] pointer here so
+// every per-CONNECT chain emits into the same struct (mirrors
+// newH1Chain). Tests that don't care about counters pass nil.
+func newRedialChain(metrics *H2UpstreamMetrics) *redialChain {
 	return &redialChain{
 		wake:        make(chan struct{}, 1),
 		prewarmDone: make(chan struct{}),
+		metrics:     metrics,
 	}
 }
 
@@ -1277,6 +1311,15 @@ func (c *redialChain) runPrewarmWorker(
 		case <-c.wake:
 		}
 
+		// USK-1001: count GOAWAY observations at the CONSUMER (worker
+		// drain) rather than the observer callback. Each drained wake
+		// event represents one peer GOAWAY (or pooled-Layer GOAWAY
+		// observation) that reached the prewarm path — head-mismatched
+		// observer callbacks short-circuit at the callsite before
+		// tickleWake, so a drained wake is by construction a relevant
+		// GOAWAY for the current chain head.
+		c.metrics.incGoAwayObservedPrewarm()
+
 		// Read the current head before dialing. If the head is already
 		// healthy (spurious wake — e.g. observer tickled but reactive
 		// path already replaced the head), skip the dial.
@@ -1300,6 +1343,8 @@ func (c *redialChain) runPrewarmWorker(
 
 		fresh, err := dialFresh(ctx, target, head, nextGen)
 		if err != nil {
+			// USK-1001: count failed pre-warm dials.
+			c.metrics.incRedialFailedPrewarm()
 			// Speculative diagnostic only — the reactive path picks up on
 			// the next request. Worker keeps running for subsequent wake
 			// events (the failed dial is NOT appended; chain.current is
@@ -1322,10 +1367,40 @@ func (c *redialChain) runPrewarmWorker(
 		c.mu.Lock()
 		c.layers = append(c.layers, fresh)
 		c.current.Store(fresh)
+		// USK-1001: bump the per-chain liveGen and emit the
+		// chain-generation gauges under mu — the same single-writer
+		// invariant that protects c.layers protects c.liveGen.
+		c.bumpGenerationLocked()
 		c.mu.Unlock()
+		// USK-1001: count successful pre-warm dials. Emitted after mu
+		// is released so a slow downstream emit cannot stall the
+		// next reactive selectUpstreamForDial picking up the fresh
+		// head.
+		c.metrics.incRedialPrewarm()
 		logger.Debug("proxybuild: pre-warm h2 dialed successfully",
 			"target", target, "generation", nextGen)
 	}
+}
+
+// bumpGenerationLocked updates the chain-generation gauges after a
+// successful redial-append. Caller MUST hold c.mu — both the layer
+// slice and the local liveGen are mutated. The generation value
+// reported to the metrics struct is the number of redial steps
+// (len(layers) - 1 for the reactive path that appends BEFORE this
+// call; len(layers) for the prewarm worker which appends inside the
+// same critical section that calls us — both yield the same "steps"
+// count because the pre-warm worker appends THEN bumps). Mirrors
+// h1Chain.bumpGenerationLocked.
+//
+// In the production wiring, callers append THEN call bumpGenerationLocked,
+// so the chain step count reported to the gauge is len(layers) - 0 = N
+// for the Nth fresh Layer. The implicit pooled chain[0] is generation 0
+// (NOT counted here); the first fresh redial is generation 1, the
+// second is generation 2, etc.
+func (c *redialChain) bumpGenerationLocked() {
+	gen := int64(len(c.layers))
+	c.liveGen = gen
+	c.metrics.observeChainGeneration(gen)
 }
 
 // headLayer returns the current chain head (current.Load() if
@@ -1359,6 +1434,15 @@ func (c *redialChain) closeAll() {
 	defer c.mu.Unlock()
 	for _, l := range c.layers {
 		_ = l.Close()
+	}
+	// USK-1001: release this chain's contribution to the manager-wide
+	// chainGenerationLive gauge so it stays meaningful across many
+	// CONNECTs (otherwise it would grow monotonically forever). The
+	// gauge max is untouched — it tracks the all-time high-water
+	// mark by design.
+	if c.liveGen > 0 {
+		c.metrics.releaseChainGeneration(c.liveGen)
+		c.liveGen = 0
 	}
 	// Hand back the empty slot so a CONNECT that somehow re-enters
 	// (it does not today) would not double-close.
@@ -1418,6 +1502,50 @@ func selectUpstreamForDial(
 	dialFresh redialFunc,
 	logger *slog.Logger,
 ) *http2.Layer {
+	return selectUpstreamForDialWithTrigger(
+		dctx, target, upstreamH2, chain, dialFresh, dialTriggerReactive, logger,
+	)
+}
+
+// dialTrigger discriminates the call-site context for
+// selectUpstreamForDialWithTrigger so the USK-1001 metrics emit point
+// can attribute redials to the correct trigger label
+// (reactive vs refused_stream). The pre-warm worker dials via
+// dialFresh directly and does NOT call selectUpstreamForDial, so
+// "prewarm" is not part of this enum.
+type dialTrigger uint8
+
+const (
+	// dialTriggerReactive is the normal selectUpstreamForDial call from
+	// the per-stream dial closure (USK-991 / USK-993 first-attempt
+	// path). Maps to {goaway_observed,redial,redial_failed}_reactive.
+	dialTriggerReactive dialTrigger = iota
+	// dialTriggerRefusedStream is the retry call from
+	// openUpstreamStreamWithRetryFn after the first OpenStream
+	// returned a Refused error (USK-993 race-recovery path). Maps to
+	// {redial,redial_failed}_refused_stream — the goaway-observed
+	// counter is NOT incremented from this trigger because the
+	// race that drives it is OpenStream-side, not GOAWAY-observation.
+	dialTriggerRefusedStream
+)
+
+// selectUpstreamForDialWithTrigger is selectUpstreamForDial with an
+// explicit trigger discriminator so the USK-1001 redial metrics can
+// distinguish the two call sites (reactive vs refused_stream).
+//
+// All semantics other than the metric trigger label match
+// selectUpstreamForDial — see that function's doc comment for
+// active-Layer selection, browser-equivalent semantics, and the
+// chain.mu single-flight discussion.
+func selectUpstreamForDialWithTrigger(
+	dctx context.Context,
+	target string,
+	upstreamH2 *http2.Layer,
+	chain *redialChain,
+	dialFresh redialFunc,
+	trigger dialTrigger,
+	logger *slog.Logger,
+) *http2.Layer {
 	// Fast path: lock-free read of the active Layer. current.Load() is
 	// either nil (no redial yet — use pooled) or points to a Layer that
 	// was appended to chain.layers under chain.mu prior to the swap, so
@@ -1428,6 +1556,20 @@ func selectUpstreamForDial(
 	}
 	if !isStaleH2(active) {
 		return active
+	}
+
+	// USK-1001: count GOAWAY observations at the CONSUMER (slow-path
+	// entry, after isStaleH2 has already returned true on the fast
+	// path). One stale observation per slow-path entry on the
+	// reactive trigger only — the refused_stream trigger represents
+	// the OpenStream-side race-recovery path and is not a fresh
+	// stale-conn observation. The under-mu re-check below may see
+	// the staleness already resolved by a concurrent goroutine, but
+	// the divergence-point semantics (matches h1's
+	// incStaleDetectedHealthcheck) means we count what THIS goroutine
+	// observed.
+	if trigger == dialTriggerReactive {
+		chain.metrics.incGoAwayObservedReactive()
 	}
 
 	// Slow path: race to fresh-dial the next chain step. The mutex
@@ -1454,6 +1596,13 @@ func selectUpstreamForDial(
 	nextGen := len(chain.layers) + 1
 	fresh, err := dialFresh(dctx, target, active, nextGen)
 	if err != nil {
+		// USK-1001: attribute the failed dial to the calling trigger.
+		switch trigger {
+		case dialTriggerReactive:
+			chain.metrics.incRedialFailedReactive()
+		case dialTriggerRefusedStream:
+			chain.metrics.incRedialFailedRefusedStream()
+		}
 		logger.Warn("proxybuild: upstream h2 redial failed",
 			"target", target, "generation", nextGen, "error", err)
 		// Return the (stale) active Layer. The caller's OpenStream will
@@ -1466,6 +1615,17 @@ func selectUpstreamForDial(
 	}
 	chain.layers = append(chain.layers, fresh)
 	chain.current.Store(fresh)
+	// USK-1001: bump the per-chain liveGen + emit chain-generation
+	// gauges under mu (the single-writer invariant that protects
+	// chain.layers also protects chain.liveGen).
+	chain.bumpGenerationLocked()
+	// USK-1001: attribute the successful dial to the calling trigger.
+	switch trigger {
+	case dialTriggerReactive:
+		chain.metrics.incRedialReactive()
+	case dialTriggerRefusedStream:
+		chain.metrics.incRedialRefusedStream()
+	}
 	logger.Debug("proxybuild: upstream h2 redialed after stale-conn detection",
 		"target", target, "generation", nextGen)
 	return fresh
@@ -1554,6 +1714,8 @@ func openUpstreamStreamWithRetryFn(
 	openStream openStreamFunc,
 	logger *slog.Logger,
 ) (*http2.Layer, layer.Channel, error) {
+	// First attempt: reactive-trigger selectUpstreamForDial. Stale-conn
+	// observations attributed to {goaway_observed,redial,redial_failed}_reactive.
 	upL := selectUpstreamForDial(dctx, target, upstreamH2, chain, dialFresh, logger)
 	upCh, err := openStream(dctx, upL)
 	if err == nil {
@@ -1562,15 +1724,57 @@ func openUpstreamStreamWithRetryFn(
 	if !isRefusedStreamError(err) {
 		return nil, nil, err
 	}
+	// USK-1001: count every observed Refused at the FIRST OpenStream
+	// attempt. Counted before the retry decision so retry-success vs
+	// retry-fail outcomes (incRetry*) form a separate partition of
+	// this counter.
+	chain.metrics.incRefused()
 	// Attempt 1 returned Refused. Retry exactly once. The second
 	// selectUpstreamForDial sees the now-stale Layer (the very Refused
 	// codes imply shutdown/GOAWAY on upL) and fresh-dials under
 	// chain.mu. Concurrent streams hitting the same race converge on
 	// the same fresh Layer through chain.current.
+	//
+	// USK-1001: dispatch the retry's selectUpstreamForDial with
+	// dialTriggerRefusedStream so the redial attribution lands under
+	// the refused_stream label instead of reactive — they are different
+	// races (GOAWAY-observed vs OpenStream-side Refused) and the MCP
+	// status surface keeps them distinct.
 	logger.Debug("proxybuild: OpenStream refused, retrying after fresh dial",
 		"target", target, "reason", refusedReason(err))
-	upL2 := selectUpstreamForDial(dctx, target, upstreamH2, chain, dialFresh, logger)
+	upL2 := selectUpstreamForDialWithTrigger(
+		dctx, target, upstreamH2, chain, dialFresh, dialTriggerRefusedStream, logger,
+	)
 	upCh2, err2 := openStream(dctx, upL2)
+	// USK-1001 Q9 heuristic: classify the retry OUTCOME by (upL == upL2)
+	// + err2. The redial COUNT is already accounted by the trigger
+	// dispatch inside selectUpstreamForDialWithTrigger, so this switch
+	// only updates retry_total — no double-counting of redials.
+	//
+	// Approximate caveat: a concurrent pre-warm worker may have
+	// already swapped chain.current to a fresh Layer between the two
+	// calls, so upL2 != upL even though this goroutine's retry path
+	// did not itself dial (selectUpstreamForDialWithTrigger took the
+	// "active is no longer stale under mu" early-return). That case
+	// classifies as fail_redial_retry / success even though no
+	// refused_stream redial was performed — over-counting the retry
+	// path. The under-count is symmetric (a prewarm stalemate that
+	// resolves at the same time can also mask a real retry-path
+	// success). See design review Q9.
+	switch {
+	case err2 == nil:
+		chain.metrics.incRetrySuccess()
+	case upL2 != upL:
+		// Retry path's selectUpstream returned a different Layer (a
+		// redial succeeded or pre-warm intervened) but the post-redial
+		// OpenStream still failed.
+		chain.metrics.incRetryFailRedialRetry()
+	default:
+		// err2 != nil && upL2 == upL: selectUpstream fell back to the
+		// same stale Layer (its dial failed) AND OpenStream failed on
+		// it again.
+		chain.metrics.incRetryFailRedial()
+	}
 	if err2 != nil {
 		return nil, nil, err2
 	}

--- a/internal/proxybuild/h1_metrics.go
+++ b/internal/proxybuild/h1_metrics.go
@@ -350,9 +350,11 @@ type H1UpstreamMetricsSnapshot struct {
 // Snapshot returns the current values atomically-loaded from each
 // counter. Safe to call concurrently with increments — each Load is
 // independent, so the snapshot is a "tear-able" view (no global
-// barrier across counters). This matches Prometheus scrape semantics
-// (counters are independently scraped) and the connector.BudgetManager
-// precedent. Returns the zero snapshot when m is nil.
+// barrier across counters). Cross-counter invariants (e.g.
+// write_epipe ≥ replay_fail_*) MAY NOT hold under concurrent
+// increments; this matches Prometheus scrape semantics (counters are
+// independently scraped) and the connector.BudgetManager precedent.
+// Returns the zero snapshot when m is nil.
 func (m *H1UpstreamMetrics) Snapshot() H1UpstreamMetricsSnapshot {
 	if m == nil {
 		return H1UpstreamMetricsSnapshot{}

--- a/internal/proxybuild/h2_metrics.go
+++ b/internal/proxybuild/h2_metrics.go
@@ -1,0 +1,407 @@
+package proxybuild
+
+import "sync/atomic"
+
+// H2UpstreamMetrics aggregates per-Manager counters that observe the
+// USK-991 (reactive GOAWAY-driven redial), USK-992 (proactive pre-warm
+// worker), and USK-993 (OpenStream Refused-stream retry) live-wire
+// surface for HTTP/2 upstreams. Each counter is an atomic.Int64 so
+// increment-from-multiple-goroutines is safe; readers use
+// [H2UpstreamMetrics.Snapshot] which loads each field with atomic.Load
+// semantics.
+//
+// Scope: one struct instance per [Manager] (Manager-level singleton),
+// shared by every per-CONNECT [redialChain] and every per-stream dial
+// closure built under that manager. Multi-listener isolation is
+// provided by Manager-per-listener — each Manager has its own metrics
+// struct, never shared across managers.
+//
+// The struct is exported (vs the internal increment methods) so the
+// production wiring (internal/mcpserver/init.go) can construct one
+// instance before NewManager and thread the same pointer into
+// [ManagerConfig.H2UpstreamMetrics] (status accessor) and
+// [Deps.H2UpstreamMetrics] (per-listener instrumentation). Increment
+// methods remain package-private — only redialChain / the per-stream
+// dial closure emit.
+//
+// Counter convention mirrors [H1UpstreamMetrics] (USK-1000) — h2 carries
+// a wider trigger-label space because it has THREE distinct stale-
+// detect / redial paths (prewarm worker, reactive GOAWAY-driven
+// selectUpstreamForDial, OpenStream Refused-stream retry) versus h1's
+// two. There is no Prometheus exporter or HTTP listener in this repo;
+// the MCP `status` resource is the single surface.
+//
+// Shared-seam extraction with H1UpstreamMetrics is deferred per memory
+// `feedback_shared_seam_hardcoded_flag` — both protocols now have the
+// same shape, so a follow-up Issue can lift them into a shared
+// internal/proxybuild/upstream_metrics.go.
+type H2UpstreamMetrics struct {
+	// goAwayObservedPrewarm counts each time the pre-warm worker
+	// drained a wake event (peer GOAWAY observed via the per-Layer
+	// WithGoAwayObserver / pooled-Layer RegisterGoAwayObserver
+	// callback) and proceeded to evaluate a fresh dial. Counted at the
+	// CONSUMER (worker drain), NOT at the observer callback, so
+	// spurious-wake races and head-mismatched callbacks do not
+	// double-count.
+	goAwayObservedPrewarm atomic.Int64
+
+	// goAwayObservedReactive counts each time selectUpstreamForDial's
+	// slow path observed a stale Layer (isStaleH2 returned true) and
+	// proceeded to fresh-dial under chain.mu. Counted at the consumer
+	// (slow-path entry), matching the "divergence point" convention
+	// that h1's incStaleDetectedHealthcheck establishes.
+	goAwayObservedReactive atomic.Int64
+
+	// refused counts each time openUpstreamStreamWithRetryFn observed
+	// OpenStream return *layer.StreamError{Code: ErrorRefused} on the
+	// FIRST attempt. Counted BEFORE the retry attempt fires, so every
+	// Refused observation contributes exactly once regardless of
+	// retry outcome.
+	refused atomic.Int64
+
+	// redialPrewarm counts successful redials initiated by the pre-warm
+	// worker. The post-dial Layer-append and chain.current swap
+	// happened under chain.mu.
+	redialPrewarm atomic.Int64
+
+	// redialReactive counts successful redials initiated by
+	// selectUpstreamForDial's slow path (reactive: stale Layer
+	// observed on the live request path).
+	redialReactive atomic.Int64
+
+	// redialRefusedStream counts successful redials initiated by
+	// openUpstreamStreamWithRetryFn's retry path. The retry's second
+	// selectUpstreamForDial observed the now-stale Layer and
+	// fresh-dialed; this counter increments on that fresh-dial
+	// success.
+	//
+	// Q9 heuristic — see Snapshot godoc and openUpstreamStreamWithRetryFn:
+	// approximate classification by (upL != upL2). Parallel pre-warm
+	// can mis-classify in rare interleavings where chain.current was
+	// already replaced by another goroutine before the second
+	// selectUpstreamForDial call.
+	redialRefusedStream atomic.Int64
+
+	// redialFailedPrewarm counts dial failures inside the pre-warm
+	// worker. The failed dial is NOT appended to chain.layers;
+	// chain.current is unchanged.
+	redialFailedPrewarm atomic.Int64
+
+	// redialFailedReactive counts dial failures inside
+	// selectUpstreamForDial's slow path. The stale Layer is returned
+	// to the caller; OpenStream surfaces the underlying refused error.
+	redialFailedReactive atomic.Int64
+
+	// redialFailedRefusedStream counts dial failures observed inside
+	// openUpstreamStreamWithRetryFn's retry path. Heuristic-classified
+	// the same way as redialRefusedStream.
+	redialFailedRefusedStream atomic.Int64
+
+	// retrySuccess counts retry-wrapper attempts where the
+	// post-redial OpenStream returned a healthy Channel. The request
+	// reached the upstream on the second try.
+	retrySuccess atomic.Int64
+
+	// retryFailRedial counts retry-wrapper attempts where the retry
+	// path's selectUpstreamForDial did NOT secure a fresh Layer (the
+	// second select returned the same stale Layer; redial failed and
+	// fell back to stale). The post-redial OpenStream then returned
+	// an error.
+	//
+	// Heuristic — see Snapshot godoc and openUpstreamStreamWithRetryFn.
+	retryFailRedial atomic.Int64
+
+	// retryFailRedialRetry counts retry-wrapper attempts where redial
+	// SUCCEEDED (the second select returned a fresh Layer different
+	// from the first) but the post-redial OpenStream still returned
+	// an error. The fresh Layer broke again on the second attempt.
+	retryFailRedialRetry atomic.Int64
+
+	// chainGenerationMax is the high-water mark of the redial chain
+	// depth observed across the manager's lifetime. Updated under
+	// chain.mu right after each layer-append (reactive slow path AND
+	// pre-warm worker post-dial). Never decreases — diagnostic "worst
+	// case" for upstream churn.
+	chainGenerationMax atomic.Int64
+
+	// chainGenerationLive is the sum of redial-step counts across
+	// every currently-live redialChain. Each chain contributes the
+	// number of redial steps it has executed (chain.layers length minus
+	// the implicit pooled chain[0]). Incremented on redial-append,
+	// decremented in [redialChain.closeAll] (CONNECT exit). Keeps the
+	// gauge meaningful across many CONNECTs.
+	chainGenerationLive atomic.Int64
+}
+
+// NewH2UpstreamMetrics returns a fresh zero-valued counter struct.
+// Production wiring (internal/mcpserver/init.go) constructs one
+// instance and threads it into both [ManagerConfig.H2UpstreamMetrics]
+// and [Deps.H2UpstreamMetrics] so all per-listener instrumentation
+// updates a single Manager-level counter set.
+//
+// Tests that need to read counters in isolation can construct one
+// directly via &H2UpstreamMetrics{} or via this constructor — both
+// produce identically-zeroed instances.
+func NewH2UpstreamMetrics() *H2UpstreamMetrics {
+	return &H2UpstreamMetrics{}
+}
+
+// incGoAwayObservedPrewarm increments the
+// http2_upstream_goaway_observed_total{trigger="prewarm"} counter.
+// Called from the pre-warm worker after draining c.wake.
+func (m *H2UpstreamMetrics) incGoAwayObservedPrewarm() {
+	if m == nil {
+		return
+	}
+	m.goAwayObservedPrewarm.Add(1)
+}
+
+// incGoAwayObservedReactive increments the
+// http2_upstream_goaway_observed_total{trigger="reactive"} counter.
+// Called from selectUpstreamForDial when the slow path is taken
+// (active Layer observed stale via isStaleH2).
+func (m *H2UpstreamMetrics) incGoAwayObservedReactive() {
+	if m == nil {
+		return
+	}
+	m.goAwayObservedReactive.Add(1)
+}
+
+// incRefused increments the http2_upstream_refused_total counter.
+// Called from openUpstreamStreamWithRetryFn when the FIRST OpenStream
+// attempt returns *layer.StreamError{Code: ErrorRefused}. Fires
+// BEFORE the retry attempt is made, so the counter is invariant under
+// retry success/failure.
+func (m *H2UpstreamMetrics) incRefused() {
+	if m == nil {
+		return
+	}
+	m.refused.Add(1)
+}
+
+// incRedialPrewarm increments the
+// http2_upstream_redial_total{trigger="prewarm"} counter on a
+// successful pre-warm worker dial. Pairs with the
+// chainGenerationLive/Max gauge bump.
+func (m *H2UpstreamMetrics) incRedialPrewarm() {
+	if m == nil {
+		return
+	}
+	m.redialPrewarm.Add(1)
+}
+
+// incRedialReactive increments the
+// http2_upstream_redial_total{trigger="reactive"} counter on a
+// successful selectUpstreamForDial slow-path fresh dial.
+func (m *H2UpstreamMetrics) incRedialReactive() {
+	if m == nil {
+		return
+	}
+	m.redialReactive.Add(1)
+}
+
+// incRedialRefusedStream increments the
+// http2_upstream_redial_total{trigger="refused_stream"} counter on a
+// successful retry-path fresh dial. Heuristic — see Q9 godoc.
+func (m *H2UpstreamMetrics) incRedialRefusedStream() {
+	if m == nil {
+		return
+	}
+	m.redialRefusedStream.Add(1)
+}
+
+// incRedialFailedPrewarm increments the
+// http2_upstream_redial_failed_total{trigger="prewarm"} counter on a
+// pre-warm worker dial failure.
+func (m *H2UpstreamMetrics) incRedialFailedPrewarm() {
+	if m == nil {
+		return
+	}
+	m.redialFailedPrewarm.Add(1)
+}
+
+// incRedialFailedReactive increments the
+// http2_upstream_redial_failed_total{trigger="reactive"} counter on a
+// selectUpstreamForDial slow-path dial failure.
+func (m *H2UpstreamMetrics) incRedialFailedReactive() {
+	if m == nil {
+		return
+	}
+	m.redialFailedReactive.Add(1)
+}
+
+// incRedialFailedRefusedStream increments the
+// http2_upstream_redial_failed_total{trigger="refused_stream"} counter
+// on a retry-path dial failure. Heuristic — see Q9 godoc.
+func (m *H2UpstreamMetrics) incRedialFailedRefusedStream() {
+	if m == nil {
+		return
+	}
+	m.redialFailedRefusedStream.Add(1)
+}
+
+// incRetrySuccess increments the
+// http2_upstream_retry_total{outcome="success"} counter on a
+// successful retry-wrapper attempt.
+func (m *H2UpstreamMetrics) incRetrySuccess() {
+	if m == nil {
+		return
+	}
+	m.retrySuccess.Add(1)
+}
+
+// incRetryFailRedial increments the
+// http2_upstream_retry_total{outcome="fail_redial"} counter when the
+// retry path observed no fresh Layer (heuristic: upL == upL2).
+func (m *H2UpstreamMetrics) incRetryFailRedial() {
+	if m == nil {
+		return
+	}
+	m.retryFailRedial.Add(1)
+}
+
+// incRetryFailRedialRetry increments the
+// http2_upstream_retry_total{outcome="fail_redial_retry"} counter when
+// the retry path secured a fresh Layer (heuristic: upL != upL2) but
+// the post-redial OpenStream still returned an error.
+func (m *H2UpstreamMetrics) incRetryFailRedialRetry() {
+	if m == nil {
+		return
+	}
+	m.retryFailRedialRetry.Add(1)
+}
+
+// observeChainGeneration updates the chain-generation gauges after a
+// redial-append. gen is the chain's redial-step count after the
+// append (1 for the first redial, 2 for the second, etc.). Callers
+// hold chain.mu so the relative ordering of Add(+1) on live and Max
+// update is consistent within a single chain — the manager-wide
+// chainGenerationMax is read-modify-write via CAS to track the
+// process-wide high-water mark across all live chains.
+func (m *H2UpstreamMetrics) observeChainGeneration(gen int64) {
+	if m == nil {
+		return
+	}
+	m.chainGenerationLive.Add(1)
+	for {
+		cur := m.chainGenerationMax.Load()
+		if gen <= cur {
+			return
+		}
+		if m.chainGenerationMax.CompareAndSwap(cur, gen) {
+			return
+		}
+	}
+}
+
+// releaseChainGeneration drops the live gauge by gen, called from
+// [redialChain.closeAll] at CONNECT exit. Without this, chainGenerationLive
+// would grow monotonically with every CONNECT that redialed and the
+// gauge becomes meaningless after enough churn.
+func (m *H2UpstreamMetrics) releaseChainGeneration(gen int64) {
+	if m == nil || gen <= 0 {
+		return
+	}
+	m.chainGenerationLive.Add(-gen)
+}
+
+// H2UpstreamMetricsSnapshot is the immutable read-only view returned
+// by [H2UpstreamMetrics.Snapshot] and [Manager.H2UpstreamMetrics]. JSON
+// tags mirror the MCP query(resource:"status") field names so the same
+// struct can be serialised on the MCP surface without an extra
+// conversion. Counters are int64 (Prometheus convention "total");
+// gauges are int64.
+//
+// The label-enum structure
+// ({trigger=prewarm|reactive|refused_stream} and
+// {outcome=success|fail_redial|fail_redial_retry}) is expressed as
+// named fields rather than a map so the schema is statically typed and
+// the MCP surface is stable across versions.
+type H2UpstreamMetricsSnapshot struct {
+	// GoAwayObservedPrewarm is
+	// http2_upstream_goaway_observed_total{trigger="prewarm"}.
+	GoAwayObservedPrewarm int64 `json:"goaway_observed_prewarm"`
+
+	// GoAwayObservedReactive is
+	// http2_upstream_goaway_observed_total{trigger="reactive"}.
+	GoAwayObservedReactive int64 `json:"goaway_observed_reactive"`
+
+	// Refused is http2_upstream_refused_total.
+	Refused int64 `json:"refused"`
+
+	// RedialPrewarm is
+	// http2_upstream_redial_total{trigger="prewarm"}.
+	RedialPrewarm int64 `json:"redial_prewarm"`
+
+	// RedialReactive is
+	// http2_upstream_redial_total{trigger="reactive"}.
+	RedialReactive int64 `json:"redial_reactive"`
+
+	// RedialRefusedStream is
+	// http2_upstream_redial_total{trigger="refused_stream"}.
+	RedialRefusedStream int64 `json:"redial_refused_stream"`
+
+	// RedialFailedPrewarm is
+	// http2_upstream_redial_failed_total{trigger="prewarm"}.
+	RedialFailedPrewarm int64 `json:"redial_failed_prewarm"`
+
+	// RedialFailedReactive is
+	// http2_upstream_redial_failed_total{trigger="reactive"}.
+	RedialFailedReactive int64 `json:"redial_failed_reactive"`
+
+	// RedialFailedRefusedStream is
+	// http2_upstream_redial_failed_total{trigger="refused_stream"}.
+	RedialFailedRefusedStream int64 `json:"redial_failed_refused_stream"`
+
+	// RetrySuccess is
+	// http2_upstream_retry_total{outcome="success"}.
+	RetrySuccess int64 `json:"retry_success"`
+
+	// RetryFailRedial is
+	// http2_upstream_retry_total{outcome="fail_redial"}.
+	RetryFailRedial int64 `json:"retry_fail_redial"`
+
+	// RetryFailRedialRetry is
+	// http2_upstream_retry_total{outcome="fail_redial_retry"}.
+	RetryFailRedialRetry int64 `json:"retry_fail_redial_retry"`
+
+	// ChainGenerationMax is the all-time high-water mark of the
+	// redial chain depth (CONNECT-scoped: each CONNECT's chain is
+	// reported individually, the max across CONNECTs is reported
+	// here).
+	ChainGenerationMax int64 `json:"chain_generation_max"`
+
+	// ChainGenerationLive is the current sum of redial-step counts
+	// across all live redialChains. Decremented on CONNECT exit.
+	ChainGenerationLive int64 `json:"chain_generation_live"`
+}
+
+// Snapshot returns the current values atomically-loaded from each
+// counter. Safe to call concurrently with increments — each Load is
+// independent, so the snapshot is a "tear-able" view (no global
+// barrier across counters). Cross-counter invariants (e.g. retry_success
+// + retry_fail_* == refused) MAY NOT hold under concurrent
+// increments; this matches Prometheus scrape semantics (counters are
+// independently scraped) and the connector.BudgetManager precedent.
+// Returns the zero snapshot when m is nil.
+func (m *H2UpstreamMetrics) Snapshot() H2UpstreamMetricsSnapshot {
+	if m == nil {
+		return H2UpstreamMetricsSnapshot{}
+	}
+	return H2UpstreamMetricsSnapshot{
+		GoAwayObservedPrewarm:     m.goAwayObservedPrewarm.Load(),
+		GoAwayObservedReactive:    m.goAwayObservedReactive.Load(),
+		Refused:                   m.refused.Load(),
+		RedialPrewarm:             m.redialPrewarm.Load(),
+		RedialReactive:            m.redialReactive.Load(),
+		RedialRefusedStream:       m.redialRefusedStream.Load(),
+		RedialFailedPrewarm:       m.redialFailedPrewarm.Load(),
+		RedialFailedReactive:      m.redialFailedReactive.Load(),
+		RedialFailedRefusedStream: m.redialFailedRefusedStream.Load(),
+		RetrySuccess:              m.retrySuccess.Load(),
+		RetryFailRedial:           m.retryFailRedial.Load(),
+		RetryFailRedialRetry:      m.retryFailRedialRetry.Load(),
+		ChainGenerationMax:        m.chainGenerationMax.Load(),
+		ChainGenerationLive:       m.chainGenerationLive.Load(),
+	}
+}

--- a/internal/proxybuild/h2_metrics_integration_test.go
+++ b/internal/proxybuild/h2_metrics_integration_test.go
@@ -1,0 +1,249 @@
+//go:build e2e && !e2e_smoke
+
+// USK-1001 integration: h2 upstream redial metrics counted through the
+// real selectUpstreamForDial / openUpstreamStreamWithRetryFn / pre-warm
+// worker dispatch on real *http2.Layer pairs (preface-completed via
+// dialPeerH2Layer). Exhaustive tier (`//go:build e2e && !e2e_smoke`)
+// per CLAUDE.md — counter wiring is diagnostic, not browser-parity
+// wire-behavior gate.
+//
+// The three scenarios covered:
+//
+//	1. reactive — a peer-FINed pooled Layer drives selectUpstreamForDial's
+//	   slow path; goaway_observed_reactive + redial_reactive +
+//	   chain_generation gauge bump fire exactly once.
+//	2. refused-retry — first OpenStream returns Refused, the retry path
+//	   uses dialTriggerRefusedStream and bumps retry_success.
+//	3. pre-warm — chain.tickleWake drives the worker, which dials and
+//	   bumps redial_prewarm (or redial_failed_prewarm on dial error).
+
+package proxybuild
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
+)
+
+// TestE2E_H2Metrics_Reactive drives the full
+// selectUpstreamForDial slow path on a peer-FINed pooled Layer and
+// asserts the reactive trigger counters fire on a SUCCESSFUL redial.
+func TestE2E_H2Metrics_Reactive(t *testing.T) {
+	t.Parallel()
+	stale, stalePeer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = stalePeer.Close()
+	awaitShutdown(t, stale)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return fresh, nil
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	got := selectUpstreamForDial(
+		context.Background(), "example.test:443",
+		stale, chain, dialFresh, silentLogger(),
+	)
+	if got != fresh {
+		t.Fatalf("selectUpstreamForDial = %p, want fresh %p", got, fresh)
+	}
+
+	snap := m.Snapshot()
+	if snap.GoAwayObservedReactive != 1 {
+		t.Errorf("goaway_observed_reactive = %d, want 1", snap.GoAwayObservedReactive)
+	}
+	if snap.RedialReactive != 1 {
+		t.Errorf("redial_reactive = %d, want 1", snap.RedialReactive)
+	}
+	if snap.ChainGenerationLive != 1 || snap.ChainGenerationMax != 1 {
+		t.Errorf("chain_generation: live=%d max=%d, want live=1 max=1",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+}
+
+// TestE2E_H2Metrics_RefusedRetrySuccess drives the USK-993 retry path
+// end-to-end: first OpenStream returns Refused → metrics record one
+// `refused` + one `retry_success`. The first selectUpstreamForDial
+// dialed fresh under reactive (the pooled was already stale), so
+// redial_reactive=1; the second selectUpstreamForDial saw the fresh
+// head and short-circuited so redial_refused_stream=0.
+func TestE2E_H2Metrics_RefusedRetrySuccess(t *testing.T) {
+	t.Parallel()
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return fresh, nil
+	}
+	stubChan := stubChannel{streamID: 5}
+	var openCalls int32
+	openFn := func(_ context.Context, l *http2.Layer) (layer.Channel, error) {
+		n := atomic.AddInt32(&openCalls, 1)
+		if n == 1 {
+			return nil, &layer.StreamError{Code: layer.ErrorRefused, Reason: "GOAWAY sent"}
+		}
+		if l != fresh {
+			t.Errorf("attempt %d: openStream got %p, want fresh %p", n, l, fresh)
+		}
+		return stubChan, nil
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	_, _, err := openUpstreamStreamWithRetryFn(
+		context.Background(), "example.test:443",
+		pooled, chain, redialFn, openFn, silentLogger(),
+	)
+	if err != nil {
+		t.Fatalf("openUpstreamStreamWithRetryFn: %v", err)
+	}
+
+	snap := m.Snapshot()
+	if snap.Refused != 1 {
+		t.Errorf("refused = %d, want 1", snap.Refused)
+	}
+	if snap.RetrySuccess != 1 {
+		t.Errorf("retry_success = %d, want 1", snap.RetrySuccess)
+	}
+	if snap.RetryFailRedial != 0 || snap.RetryFailRedialRetry != 0 {
+		t.Errorf("retry_fail_* fired during retry-success: %+v", snap)
+	}
+}
+
+// TestE2E_H2Metrics_PrewarmDialSuccess drives the pre-warm worker
+// against a stale chain head with a successful dialFresh and asserts
+// the prewarm-trigger counters fire (goaway_observed_prewarm +
+// redial_prewarm + chain_generation gauge bump).
+func TestE2E_H2Metrics_PrewarmDialSuccess(t *testing.T) {
+	t.Parallel()
+	stale, stalePeer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = stalePeer.Close()
+	awaitShutdown(t, stale)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	// Manually point chain.current at the stale Layer so the worker's
+	// head-check sees staleness and proceeds to dial. The worker
+	// otherwise reads chain.headLayer() == nil and skips on the first
+	// wake.
+	chain.current.Store(stale)
+	defer chain.closeAll()
+
+	dialReturned := make(chan struct{}, 1)
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		dialReturned <- struct{}{}
+		return fresh, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain.startPrewarmWorker(ctx, "example.test:443", dialFresh, nil, silentLogger())
+
+	chain.tickleWake()
+	<-dialReturned
+
+	// Wait for the worker to publish the metric updates (append +
+	// counter inc happen after dialFresh returns).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && m.Snapshot().RedialPrewarm < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	snap := m.Snapshot()
+	if snap.GoAwayObservedPrewarm != 1 {
+		t.Errorf("goaway_observed_prewarm = %d, want 1", snap.GoAwayObservedPrewarm)
+	}
+	if snap.RedialPrewarm != 1 {
+		t.Errorf("redial_prewarm = %d, want 1", snap.RedialPrewarm)
+	}
+	if snap.RedialFailedPrewarm != 0 {
+		t.Errorf("redial_failed_prewarm = %d, want 0 on success path", snap.RedialFailedPrewarm)
+	}
+	if snap.ChainGenerationLive != 1 || snap.ChainGenerationMax != 1 {
+		t.Errorf("chain_generation: live=%d max=%d, want live=1 max=1",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+	// Reactive / refused_stream labels must NOT fire from a prewarm
+	// drain.
+	if snap.GoAwayObservedReactive != 0 || snap.RedialReactive != 0 {
+		t.Errorf("reactive counters fired during prewarm path: %+v", snap)
+	}
+	if snap.Refused != 0 || snap.RedialRefusedStream != 0 {
+		t.Errorf("refused_stream counters fired during prewarm path: %+v", snap)
+	}
+}
+
+// TestE2E_H2Metrics_PrewarmDialFail mirrors PrewarmDialSuccess but
+// with dialFresh returning an error → incRedialFailedPrewarm fires
+// without redial_prewarm; chain_generation gauge stays at 0.
+func TestE2E_H2Metrics_PrewarmDialFail(t *testing.T) {
+	t.Parallel()
+	stale, stalePeer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = stalePeer.Close()
+	awaitShutdown(t, stale)
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	chain.current.Store(stale)
+	defer chain.closeAll()
+
+	dialReturned := make(chan struct{}, 1)
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		dialReturned <- struct{}{}
+		return nil, errors.New("synthetic prewarm dial failure")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain.startPrewarmWorker(ctx, "example.test:443", dialFresh, nil, silentLogger())
+
+	chain.tickleWake()
+	<-dialReturned
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && m.Snapshot().RedialFailedPrewarm < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	snap := m.Snapshot()
+	if snap.GoAwayObservedPrewarm != 1 {
+		t.Errorf("goaway_observed_prewarm = %d, want 1", snap.GoAwayObservedPrewarm)
+	}
+	if snap.RedialFailedPrewarm != 1 {
+		t.Errorf("redial_failed_prewarm = %d, want 1", snap.RedialFailedPrewarm)
+	}
+	if snap.RedialPrewarm != 0 {
+		t.Errorf("redial_prewarm = %d, want 0 on failure path", snap.RedialPrewarm)
+	}
+	if snap.ChainGenerationLive != 0 {
+		t.Errorf("chain_generation_live = %d, want 0 (failed dial does NOT append)",
+			snap.ChainGenerationLive)
+	}
+}

--- a/internal/proxybuild/h2_metrics_test.go
+++ b/internal/proxybuild/h2_metrics_test.go
@@ -1,0 +1,496 @@
+package proxybuild
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2"
+)
+
+// TestH2Metrics_NewIsZero asserts a fresh counter set returns the zero
+// snapshot. Mirrors TestH1Metrics_NewIsZero.
+func TestH2Metrics_NewIsZero(t *testing.T) {
+	t.Parallel()
+	m := NewH2UpstreamMetrics()
+	snap := m.Snapshot()
+	if snap != (H2UpstreamMetricsSnapshot{}) {
+		t.Errorf("NewH2UpstreamMetrics: snapshot = %+v, want zero", snap)
+	}
+}
+
+// TestH2Metrics_NilSafe asserts every emit method short-circuits on a
+// nil receiver. Production callers do not check for nil — the
+// emit-site doc-comment promises nil-safety. Mirrors
+// TestH1Metrics_NilSafe.
+func TestH2Metrics_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *H2UpstreamMetrics // nil pointer
+	// All emit methods must not panic on nil. Snapshot returns the
+	// zero value.
+	m.incGoAwayObservedPrewarm()
+	m.incGoAwayObservedReactive()
+	m.incRefused()
+	m.incRedialPrewarm()
+	m.incRedialReactive()
+	m.incRedialRefusedStream()
+	m.incRedialFailedPrewarm()
+	m.incRedialFailedReactive()
+	m.incRedialFailedRefusedStream()
+	m.incRetrySuccess()
+	m.incRetryFailRedial()
+	m.incRetryFailRedialRetry()
+	m.observeChainGeneration(5)
+	m.releaseChainGeneration(5)
+	snap := m.Snapshot()
+	if snap != (H2UpstreamMetricsSnapshot{}) {
+		t.Errorf("nil-receiver Snapshot: %+v, want zero", snap)
+	}
+}
+
+// TestH2Metrics_DirectIncrements asserts each emit helper increments
+// the corresponding atomic.Int64 exactly once. Mirrors
+// TestH1Metrics_DirectIncrements — one row per (counter, label) tuple.
+func TestH2Metrics_DirectIncrements(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		emit func(*H2UpstreamMetrics)
+		want func(H2UpstreamMetricsSnapshot) int64
+	}{
+		{
+			name: "goaway_observed_prewarm",
+			emit: (*H2UpstreamMetrics).incGoAwayObservedPrewarm,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.GoAwayObservedPrewarm },
+		},
+		{
+			name: "goaway_observed_reactive",
+			emit: (*H2UpstreamMetrics).incGoAwayObservedReactive,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.GoAwayObservedReactive },
+		},
+		{
+			name: "refused",
+			emit: (*H2UpstreamMetrics).incRefused,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.Refused },
+		},
+		{
+			name: "redial_prewarm",
+			emit: (*H2UpstreamMetrics).incRedialPrewarm,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialPrewarm },
+		},
+		{
+			name: "redial_reactive",
+			emit: (*H2UpstreamMetrics).incRedialReactive,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialReactive },
+		},
+		{
+			name: "redial_refused_stream",
+			emit: (*H2UpstreamMetrics).incRedialRefusedStream,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialRefusedStream },
+		},
+		{
+			name: "redial_failed_prewarm",
+			emit: (*H2UpstreamMetrics).incRedialFailedPrewarm,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialFailedPrewarm },
+		},
+		{
+			name: "redial_failed_reactive",
+			emit: (*H2UpstreamMetrics).incRedialFailedReactive,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialFailedReactive },
+		},
+		{
+			name: "redial_failed_refused_stream",
+			emit: (*H2UpstreamMetrics).incRedialFailedRefusedStream,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RedialFailedRefusedStream },
+		},
+		{
+			name: "retry_success",
+			emit: (*H2UpstreamMetrics).incRetrySuccess,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RetrySuccess },
+		},
+		{
+			name: "retry_fail_redial",
+			emit: (*H2UpstreamMetrics).incRetryFailRedial,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RetryFailRedial },
+		},
+		{
+			name: "retry_fail_redial_retry",
+			emit: (*H2UpstreamMetrics).incRetryFailRedialRetry,
+			want: func(s H2UpstreamMetricsSnapshot) int64 { return s.RetryFailRedialRetry },
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewH2UpstreamMetrics()
+			tc.emit(m)
+			tc.emit(m)
+			snap := m.Snapshot()
+			if got := tc.want(snap); got != 2 {
+				t.Errorf("%s after 2 increments = %d, want 2", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestH2Metrics_ChainGeneration asserts the gauge family: observe
+// increments Live and updates Max; release decrements Live but does
+// not touch Max. Max records the high-water mark across the lifetime.
+// Mirrors TestH1Metrics_ChainGeneration.
+func TestH2Metrics_ChainGeneration(t *testing.T) {
+	t.Parallel()
+	m := NewH2UpstreamMetrics()
+
+	// First chain redials twice -> generations 1, 2.
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 2 || snap.ChainGenerationMax != 2 {
+		t.Errorf("after 2 observes (1,2): live=%d max=%d, want live=2 max=2",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// Second chain redials thrice -> generations 1, 2, 3.
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	m.observeChainGeneration(3)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 5 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after second chain (1,2,3): live=%d max=%d, want live=5 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// First chain closes (released gen=2). Live drops by 2; max stays at 3.
+	m.releaseChainGeneration(2)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 3 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after release(2): live=%d max=%d, want live=3 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// Second chain closes (released gen=3). Live -> 0, max stays.
+	m.releaseChainGeneration(3)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 0 || snap.ChainGenerationMax != 3 {
+		t.Errorf("after release(3): live=%d max=%d, want live=0 max=3",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+
+	// release(0) is a no-op.
+	m.releaseChainGeneration(0)
+	if snap := m.Snapshot(); snap.ChainGenerationLive != 0 {
+		t.Errorf("release(0): live=%d, want 0", snap.ChainGenerationLive)
+	}
+}
+
+// TestH2Chain_Metrics_ReactiveRedialFail drives a stale pooled Layer
+// through selectUpstreamForDial with a failing redialFn and asserts
+// the reactive trigger labels fire: incGoAwayObservedReactive +
+// incRedialFailedReactive. Mirrors the h1
+// TestH1Chain_Metrics_EnsureFreshDialFail shape.
+func TestH2Chain_Metrics_ReactiveRedialFail(t *testing.T) {
+	t.Parallel()
+	stale, peer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = peer.Close()
+	awaitShutdown(t, stale)
+
+	wantErr := errors.New("dial: synthetic")
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return nil, wantErr
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	got := selectUpstreamForDial(
+		context.Background(), "example.test:443",
+		stale, chain, dialFresh, silentLogger(),
+	)
+	if got != stale {
+		t.Errorf("selectUpstreamForDial after redial-fail = %p, want stale %p", got, stale)
+	}
+	snap := m.Snapshot()
+	if snap.GoAwayObservedReactive < 1 {
+		t.Errorf("goaway_observed_reactive = %d, want >= 1", snap.GoAwayObservedReactive)
+	}
+	if snap.RedialFailedReactive < 1 {
+		t.Errorf("redial_failed_reactive = %d, want >= 1", snap.RedialFailedReactive)
+	}
+	// Successful redial did NOT fire.
+	if snap.RedialReactive != 0 {
+		t.Errorf("redial_reactive = %d, want 0 on dial-failure path", snap.RedialReactive)
+	}
+	// The prewarm / refused_stream triggers must NOT fire from a
+	// reactive call.
+	if snap.GoAwayObservedPrewarm != 0 || snap.RedialPrewarm != 0 || snap.RedialFailedPrewarm != 0 {
+		t.Errorf("prewarm counters fired during reactive path: %+v", snap)
+	}
+	if snap.RedialRefusedStream != 0 || snap.RedialFailedRefusedStream != 0 || snap.Refused != 0 {
+		t.Errorf("refused_stream counters fired during reactive path: %+v", snap)
+	}
+}
+
+// TestH2Chain_Metrics_ReactiveRedialSuccess pins the success-path
+// reactive counter set: stale pooled triggers exactly one
+// goaway_observed_reactive + one redial_reactive + one
+// chain_generation gauge bump.
+func TestH2Chain_Metrics_ReactiveRedialSuccess(t *testing.T) {
+	t.Parallel()
+	stale, stalePeer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = stalePeer.Close()
+	awaitShutdown(t, stale)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return fresh, nil
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	got := selectUpstreamForDial(
+		context.Background(), "example.test:443",
+		stale, chain, dialFresh, silentLogger(),
+	)
+	if got != fresh {
+		t.Errorf("selectUpstreamForDial = %p, want fresh %p", got, fresh)
+	}
+	snap := m.Snapshot()
+	if snap.GoAwayObservedReactive != 1 {
+		t.Errorf("goaway_observed_reactive = %d, want 1", snap.GoAwayObservedReactive)
+	}
+	if snap.RedialReactive != 1 {
+		t.Errorf("redial_reactive = %d, want 1", snap.RedialReactive)
+	}
+	if snap.RedialFailedReactive != 0 {
+		t.Errorf("redial_failed_reactive = %d, want 0", snap.RedialFailedReactive)
+	}
+	if snap.ChainGenerationLive != 1 || snap.ChainGenerationMax != 1 {
+		t.Errorf("chain_generation: live=%d max=%d, want live=1 max=1",
+			snap.ChainGenerationLive, snap.ChainGenerationMax)
+	}
+}
+
+// TestH2Retry_Metrics_RefusedSuccess drives the USK-993 retry path
+// (first OpenStream returns Refused → fresh dial → second OpenStream
+// succeeds) and asserts the refused + retry_success counters fire
+// (plus redial_refused_stream because the second selectUpstreamForDial
+// uses dialTriggerRefusedStream).
+func TestH2Retry_Metrics_RefusedSuccess(t *testing.T) {
+	t.Parallel()
+	pooled, pooledPeer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer pooledPeer.Close()
+	_ = pooledPeer.Close()
+	awaitShutdown(t, pooled)
+
+	fresh, freshPeer := dialPeerH2Layer(t)
+	defer fresh.Close()
+	defer freshPeer.Close()
+
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		return fresh, nil
+	}
+
+	stubChan := stubChannel{streamID: 7}
+	var openCalls int32
+	openFn := func(_ context.Context, l *http2.Layer) (layer.Channel, error) {
+		n := atomic.AddInt32(&openCalls, 1)
+		if n == 1 {
+			return nil, &layer.StreamError{Code: layer.ErrorRefused, Reason: "layer shutdown"}
+		}
+		if l != fresh {
+			t.Errorf("attempt %d: openStream got %p, want fresh %p", n, l, fresh)
+		}
+		return stubChan, nil
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	_, _, err := openUpstreamStreamWithRetryFn(
+		context.Background(), "example.test:443",
+		pooled, chain, redialFn, openFn, silentLogger(),
+	)
+	if err != nil {
+		t.Fatalf("openUpstreamStreamWithRetryFn: %v", err)
+	}
+	snap := m.Snapshot()
+	if snap.Refused != 1 {
+		t.Errorf("refused = %d, want 1", snap.Refused)
+	}
+	if snap.RetrySuccess != 1 {
+		t.Errorf("retry_success = %d, want 1", snap.RetrySuccess)
+	}
+	if snap.RetryFailRedial != 0 || snap.RetryFailRedialRetry != 0 {
+		t.Errorf("retry_fail_* counters fired during retry-success path: %+v", snap)
+	}
+	// The retry path uses dialTriggerRefusedStream. The first
+	// selectUpstreamForDial inside the helper uses the reactive
+	// trigger (incRedialReactive on success), but the SECOND call —
+	// the one driven by the Refused retry — uses
+	// dialTriggerRefusedStream. The pooled was stale at construction,
+	// so the first call dials fresh under reactive and the second
+	// call observes that fresh head and bypasses its own dial
+	// (no refused_stream redial). Net: redial_reactive=1,
+	// redial_refused_stream=0.
+	if snap.RedialReactive != 1 {
+		t.Errorf("redial_reactive = %d, want 1", snap.RedialReactive)
+	}
+	if snap.RedialRefusedStream != 0 {
+		t.Errorf("redial_refused_stream = %d, want 0 (first-call reactive dial fresh-handled the chain head)",
+			snap.RedialRefusedStream)
+	}
+}
+
+// TestH2Retry_Metrics_NonRefusedNoCount asserts a non-Refused error
+// from the first OpenStream attempt does NOT increment refused/retry
+// counters — the error passes through verbatim.
+func TestH2Retry_Metrics_NonRefusedNoCount(t *testing.T) {
+	t.Parallel()
+	pooled, peer := dialPeerH2Layer(t)
+	defer pooled.Close()
+	defer peer.Close()
+
+	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		t.Error("redialFn must not be called for non-Refused error")
+		return nil, errors.New("unexpected redial")
+	}
+	wantErr := errors.New("synthetic non-refused")
+	openFn := func(_ context.Context, _ *http2.Layer) (layer.Channel, error) {
+		return nil, wantErr
+	}
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	defer chain.closeAll()
+
+	_, _, err := openUpstreamStreamWithRetryFn(
+		context.Background(), "example.test:443",
+		pooled, chain, redialFn, openFn, silentLogger(),
+	)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+	snap := m.Snapshot()
+	if snap.Refused != 0 || snap.RetrySuccess != 0 || snap.RetryFailRedial != 0 || snap.RetryFailRedialRetry != 0 {
+		t.Errorf("non-Refused path incremented retry counters: %+v", snap)
+	}
+}
+
+// TestH2Chain_Metrics_CloseAllReleasesGauge asserts closeAll
+// decrements chainGenerationLive by this chain's contribution but
+// leaves chainGenerationMax intact. Multi-chain scoping is exercised
+// by manually injecting a second chain's contribution into the same
+// metrics struct. Mirrors TestH1Chain_Metrics_CloseAllReleasesGauge.
+func TestH2Chain_Metrics_CloseAllReleasesGauge(t *testing.T) {
+	t.Parallel()
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+
+	// Simulate 2 successful redials by directly bumping the gauge
+	// under c.mu (avoids needing a working dial).
+	chain.mu.Lock()
+	chain.liveGen = 2
+	chain.mu.Unlock()
+	m.observeChainGeneration(1)
+	m.observeChainGeneration(2)
+	// Add a second chain's contribution to verify isolation.
+	m.observeChainGeneration(1)
+
+	beforeMax := m.Snapshot().ChainGenerationMax
+	beforeLive := m.Snapshot().ChainGenerationLive
+	if beforeLive != 3 || beforeMax != 2 {
+		t.Fatalf("setup: live=%d max=%d, want live=3 max=2", beforeLive, beforeMax)
+	}
+
+	chain.closeAll()
+
+	snap := m.Snapshot()
+	if snap.ChainGenerationLive != 1 {
+		t.Errorf("closeAll: live=%d, want 1 (second chain's contribution remains)",
+			snap.ChainGenerationLive)
+	}
+	if snap.ChainGenerationMax != 2 {
+		t.Errorf("closeAll: max=%d, want 2 (Max never decreases)", snap.ChainGenerationMax)
+	}
+	// Repeat call: closeAll is idempotent. liveGen has been zeroed so
+	// the second call is a no-op (no double-decrement of the manager
+	// gauge).
+	chain.closeAll()
+	if snap2 := m.Snapshot(); snap2.ChainGenerationLive != 1 {
+		t.Errorf("second closeAll caused double-decrement: live=%d, want 1",
+			snap2.ChainGenerationLive)
+	}
+}
+
+// TestH2Metrics_PrewarmTriggersIsolated drives the pre-warm worker
+// drain via tickleWake and asserts the prewarm trigger labels fire
+// without leaking into reactive / refused_stream slots. The dialFresh
+// closure returns an error so we exercise the failure path; the
+// drain count is asserted via incGoAwayObservedPrewarm.
+func TestH2Metrics_PrewarmTriggersIsolated(t *testing.T) {
+	t.Parallel()
+	stale, stalePeer := dialPeerH2Layer(t)
+	defer stale.Close()
+	_ = stalePeer.Close()
+	awaitShutdown(t, stale)
+
+	m := NewH2UpstreamMetrics()
+	chain := newRedialChain(m)
+	// Manually seed chain.current so the worker's head check returns
+	// the stale Layer (and is_stale=true so the dial path is taken).
+	chain.current.Store(stale)
+	defer chain.closeAll()
+
+	dialErr := errors.New("dial: synthetic prewarm")
+	dialDone := make(chan struct{}, 1)
+	dialFresh := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
+		dialDone <- struct{}{}
+		return nil, dialErr
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain.startPrewarmWorker(ctx, "example.test:443", dialFresh, nil, silentLogger())
+
+	chain.tickleWake()
+
+	// Wait for the worker to drain the wake and run dialFresh.
+	<-dialDone
+
+	// Allow the worker a moment to update counters after dialFresh
+	// returns; we poll the metric since the worker emits AFTER the
+	// dial returns.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && m.Snapshot().RedialFailedPrewarm < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	snap := m.Snapshot()
+	if snap.GoAwayObservedPrewarm < 1 {
+		t.Errorf("goaway_observed_prewarm = %d, want >= 1", snap.GoAwayObservedPrewarm)
+	}
+	if snap.RedialFailedPrewarm < 1 {
+		t.Errorf("redial_failed_prewarm = %d, want >= 1", snap.RedialFailedPrewarm)
+	}
+	if snap.RedialPrewarm != 0 {
+		t.Errorf("redial_prewarm = %d, want 0 on dial-failure path", snap.RedialPrewarm)
+	}
+	// Reactive / refused_stream labels must NOT fire from a prewarm
+	// drain.
+	if snap.GoAwayObservedReactive != 0 || snap.RedialReactive != 0 || snap.RedialFailedReactive != 0 {
+		t.Errorf("reactive counters fired during prewarm path: %+v", snap)
+	}
+	if snap.Refused != 0 || snap.RedialRefusedStream != 0 || snap.RedialFailedRefusedStream != 0 {
+		t.Errorf("refused_stream counters fired during prewarm path: %+v", snap)
+	}
+}

--- a/internal/proxybuild/h2_pool_observer_test.go
+++ b/internal/proxybuild/h2_pool_observer_test.go
@@ -103,7 +103,7 @@ func TestH2PoolObserver_PreWarmFiresOnPooledLayerGoAway(t *testing.T) {
 	defer (*peer).Close()
 
 	// Construct the chain + worker shape buildOnHTTP2Stack produces.
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	var dialCount int32
 	dialReady := make(chan struct{}, 1)

--- a/internal/proxybuild/h2_prewarm_test.go
+++ b/internal/proxybuild/h2_prewarm_test.go
@@ -138,7 +138,7 @@ func TestRedialChain_PrewarmFiresOnWake(t *testing.T) {
 	_ = pooledPeer.Close()
 	awaitShutdown(t, pooled)
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	// Manually seed the chain head with pooled (mirrors what
 	// selectUpstreamForDial would do on first reactive redial).
 	chain.layers = append(chain.layers, pooled)
@@ -205,7 +205,7 @@ func TestRedialChain_PrewarmDedupsOnRapidWakeBursts(t *testing.T) {
 		return fresh, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	chain.layers = append(chain.layers, pooled)
 	chain.current.Store(pooled)
 
@@ -253,7 +253,7 @@ func TestRedialChain_PrewarmDedupsOnRapidWakeBursts(t *testing.T) {
 // termination via ctx.Done(). When the CONNECT context cancels, the
 // worker exits without leaking goroutines.
 func TestRedialChain_PrewarmWorkerExitsCleanlyOnCtxCancel(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	// dialFn never fires because we don't tickle wake.
 	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		t.Error("redialFn must not be called when wake is never tickled")
@@ -302,7 +302,7 @@ func TestRedialChain_PrewarmFailedDialKeepsWorkerAlive(t *testing.T) {
 		return nil, dialErr
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	chain.layers = append(chain.layers, pooled)
 	chain.current.Store(pooled)
 
@@ -354,7 +354,7 @@ func TestRedialChain_PrewarmFailedDialKeepsWorkerAlive(t *testing.T) {
 //  3. Worker drains wake, calls redialFn (gated), returns fresh2.
 //  4. Assert chain.current swaps to fresh2 before any selectUpstreamForDial.
 func TestRedialChain_PrewarmFiresViaRealGoAwayObserver(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	// Pre-mint fresh2 up front so we don't race on assignment inside the
 	// worker goroutine.
@@ -426,7 +426,7 @@ func TestRedialChain_PrewarmFiresViaRealGoAwayObserver(t *testing.T) {
 // is technically canceled (it's the CONNECT-exit defer); the worker
 // must respect prewarmDone in its select.
 func TestRedialChain_CloseAllExitsWorkerEvenWithoutCtxCancel(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		t.Error("redialFn must not fire when wake is never tickled")
 		return nil, errors.New("unexpected dial")
@@ -455,7 +455,7 @@ func TestRedialChain_CloseAllExitsWorkerEvenWithoutCtxCancel(t *testing.T) {
 // (which would panic with "close of closed channel"). Mirrors the
 // USK-991 idempotency test of closeAll's layer-close pass.
 func TestRedialChain_CloseAllIsIdempotent(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	// Run a second time after the worker has exited. closeAll wraps the
 	// close(prewarmDone) in sync.Once so the second call is a no-op.
@@ -505,7 +505,7 @@ func TestRedialChain_PrewarmRespectsCtxCancelMidDial(t *testing.T) {
 		return fresh, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	chain.layers = append(chain.layers, pooled)
 	chain.current.Store(pooled)
 
@@ -559,7 +559,7 @@ func TestRedialChain_PrewarmRespectsCtxCancelMidDial(t *testing.T) {
 // buildOnHTTP2Stack (not on redialChain itself), this test asserts on
 // the assembled production closure shape by recreating it.
 func TestRedialChain_ObserverGatesByCurrentHead(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	// We construct two fresh Layers: layerA and layerB. layerB becomes
 	// the current head; layerA's observer fires after the swap and must
 	// NOT tickle wake.
@@ -611,7 +611,7 @@ func TestRedialChain_ObserverGatesByCurrentHead(t *testing.T) {
 // the rapid-burst dedup tested in
 // TestRedialChain_PrewarmDedupsOnRapidWakeBursts.
 func TestRedialChain_TickleWakeCapacityOne(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	// 3 tickles back-to-back — only the first should buffer.
 	chain.tickleWake()
 	chain.tickleWake()
@@ -639,7 +639,7 @@ func TestRedialChain_TickleWakeCapacityOne(t *testing.T) {
 // — we don't need a "calling it twice panics" invariant (the worker
 // API is internal and only called by buildOnHTTP2Stack).
 func TestRedialChain_PrewarmWorkerExitsViaCloseAllAfterIdle(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	redialFn := func(_ context.Context, _ string, _ *http2.Layer, _ int) (*http2.Layer, error) {
 		t.Error("redialFn must not fire when wake is never tickled")
 		return nil, errors.New("unexpected dial")
@@ -682,7 +682,7 @@ type stubWorkerHarness struct {
 func newStubWorkerHarness(t *testing.T) *stubWorkerHarness {
 	t.Helper()
 	h := &stubWorkerHarness{
-		chain:     newRedialChain(),
+		chain:     newRedialChain(nil),
 		dialReady: make(chan struct{}, 8),
 		dialNext:  make(chan *http2.Layer, 8),
 		t:         t,
@@ -794,7 +794,7 @@ func TestRedialChain_PrewarmAndReactiveCooperate(t *testing.T) {
 //  4. Inject a real GOAWAY into pooled.
 //  5. Assert worker dials → chain.current swaps to fresh.
 func TestRedialChain_PrewarmFiresOnPooledChain0GoAway(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	// Pre-mint fresh up front so we don't race on assignment inside the
 	// worker goroutine.
@@ -881,7 +881,7 @@ func TestRedialChain_PrewarmFiresOnPooledChain0GoAway(t *testing.T) {
 // This mirrors TestRedialChain_ObserverGatesByCurrentHead but for the
 // chain[0] (pooled) observer closure produced by buildOnHTTP2Stack.
 func TestRedialChain_PrewarmPooledObserverGatedByHeadAfterSwap(t *testing.T) {
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	pooled, pooledPeer := dialPeerH2Layer(t)
 	defer pooled.Close()

--- a/internal/proxybuild/h2_redial_test.go
+++ b/internal/proxybuild/h2_redial_test.go
@@ -104,7 +104,7 @@ func TestSelectUpstreamForDial_StaleLayerTriggersRedial(t *testing.T) {
 		return fresh, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
 		stale, chain, redialFn, silentLogger())
 
@@ -148,7 +148,7 @@ func TestSelectUpstreamForDial_HealthyLayerSkipsRedial(t *testing.T) {
 		return nil, errors.New("unexpected redial")
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
 		healthy, chain, redialFn, silentLogger())
 
@@ -179,7 +179,7 @@ func TestSelectUpstreamForDial_RedialFailureFallsBackToStale(t *testing.T) {
 		return nil, wantErr
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	got := selectUpstreamForDial(context.Background(), "example.test:443",
 		stale, chain, redialFn, silentLogger())
 
@@ -245,7 +245,7 @@ func TestSelectUpstreamForDial_ConcurrentStreamsShareSingleRedial(t *testing.T) 
 		return fresh, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	const n = 8
 	results := make(chan *http2.Layer, n)
 	for i := 0; i < n; i++ {
@@ -320,7 +320,7 @@ func TestSelectUpstreamForDial_NChainRedials(t *testing.T) {
 		return freshSeq[i-1], nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 
 	// Stage 0: kill pooled, expect fresh1 with generation=1.
 	_ = pooledPeer.Close()
@@ -401,7 +401,7 @@ func TestSelectUpstreamForDial_NChainConcurrentSingleFlightPerStep(t *testing.T)
 		}
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	const m = 8
 
 	// Step A: pooled is stale → all M goroutines must converge on fresh1.
@@ -484,7 +484,7 @@ func TestRedialChain_CloseAllClosesEveryStep(t *testing.T) {
 	fresh3, peer3 := dialPeerH2Layer(t)
 	defer peer3.Close()
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	chain.layers = append(chain.layers, fresh1, fresh2, fresh3)
 	chain.current.Store(fresh3)
 
@@ -575,7 +575,7 @@ func TestOpenUpstreamStreamWithRetry_RefusedTriggersRetry(t *testing.T) {
 				return stubChan, nil
 			}
 
-			chain := newRedialChain()
+			chain := newRedialChain(nil)
 			gotL, gotCh, err := openUpstreamStreamWithRetryFn(
 				context.Background(), "example.test:443",
 				pooled, chain, redialFn, openFn, silentLogger(),
@@ -627,7 +627,7 @@ func TestOpenUpstreamStreamWithRetry_BudgetExactlyOne(t *testing.T) {
 		return nil, &layer.StreamError{Code: layer.ErrorRefused, Reason: wantReason}
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	_, _, err := openUpstreamStreamWithRetryFn(
 		context.Background(), "example.test:443",
 		pooled, chain, redialFn, openFn, silentLogger(),
@@ -684,7 +684,7 @@ func TestOpenUpstreamStreamWithRetry_NonRefusedPassesThrough(t *testing.T) {
 				return nil, tc.err
 			}
 
-			chain := newRedialChain()
+			chain := newRedialChain(nil)
 			_, _, err := openUpstreamStreamWithRetryFn(
 				context.Background(), "example.test:443",
 				pooled, chain, redialFn, openFn, silentLogger(),
@@ -726,7 +726,7 @@ func TestOpenUpstreamStreamWithRetry_FirstAttemptSucceedsNoRetry(t *testing.T) {
 		return stubChan, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	gotL, gotCh, err := openUpstreamStreamWithRetryFn(
 		context.Background(), "example.test:443",
 		pooled, chain, redialFn, openFn, silentLogger(),
@@ -784,7 +784,7 @@ func TestOpenUpstreamStreamWithRetry_ConcurrentRefusedSingleFlightRedial(t *test
 		return stubChannel{streamID: 1}, nil
 	}
 
-	chain := newRedialChain()
+	chain := newRedialChain(nil)
 	const n = 8
 	results := make(chan *http2.Layer, n)
 	for i := 0; i < n; i++ {

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -79,6 +79,17 @@ type ManagerConfig struct {
 	// working snapshot accessor; they just won't see counters from any
 	// listener built via a Deps that omitted the matching field.
 	H1UpstreamMetrics *H1UpstreamMetrics
+
+	// H2UpstreamMetrics is the Manager-level USK-1001 counter set —
+	// h1 parity for the HTTP/2 upstream redial / refused-retry surface.
+	// When non-nil, [Manager.H2UpstreamMetrics] returns a snapshot of
+	// these counters; production wiring threads the SAME pointer into
+	// every [Deps.H2UpstreamMetrics] so all per-CONNECT chains emit
+	// into the same struct. nil constructs a fresh empty counter set
+	// inside NewManager — callers that omit the field still get a
+	// working snapshot accessor; they just won't see counters from any
+	// listener built via a Deps that omitted the matching field.
+	H2UpstreamMetrics *H2UpstreamMetrics
 }
 
 // Manager orchestrates one or more named live Stacks. It exposes
@@ -133,6 +144,14 @@ type Manager struct {
 	// [Manager.H1UpstreamMetrics] for the snapshot accessor and
 	// internal/proxybuild/h1_metrics.go for the schema.
 	h1Upstream *H1UpstreamMetrics
+
+	// h2Upstream collects USK-991 + USK-992 + USK-993 + USK-1001
+	// observability counters for the HTTP/2 upstream redial /
+	// refused-retry surface. Same scoping rules as h1Upstream — one
+	// per Manager, threaded through every per-CONNECT redialChain via
+	// Deps. See [Manager.H2UpstreamMetrics] for the snapshot accessor
+	// and internal/proxybuild/h2_metrics.go for the schema.
+	h2Upstream *H2UpstreamMetrics
 }
 
 // upstreamProxyRotationEntry pairs the operator-supplied template
@@ -164,12 +183,18 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if h1Metrics == nil {
 		h1Metrics = NewH1UpstreamMetrics()
 	}
+	// USK-1001: same singleton/fallback pattern for the h2 counter set.
+	h2Metrics := cfg.H2UpstreamMetrics
+	if h2Metrics == nil {
+		h2Metrics = NewH2UpstreamMetrics()
+	}
 	return &Manager{
 		logger:     logger,
 		factory:    cfg.StackFactory,
 		buildCfg:   cfg.BuildConfig,
 		listeners:  make(map[string]*listenerEntry),
 		h1Upstream: h1Metrics,
+		h2Upstream: h2Metrics,
 	}, nil
 }
 
@@ -193,6 +218,31 @@ func (m *Manager) H1UpstreamMetrics() H1UpstreamMetricsSnapshot {
 	// reassigned, so a lock is unnecessary for the pointer read. The
 	// snapshot itself uses atomic Loads inside.
 	return m.h1Upstream.Snapshot()
+}
+
+// H2UpstreamMetrics returns a snapshot of the USK-991 / USK-992 /
+// USK-993 / USK-1001 HTTP/2 upstream redial counters maintained under
+// this Manager. The snapshot is a value type so callers may retain it
+// safely; subsequent increments do not back-mutate the returned
+// struct.
+//
+// The MCP query(resource:"status") tool surfaces these counters to
+// AI agents under the `h2_upstream` field. The counter set matches
+// the design review schema (3 stale-detect counters + 3 redial
+// triggers + 3 redial-failed triggers + 3 retry outcomes +
+// chain_generation gauge family — 12 counters + 2 gauges, mirroring
+// the h1 14-field shape).
+//
+// Shared-seam extraction with H1UpstreamMetrics is deferred to a
+// follow-up Issue per memory `feedback_shared_seam_hardcoded_flag` —
+// once both protocols have counters of identical shape we can lift
+// them into a shared file without baking h1-only assumptions into
+// the seam.
+func (m *Manager) H2UpstreamMetrics() H2UpstreamMetricsSnapshot {
+	// h2Upstream is set at construction by NewManager and never
+	// reassigned, so a lock is unnecessary for the pointer read. The
+	// snapshot itself uses atomic Loads inside.
+	return m.h2Upstream.Snapshot()
 }
 
 // Start is shorthand for StartNamed(ctx, DefaultListenerName, listenAddr).


### PR DESCRIPTION
## Summary

USK-1001 brings h1 parity for the HTTP/2 upstream redial / Refused-retry observability surface introduced by USK-1000 (PR #73). Mirrors the H1UpstreamMetrics struct shape for the three h2 redial paths (prewarm, reactive GOAWAY, OpenStream Refused retry) and surfaces the H2Upstream snapshot via MCP query(resource:\"status\").

### What

- **`internal/proxybuild/h2_metrics.go`** — new `H2UpstreamMetrics` struct (12 atomic.Int64 counter fields + 2 gauges) + `H2UpstreamMetricsSnapshot` + helper-method-per-(counter,label) emit methods. Nil-safe receivers; mirror of `h1_metrics.go` shape with the wider trigger label space (`prewarm`/`reactive`/`refused_stream`) and retry-outcome enum (`success`/`fail_redial`/`fail_redial_retry`).
- **`internal/proxybuild/builder.go`** — `redialChain` carries `metrics *H2UpstreamMetrics` + `liveGen int64` (mirroring `h1Chain`). The 5 slog emit sites (prewarm worker drain / dial-fail / dial-success / reactive dial-fail / reactive dial-success) all gain counter increments. Pre-warm worker counts `goaway_observed_prewarm` at the wake-drain consumer; reactive path counts `goaway_observed_reactive` at `selectUpstreamForDial` slow-path entry. Introduced `dialTrigger` enum + `selectUpstreamForDialWithTrigger` so the USK-993 retry path's second `selectUpstreamForDial` call attributes its redial to `refused_stream` instead of double-counting as `reactive`. `closeAll` releases the chain-generation gauge contribution.
- **`internal/proxybuild/h1_metrics.go`** — Snapshot godoc reworded per PR #73 review LOW carry-over: drop the misleading \"callers can verify write_epipe ≥ replay_fail_*\" invariant claim; state tear-able + Prometheus-scrape semantics. New h2 Snapshot godoc uses the same wording.
- **Plumbing** (manager.go / Deps / components.go / query_tool.go / mcpserver/init.go): one `H2UpstreamMetrics` per Manager, threaded into Deps and ManagerConfig, surfaced via `Manager.H2UpstreamMetrics()` and the MCP `query(resource:\"status\")` tool's new `H2Upstream` JSON field (omitempty when no Manager).

### Tests

- `internal/proxybuild/h2_metrics_test.go` — table-driven unit tests for all 12 counters + nil-safe + chain-generation gauge + per-path attribution isolation (reactive doesn't leak into prewarm/refused_stream slots and vice versa).
- `internal/proxybuild/h2_metrics_integration_test.go` (e2e + !e2e_smoke per CLAUDE.md) — real-`*http2.Layer`-backed scenarios for reactive redial / refused-retry / prewarm dial success+fail.
- `internal/mcp/query_tool_test.go` — `H2UpstreamMetrics_Empty` (Manager bound but no churn) + `H2UpstreamMetrics_NoManager` (omitempty).

## Q9 retry-outcome classifier (heuristic)

Implementer chose the recommended heuristic (`upL == upL2` + `err2`) rather than refactoring `selectUpstreamForDial` to return `(layer, dialed bool)`. Documented in `openUpstreamStreamWithRetryFn` godoc — concurrent pre-warm can mis-classify in rare interleavings; the under/over-count is symmetric.

## Test plan

- [x] `make lint` clean
- [x] `make test` passes (fast tier)
- [x] `make test-e2e-smoke` passes (merge gate)
- [x] New `TestE2E_H2Metrics_*` integration tests pass under `go test -tags e2e`
- [x] H1 Snapshot godoc corrected (LOW carry-over from PR #73)
- [x] No pre-extraction of shared `protoUpstreamMetrics` (deferred to follow-up Issue)

Refs: USK-1001