### PR TITLE
fix(layer/http2): close goAwayHit vs GoAwayClosed race in RegisterGoAwayObserver (USK-1003)

### DIFF
--- a/internal/layer/http2/layer.go
+++ b/internal/layer/http2/layer.go
@@ -396,6 +396,20 @@ func (l *Layer) RegisterGoAwayObserver(cb func()) (cancel func()) {
 
 	l.goAwayObsMu.Lock()
 	hit := l.goAwayHit
+	if !hit && l.GoAwayClosed() {
+		// USK-1003: handleGoAwayFrame flips conn-level state via
+		// l.conn.HandleGoAway BEFORE acquiring goAwayObsMu to set
+		// goAwayHit (reader.go:101 vs reader.go:153-154). A caller that
+		// observes GoAwayClosed() == true and immediately registers can
+		// race into the gap between those two writes — goAwayHit reads
+		// false here, the entry would be appended to l.goAwayObs, and
+		// the reader's pending snapshot would fire cb async. The godoc
+		// promises a synchronous fire when GOAWAY is already visible,
+		// so cross-check the conn-level signal under goAwayObsMu and
+		// treat it as already-hit. GoAwayClosed() reads conn-level
+		// mutexes, not goAwayObsMu, so this is safe to call here.
+		hit = true
+	}
 	if !hit {
 		l.goAwayObs = append(l.goAwayObs, entry)
 	}


### PR DESCRIPTION
## Summary

- Fixes the post-merge CI flake hit by [main run #178](https://github.com/usk6666/yorishiro-proxy/actions/runs/26420599892) (after PR #74 / USK-1001 merge):
  `--- FAIL: TestRegisterGoAwayObserver_FiresImmediatelyIfGoAwayAlreadySeen — RegisterGoAwayObserver did not fire cb synchronously after GoAwayClosed was already true`
- `RegisterGoAwayObserver` now cross-checks `l.GoAwayClosed()` under `goAwayObsMu` when `goAwayHit` reads false, closing the race window between `l.conn.HandleGoAway` (which flips conn-level state) and the later `l.goAwayHit = true` write inside `handleGoAwayFrame`.
- Pre-existing race (test added in PR #68 / USK-993). PR #74's added prewarm load made it observable on CI.

## Root cause

`internal/layer/http2/reader.go:101` flips conn-state via `l.conn.HandleGoAway(f)` ~50 lines before the reader acquires `goAwayObsMu` at `reader.go:153-154` to set `l.goAwayHit = true`. Callers that poll `GoAwayClosed()` to true and immediately register can see `goAwayHit == false`, get appended to `l.goAwayObs`, and have their cb fired asynchronously by the reader's snapshot loop — violating the godoc's promised synchronous fire.

## Fix

In `RegisterGoAwayObserver`, when `goAwayHit` reads false under `goAwayObsMu`, also consult `l.GoAwayClosed()`. `GoAwayClosed()` reads conn-level mutexes (not `goAwayObsMu`), so the cross-check is safe under the observer lock. When it trips, treat as already-hit, fire `entry.once.Do(cb)` synchronously, and return a no-op cancel — same code path as the original `hit == true` branch. Per-registration `entry.once` already gates against double-fire if the reader's in-flight snapshot also reaches the entry (defense in depth — the fixed path doesn't append).

## Test plan

- [x] Repro with the fix reverted: `go test -race -count=200 -cpu 4 -run TestRegisterGoAwayObserver_FiresImmediatelyIfGoAwayAlreadySeen ./internal/layer/http2/` → 3+ FAIL hits
- [x] With the fix: same command, 200/200 PASS
- [x] All `TestRegisterGoAwayObserver_*` cases: `go test -race -count=10 -run TestRegisterGoAwayObserver ./internal/layer/http2/` → green
- [x] Full http2 package: `go test -race -v ./internal/layer/http2/` → green
- [x] `make lint` → green
- [x] `make test` (full repo, `-race -timeout 4m ./...`) → green

Refs: USK-1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)