### PR TITLE
fix(test): unflake fuzz_grpc finalize-poll + h1_chain testTCPPair finalizer

### DIFF
--- a/internal/mcp/fuzz_grpc_integration_test.go
+++ b/internal/mcp/fuzz_grpc_integration_test.go
@@ -1351,24 +1351,39 @@ func TestFuzzGRPC_FinalizesUnderCallerCancel(t *testing.T) {
 	})
 	_ = res // either an in-band stopped_reason or a transport-level cancel error is OK
 
-	// Query fuzz_jobs through a fresh context (the caller cancel does not
-	// affect this query).
-	jobsRes, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
-		Name: "query",
-		Arguments: map[string]any{
-			"resource": "fuzz_jobs",
-			"filter":   map[string]any{"tag": "usk-835-cancel"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("query fuzz_jobs: %v", err)
-	}
-	if jobsRes.IsError {
-		t.Fatalf("query fuzz_jobs returned error: %+v", jobsRes.Content)
-	}
+	// The cancelled CallTool may return to the client before the server's
+	// handler has actually finished. finalizeFuzzGRPCJob uses
+	// context.Background() internally so the closing UPDATE WILL eventually
+	// land — but not necessarily before this test reaches the assertion.
+	// Poll fuzz_jobs until completed_at is non-nil (mirror of USK-953 for
+	// fuzz_http; the http/ws/raw siblings already poll).
+	pollDeadline := time.Now().Add(2 * time.Second)
 	var jobsOut queryFuzzJobsResult
-	if err := json.Unmarshal([]byte(jobsRes.Content[0].(*gomcp.TextContent).Text), &jobsOut); err != nil {
-		t.Fatalf("unmarshal jobs: %v", err)
+	for {
+		jobsRes, err := cs.CallTool(context.Background(), &gomcp.CallToolParams{
+			Name: "query",
+			Arguments: map[string]any{
+				"resource": "fuzz_jobs",
+				"filter":   map[string]any{"tag": "usk-835-cancel"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("query fuzz_jobs: %v", err)
+		}
+		if jobsRes.IsError {
+			t.Fatalf("query fuzz_jobs returned error: %+v", jobsRes.Content)
+		}
+		jobsOut = queryFuzzJobsResult{}
+		if err := json.Unmarshal([]byte(jobsRes.Content[0].(*gomcp.TextContent).Text), &jobsOut); err != nil {
+			t.Fatalf("unmarshal jobs: %v", err)
+		}
+		if jobsOut.Total == 1 && jobsOut.Jobs[0].CompletedAt != nil {
+			break
+		}
+		if time.Now().After(pollDeadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	if jobsOut.Total != 1 {
 		t.Fatalf("jobs total = %d, want 1 (start INSERT must land via background ctx)", jobsOut.Total)

--- a/internal/proxybuild/h1_chain_test.go
+++ b/internal/proxybuild/h1_chain_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http1"
 )
 
-// testTCPPair returns a connected TCP pair; the caller closes both sides.
+// testTCPPair returns a connected TCP pair. Both ends are registered
+// with t.Cleanup so they stay alive (preventing the *net.TCPConn
+// finalizer from closing whichever side the caller discards via `_`,
+// which surfaced as a ~0.2% HealthCheck EOF flake) and are closed when
+// the test ends. Callers may still defer Close on either end without
+// double-close concerns — net.Conn.Close is idempotent.
 // We use real loopback TCP rather than net.Pipe so SetReadDeadline
 // behaves the same way the production code path observes (net.Pipe is
 // strictly synchronous and does not surface a queued FIN through the
@@ -36,6 +41,10 @@ func testTCPPair(t *testing.T) (client, server net.Conn) {
 		t.Fatal(err)
 	}
 	server = <-ch
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
 	return client, server
 }
 


### PR DESCRIPTION
## Summary

Two unrelated nightly-e2e flakes coalesced under this branch, both prompting test-side fixes only — no production code change.

### 1. `TestFuzzGRPC_FinalizesUnderCallerCancel` (commit f70455c)

`internal/mcp/fuzz_grpc_integration_test.go:1377` had been failing on the nightly e2e tier for three consecutive runs (#11/#12/#13):

```
fuzz_grpc_integration_test.go:1377:
fuzz_jobs.completed_at = nil after caller cancel; finalize did not land
```

Same race as **USK-953** (already fixed for fuzz_http): on the in-memory MCP transport, the cancelled `CallTool` returns to the client as soon as the handler ctx is cancelled, even though the server-side handler is still running and will dispatch `finalizeFuzzGRPCJob` via `context.Background()`. If the test's follow-up `query fuzz_jobs` lands before the finalize UPDATE, `completed_at` reads nil and the assertion fails.

Mirror the USK-953 polling pattern: poll `fuzz_jobs` with a 2 s deadline and 20 ms interval until `completed_at` is non-nil before asserting. The http/ws/raw siblings already poll; this brings fuzz_grpc into parity.

### 2. `TestH1Chain_EnsureFresh_PassThroughWhenAlive` (commit f02c5f8)

PR #76's own `test-e2e-smoke` run surfaced a separate ~0.2% flake:

```
h1_chain_test.go:58: EnsureFresh: connector: RedialUpstreamH1: cfg is nil
```

`testTCPPair` returns a connected loopback pair; the test discards the client side via `_, server := testTCPPair(t)`. With no live reference, Go's runtime is free to finalize the `*net.TCPConn` — its finalizer calls Close, sending FIN to the server. `HealthCheck`'s 1ms peek then sees EOF, EnsureFresh tries to redial, and the test's nil `cfg` surfaces the "cfg is nil" assertion failure. Reproduced locally at 10/5000 iterations; 0/5000 when both ends are retained.

Fix lives in the helper so all three `_`-discarding call sites are covered at once: register a `t.Cleanup` closure that captures both client and server references. Existing `defer Close()` calls stay correct because `net.Conn.Close` is idempotent.

## Test plan

- [x] `go test -race -tags e2e -run TestFuzzGRPC_FinalizesUnderCallerCancel -count=30 ./internal/mcp/` — 30/30 pass
- [x] `go test -race -count=500 -run 'TestH1Chain_EnsureFresh_*|TestH1Chain_CloseAll_*' ./internal/proxybuild/` — 500/500 pass
- [x] `gofmt` clean
- [ ] CI `test-e2e-smoke` green
- [ ] Nightly e2e (full) green on next scheduled fire (17:00 UTC) or via workflow_dispatch