### PR TITLE
fix(mcp/safety): redact matched fragment in SafetyFilter violation log (CWE-312)

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
@@ -172,15 +173,30 @@ func (s *Server) checkSafetyInput(body []byte, rawURL string, headers []envelope
 }
 
 // safetyViolationError returns a generic error message for MCP clients when a safety
-// filter violation occurs. Details (rule ID, target, pattern) are logged server-side
-// to prevent leaking filter internals to the AI agent, which could enable bypass attempts.
+// filter violation occurs. Details (rule ID, target, matched-fragment digest) are logged
+// server-side to prevent leaking filter internals to the AI agent, which could enable
+// bypass attempts.
 func safetyViolationError(v *safety.InputViolation) string {
 	slog.Warn("SafetyFilter violation",
 		"rule_id", v.RuleID,
 		"rule_name", v.RuleName,
 		"target", v.Target,
-		"matched_on", v.MatchedOn,
+		"matched_on", redactMatchedFragment(v.MatchedOn),
 	)
 	return "SafetyFilter blocked this operation: request blocked by safety policy. " +
 		"This payload was classified as destructive and cannot be sent."
+}
+
+// redactMatchedFragment obfuscates a safety-filter matched fragment for logging.
+// The raw fragment is a slice of the request that triggered the match (e.g. an
+// Authorization/Cookie header value or a request-body span), so it must never be
+// logged in clear text (CWE-312). A truncated SHA-256 digest plus the byte length
+// preserves cross-log correlation and lets an operator confirm a repeated match
+// without exposing the underlying sensitive bytes.
+func redactMatchedFragment(fragment string) string {
+	if fragment == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(fragment))
+	return fmt.Sprintf("sha256:%x len=%d", sum[:8], len(fragment))
 }

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -1,0 +1,48 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestRedactMatchedFragment verifies that the safety-filter matched fragment is
+// never emitted in clear text (CWE-312 / go/clear-text-logging) while remaining
+// stable enough for cross-log correlation.
+func TestRedactMatchedFragment(t *testing.T) {
+	t.Run("empty stays empty", func(t *testing.T) {
+		if got := redactMatchedFragment(""); got != "" {
+			t.Errorf("redactMatchedFragment(\"\") = %q, want \"\"", got)
+		}
+	})
+
+	t.Run("sensitive fragment is not echoed verbatim", func(t *testing.T) {
+		secret := "Bearer sk-live-supersecrettoken"
+		got := redactMatchedFragment(secret)
+		if strings.Contains(got, secret) {
+			t.Fatalf("redacted output %q leaks the raw fragment", got)
+		}
+		if !strings.HasPrefix(got, "sha256:") {
+			t.Errorf("redacted output %q does not start with sha256:", got)
+		}
+		if !strings.Contains(got, fmt.Sprintf("len=%d", len(secret))) {
+			t.Errorf("redacted output %q missing byte length", got)
+		}
+	})
+
+	t.Run("digest is deterministic and matches SHA-256 prefix", func(t *testing.T) {
+		frag := "DROP TABLE users"
+		sum := sha256.Sum256([]byte(frag))
+		want := fmt.Sprintf("sha256:%x len=%d", sum[:8], len(frag))
+		if got := redactMatchedFragment(frag); got != want {
+			t.Errorf("redactMatchedFragment(%q) = %q, want %q", frag, got, want)
+		}
+	})
+
+	t.Run("distinct fragments produce distinct digests", func(t *testing.T) {
+		if redactMatchedFragment("a") == redactMatchedFragment("b") {
+			t.Error("distinct fragments produced identical digests")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert [#2](https://github.com/usk6666/yorishiro-proxy/security/code-scanning/2) — `go/clear-text-logging` (CWE-312 / CWE-315 / CWE-359, severity **high**).

CodeQL traced sensitive data from HTTP request headers (`internal/mcp/macro_handlers.go:598`) into a logging call (`internal/mcp/helpers.go:182`). The sink is the `matched_on` field of the `SafetyFilter violation` warning:

```go
slog.Warn("SafetyFilter violation", ..., "matched_on", v.MatchedOn)
```

`safety.InputViolation.MatchedOn` is the **raw slice of the request that triggered the match**. When the matched target is a header (`TargetHeader`), that fragment is a header value — e.g. an `Authorization` bearer token or a `Cookie` — so it was being logged in clear text.

## Fix

Obfuscate the fragment before logging with a truncated SHA-256 digest plus byte length via a new `redactMatchedFragment` helper:

```
matched_on=sha256:1a2b3c4d5e6f7a8b len=31
```

- Hashing is a recognized taint barrier for the `go/clear-text-logging` query, so the alert clears.
- The digest is deterministic, so an operator can still correlate a repeated match across log lines and confirm the length — without exposing the underlying sensitive bytes.
- `rule_id` / `rule_name` / `target` stay in clear text as before; they are filter internals, not request payload.

This aligns with the CodeQL recommendation to *encrypt, obfuscate, or omit* sensitive data before logging.

## Test

- New `TestRedactMatchedFragment` in `internal/mcp/helpers_test.go`: empty passthrough, no verbatim leak of the raw fragment, deterministic SHA-256-prefix format, and distinct-input/distinct-digest.
- `make build`, `make lint` (exit 0), `go test ./internal/mcp/ ./internal/safety/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)