### PR TITLE
fix(ci/depsec): use cursor pagination for Dependabot alerts API

### DIFF
--- a/tools/depsec/main.go
+++ b/tools/depsec/main.go
@@ -104,9 +104,11 @@ type ghAlert struct {
 
 func fetchAlerts(ctx context.Context, apiBase, owner, repo, token string) ([]Alert, error) {
 	hc := &http.Client{Timeout: 30 * time.Second}
+	// The Dependabot alerts API uses cursor pagination (Link header rel="next"),
+	// NOT ?page=N — the page parameter returns HTTP 400. Follow the Link header.
+	url := fmt.Sprintf("%s/repos/%s/%s/dependabot/alerts?state=open&per_page=100", apiBase, owner, repo)
 	var out []Alert
-	for page := 1; ; page++ {
-		url := fmt.Sprintf("%s/repos/%s/%s/dependabot/alerts?state=open&per_page=100&page=%d", apiBase, owner, repo, page)
+	for pages := 0; url != "" && pages < 1000; pages++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, err
@@ -120,6 +122,7 @@ func fetchAlerts(ctx context.Context, apiBase, owner, repo, token string) ([]Ale
 			return nil, err
 		}
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+		link := resp.Header.Get("Link")
 		resp.Body.Close()
 		if err != nil {
 			return nil, err
@@ -133,7 +136,7 @@ func fetchAlerts(ctx context.Context, apiBase, owner, repo, token string) ([]Ale
 
 		var batch []ghAlert
 		if err := json.Unmarshal(body, &batch); err != nil {
-			return nil, fmt.Errorf("decode alerts page %d: %w", page, err)
+			return nil, fmt.Errorf("decode alerts: %w", err)
 		}
 		for _, a := range batch {
 			if a.State != "open" {
@@ -151,10 +154,37 @@ func fetchAlerts(ctx context.Context, apiBase, owner, repo, token string) ([]Ale
 				URL:          a.HTMLURL,
 			})
 		}
-		if len(batch) < 100 {
-			return out, nil
+
+		next := parseNextLink(link)
+		if next == "" || next == url {
+			break
+		}
+		url = next
+	}
+	return out, nil
+}
+
+// parseNextLink extracts the rel="next" URL from a GitHub Link header, or "" if
+// there is no next page. Format:
+//
+//	<https://api.github.com/...&after=CUR>; rel="next", <...>; rel="prev"
+func parseNextLink(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		segs := strings.Split(part, ";")
+		if len(segs) < 2 {
+			continue
+		}
+		u := strings.TrimSpace(segs[0])
+		if !strings.HasPrefix(u, "<") || !strings.HasSuffix(u, ">") {
+			continue
+		}
+		for _, s := range segs[1:] {
+			if v := strings.TrimSpace(s); v == `rel="next"` || v == "rel=next" {
+				return u[1 : len(u)-1]
+			}
 		}
 	}
+	return ""
 }
 
 // loadNpmDirect returns the set of package names declared directly in

--- a/tools/depsec/main_test.go
+++ b/tools/depsec/main_test.go
@@ -47,6 +47,54 @@ func TestFetchAlerts(t *testing.T) {
 	}
 }
 
+func TestFetchAlerts_CursorPagination(t *testing.T) {
+	// The Dependabot API paginates by cursor (Link header), never ?page=N.
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "" {
+			t.Errorf("must not use ?page= pagination; got %q", r.URL.RawQuery)
+		}
+		switch r.URL.Query().Get("after") {
+		case "":
+			// First page advertises a next cursor.
+			w.Header().Set("Link", `<`+srvURL+`/repos/o/r/dependabot/alerts?state=open&per_page=100&after=CUR>; rel="next"`)
+			w.Write([]byte(`[{"number":1,"state":"open","dependency":{"package":{"ecosystem":"go","name":"m1"}},"security_vulnerability":{"first_patched_version":{"identifier":"v1"}}}]`))
+		case "CUR":
+			// Last page: no Link header.
+			w.Write([]byte(`[{"number":2,"state":"open","dependency":{"package":{"ecosystem":"npm","name":"m2"}},"security_vulnerability":{"first_patched_version":{"identifier":"2.0.0"}}}]`))
+		default:
+			t.Errorf("unexpected cursor %q", r.URL.Query().Get("after"))
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	alerts, err := fetchAlerts(context.Background(), srv.URL, "o", "r", "tkn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("want 2 alerts across 2 pages, got %d: %+v", len(alerts), alerts)
+	}
+	if alerts[0].Name != "m1" || alerts[1].Name != "m2" {
+		t.Errorf("pagination aggregation wrong: %+v", alerts)
+	}
+}
+
+func TestParseNextLink(t *testing.T) {
+	cases := map[string]string{
+		``: "",
+		`<https://api.github.com/x?after=A>; rel="next"`:                                                  "https://api.github.com/x?after=A",
+		`<https://api.github.com/x?before=B>; rel="prev", <https://api.github.com/x?after=A>; rel="next"`: "https://api.github.com/x?after=A",
+		`<https://api.github.com/x?before=B>; rel="prev"`:                                                 "",
+	}
+	for in, want := range cases {
+		if got := parseNextLink(in); got != want {
+			t.Errorf("parseNextLink(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestFetchAlerts_ForbiddenIsExplicit(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"Resource not accessible"}`, http.StatusForbidden)


### PR DESCRIPTION
## Problem

The first `workflow_dispatch` dry run of the weekly security workflow (added in #77) failed at **Compute update plan**:

```
status 400: "Pagination using the `page` parameter is not supported."
```

The Dependabot alerts REST endpoint rejects `?page=N` and only supports **cursor pagination via the `Link` header**. Local mocks accepted the `page` parameter, so this only surfaced against the live API — exactly what the dry run was for.

## Fix

- Follow the `Link` header `rel="next"` cursor instead of incrementing `?page=N`.
- Add a cursor-pagination integration test (two-page Link chain) and a `parseNextLink` unit test to lock in the wire contract so a mock can't mask this again.

## Validation

- `tools/depsec` `go test -race` green
- `make lint` clean

## After merge

Re-run `workflow_dispatch`. The repo currently has 20 open Dependabot alerts (2 high / 15 moderate / 3 low), so this run will exercise real alert fetch → plan routing (go_accepted / npm_update / deferred / manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)