### PR TITLE
fix(ci/depsec): reset security-update branch ref with explicit force body

### DIFF
--- a/.github/workflows/dependabot-security.yml
+++ b/.github/workflows/dependabot-security.yml
@@ -144,11 +144,17 @@ jobs:
 
           # Reset the branch ref to the current base so expectedHeadOid is known.
           # (git diff below is relative to that same base, so the API commit
-          # contains exactly this run's dependency-manifest changes.)
-          if ! gh api -X PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" \
-                 -f sha="$base_sha" -F force=true >/dev/null 2>&1; then
-            gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref="refs/heads/$branch" -f sha="$base_sha" >/dev/null
+          # contains exactly this run's dependency-manifest changes.) Check
+          # existence first, then send an explicit JSON body via --input: a
+          # force-update needs {"force": true} as a real boolean, which the -F
+          # shorthand does not reliably encode. Force is required because a prior
+          # run's branch tip is not an ancestor of the new base (non-fast-forward).
+          if gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" >/dev/null 2>&1; then
+            printf '{"sha":"%s","force":true}' "$base_sha" \
+              | gh api -X PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" --input - >/dev/null
+          else
+            printf '{"ref":"refs/heads/%s","sha":"%s"}' "$branch" "$base_sha" \
+              | gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" --input - >/dev/null
           fi
 
           # Changed files vs base. plan.json / pr-body.md live in $RUNNER_TEMP,


### PR DESCRIPTION
Follow-up to #81. The dry run got further this time — plan → Go bumps → npm bumps all passed, `client-id` auth works (no deprecation warning), and the ARG_MAX fix held. It then failed at the **branch-ref reset** with:

```
gh: Reference already exists (HTTP 422)
```

## Cause

The reset did `PATCH … -F force=true` with the PATCH error suppressed (`>/dev/null 2>&1`), then fell through to `POST … git/refs`. A prior failed run had already created `automated/security-updates`, so:
- the PATCH (force-update) failed silently — `-F force=true` didn't reliably encode `force` as a JSON boolean, so the non-fast-forward update was rejected;
- the fallback POST then hit `422 Reference already exists`.

## Fix

- **GET the ref first** to decide PATCH (exists) vs POST (new) — no more blind fallback.
- Send an **explicit JSON body** via `gh api --input -` (`{"sha":…,"force":true}` / `{"ref":…,"sha":…}`) so `force` is a genuine boolean.
- **Stop suppressing errors**, so any future failure surfaces its cause in the log.

Workflow-YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)