### PR TITLE
feat(http2): firefox-shaped upstream H2 fingerprint driven by tls_fingerprint

### DIFF
--- a/docs/rfc/envelope.md
+++ b/docs/rfc/envelope.md
@@ -724,6 +724,23 @@ All forwarded streams reuse the same `Pipeline` and `RecordStep`, so Flow / Stre
 
 **gRPC-Web auto-classify (USK-934).** The `http` arm (and `auto` arm when it dispatches to HTTP/1.1) inspects the first request's `Content-Type` header per-exchange. When it matches `application/grpc-web[-text][+proto|…]`, the per-exchange client Channel is wrapped with `grpcweb.Wrap` (downstream) and the upstream Channel is wrapped via `connector.WrapH1UpstreamForDispatch` (upstream symmetry) — Stream `Protocol` is then re-tagged to `grpc-web` by `record_step.maybeRetagProtocol`. This mirrors the H2 sibling pattern (`connector.DispatchH2Stream`) so HTTP/1.1 keep-alive that mixes grpc-web POST and JSON POST on the same connection routes correctly per-exchange. See `internal/connector/h1_dispatch.go`.
 
+#### 3.4.3 Upstream HTTP/2 Fingerprint Parity (USK-1007)
+
+Anti-bot frontends (Cloudflare, Akamai) fingerprint a client's **HTTP/2 behaviour** — SETTINGS values + wire order, the connection-level WINDOW_UPDATE increment, and the request pseudo-header order — in addition to the TLS ClientHello. For the proxy's MITM identity to be coherent, its own *upstream* (ClientRole) H2 send-shape must match the browser it claims to be.
+
+The shape is driven by the existing `tls_fingerprint` value (no separate `h2_fingerprint` config): `http2.WithH2Fingerprint(cfg.EffectiveTLSFingerprint())` is threaded through all four upstream ClientRole dial seams (`stack_builder.go` pool dial, `connect_inner_dispatch.go` h2c, `stack_builder_target_override.go` forward, `h2_redial.go` GOAWAY redial). Only `firefox` diverges:
+
+- **SETTINGS** (`internal/layer/http2/fingerprint.go`, `firefoxSettingsFrame`): `HEADER_TABLE_SIZE=65536`, `ENABLE_PUSH=0`, `INITIAL_WINDOW_SIZE=131072`, `MAX_FRAME_SIZE=16384`, in that wire order; `MAX_CONCURRENT_STREAMS` dropped.
+- **Connection WINDOW_UPDATE**: stream-0 increment `12517377` (12 MiB window) vs the default 16 MiB.
+- **Request pseudo-header order** (`appendRequestPseudoHeaders`): Firefox `:method :path :authority :scheme` vs the default (Chrome-shaped) `:method :scheme :authority :path`.
+
+Every other profile (chrome / edge / safari / random / none / unset) and every ServerRole Layer keep the pre-USK-1007 behaviour byte-for-byte. Pinned against a Firefox 120 capture (coherent with the uTLS `Firefox_120` ClientHello, USK-1014); Akamai H2 fingerprint `1:65536;2:0;4:131072;5:16384|12517377|0|m,p,a,s`. `env.Raw` (the wire-observed snapshot) is never modified — this is an upstream send-shape only.
+
+> **Known limitations.**
+> - **PRIORITY frames / stream-dependency tree — unimplemented: USK-1018.** Firefox's HTTP/2 PRIORITY tree is not reproduced (RFC 9113 deprecated the scheme; high engine cost given lazy stream-id allocation). Acceptance is verifiable on SETTINGS + WINDOW_UPDATE + pseudo-order without it.
+> - **safari / edge / random** get coherent TLS but Chrome-shaped H2 (only `firefox` has an H2 profile today; an independent `h2_fingerprint` axis is deferred to M48).
+> - The offline recorded **modified-variant** re-encode (`httpaggregator.EncodeWireBytes`, used by `RecordStep` for the diagnostic `env.Raw` of a rule/plugin-mutated request) uses the default pseudo-header order regardless of fingerprint. The **live wire** is always correct (it is re-decomposed from the structured `HTTPMessage` through the fingerprint-aware native send path, not from the recorded bytes); wiring the per-connection fingerprint into the shared per-stack `WireEncoderRegistry` requires envelope-carried or per-connection registry plumbing, deferred.
+
 ### 3.5 Pipeline Step Categorization
 
 Pipeline interface is unchanged:

--- a/internal/connector/connect_inner_dispatch.go
+++ b/internal/connector/connect_inner_dispatch.go
@@ -232,6 +232,9 @@ func BuildPlainH2CStack(
 		http2.WithBodySpillThreshold(cfg.BodySpillThreshold),
 		http2.WithMaxBodySize(cfg.MaxBodySize),
 		http2.WithStateReleaser(cfg.PluginV2Engine),
+		// USK-1007: Firefox-shaped upstream H2 fingerprint when
+		// tls_fingerprint=firefox; no-op (Chrome shape) otherwise.
+		http2.WithH2Fingerprint(cfg.EffectiveTLSFingerprint()),
 	)
 	if err != nil {
 		// http2.New already closed upstreamConn on failure; close the

--- a/internal/connector/h2_redial.go
+++ b/internal/connector/h2_redial.go
@@ -105,6 +105,10 @@ func RedialUpstreamH2(
 		http2.WithMaxBodySize(cfg.MaxBodySize),
 		http2.WithStateReleaser(cfg.PluginV2Engine),
 		http2.WithGoAwayObserver(onGoAway),
+		// USK-1007: preserve the Firefox-shaped upstream H2 fingerprint
+		// across GOAWAY redials (USK-991 browser-parity north-star) —
+		// no-op (Chrome shape) when tls_fingerprint is not firefox.
+		http2.WithH2Fingerprint(cfg.EffectiveTLSFingerprint()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connector: redial h2 layer: %w", err)

--- a/internal/connector/stack_builder.go
+++ b/internal/connector/stack_builder.go
@@ -1719,6 +1719,9 @@ func buildH2Stack(
 			http2.WithBodySpillThreshold(cfg.BodySpillThreshold),
 			http2.WithMaxBodySize(cfg.MaxBodySize),
 			http2.WithStateReleaser(cfg.PluginV2Engine),
+			// USK-1007: Firefox-shaped upstream H2 fingerprint when
+			// tls_fingerprint=firefox; no-op (Chrome shape) otherwise.
+			http2.WithH2Fingerprint(cfg.EffectiveTLSFingerprint()),
 		)
 		if lerr != nil {
 			// http2.New already closed upstreamConn on failure.

--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -455,6 +455,9 @@ func buildTargetOverrideH2CStack(
 		http2.WithBodySpillThreshold(cfg.BodySpillThreshold),
 		http2.WithMaxBodySize(cfg.MaxBodySize),
 		http2.WithStateReleaser(cfg.PluginV2Engine),
+		// USK-1007: Firefox-shaped upstream H2 fingerprint when
+		// tls_fingerprint=firefox; no-op (Chrome shape) otherwise.
+		http2.WithH2Fingerprint(cfg.EffectiveTLSFingerprint()),
 	)
 	if err != nil {
 		// http2.New already closed upstreamConn on failure; close the

--- a/internal/layer/http2/channel.go
+++ b/internal/layer/http2/channel.go
@@ -341,7 +341,11 @@ func (c *channel) Send(ctx context.Context, env *envelope.Envelope) error {
 // id. Server-role channels arrive here with h2Stream pre-populated from
 // the inbound frame and skip allocation.
 func (c *channel) sendHeadersEvent(ctx context.Context, env *envelope.Envelope, evt *H2HeadersEvent) error {
-	fields := BuildHeaderFieldsFromEvent(env, evt)
+	// USK-1007: use the Layer's resolved browser fingerprint so the request
+	// pseudo-header order on the wire matches the advertised browser identity
+	// (Firefox: :method :path :authority :scheme). ServerRole / non-firefox
+	// Layers resolve to H2FingerprintDefault (Chrome-shaped order).
+	fields := BuildHeaderFieldsFromEventWithFingerprint(env, evt, c.layer.h2Fingerprint)
 	done := make(chan error, 1)
 
 	if err := c.allocateAndEnqueueFirstHeaders(ctx, fields, evt.EndStream, done); err != nil {
@@ -581,6 +585,18 @@ func BuildHeaderFieldsFromEvent(env *envelope.Envelope, evt *H2HeadersEvent) []h
 	return fields
 }
 
+// BuildHeaderFieldsFromEventWithFingerprint is the fingerprint-aware variant
+// of BuildHeaderFieldsFromEvent (USK-1007). fp selects the request
+// pseudo-header order: H2FingerprintFirefox emits :method :path :authority
+// :scheme; every other value keeps the historical :method :scheme :authority
+// :path order. Response pseudo-headers (:status) are unaffected. The native
+// send path (sendHeadersEvent) calls this with the Layer's resolved
+// fingerprint so the wire order matches the browser identity.
+func BuildHeaderFieldsFromEventWithFingerprint(env *envelope.Envelope, evt *H2HeadersEvent, fp H2Fingerprint) []hpack.HeaderField {
+	fields, _ := buildHeaderFieldsFromEventWithDiag(env, evt, fp)
+	return fields
+}
+
 // BuildHeaderFieldsFromEventWithDiag is the diagnostic-aware variant of
 // BuildHeaderFieldsFromEvent. It returns the HPACK field list and the
 // verbatim wire-name(s) of any RFC 7540 §8.1.2.2 / RFC 9113 §8.2.2
@@ -597,12 +613,22 @@ func BuildHeaderFieldsFromEvent(env *envelope.Envelope, evt *H2HeadersEvent) []h
 // mirror the receive-side anomaly Detail shape (assembler.go
 // regularHeaderAnomalies).
 func BuildHeaderFieldsFromEventWithDiag(env *envelope.Envelope, evt *H2HeadersEvent) ([]hpack.HeaderField, []string) {
+	return buildHeaderFieldsFromEventWithDiag(env, evt, H2FingerprintDefault)
+}
+
+// buildHeaderFieldsFromEventWithDiag is the shared implementation behind
+// BuildHeaderFieldsFromEventWithDiag (default fingerprint) and
+// BuildHeaderFieldsFromEventWithFingerprint (explicit fingerprint). fp only
+// affects request pseudo-header ordering (appendRequestPseudoHeaders); the
+// connection-specific strip and response path are identical for all
+// fingerprints.
+func buildHeaderFieldsFromEventWithDiag(env *envelope.Envelope, evt *H2HeadersEvent, fp H2Fingerprint) ([]hpack.HeaderField, []string) {
 	out := make([]hpack.HeaderField, 0, len(evt.Headers)+5)
 
 	if isResponseHeadersEvent(env, evt) {
 		out = appendResponsePseudoHeaders(out, evt)
 	} else {
-		out = appendRequestPseudoHeaders(out, evt)
+		out = appendRequestPseudoHeaders(out, evt, fp)
 	}
 
 	var stripped []string
@@ -650,22 +676,28 @@ func appendResponsePseudoHeaders(out []hpack.HeaderField, evt *H2HeadersEvent) [
 }
 
 // appendRequestPseudoHeaders adds the :method / :scheme / :authority /
-// :path / :protocol pseudo-headers for a request HEADERS event in
-// canonical wire order. Defaults mirror the previous inline logic in
-// BuildHeaderFieldsFromEvent for backward compatibility.
-func appendRequestPseudoHeaders(out []hpack.HeaderField, evt *H2HeadersEvent) []hpack.HeaderField {
+// :path / :protocol pseudo-headers for a request HEADERS event.
+//
+// The pseudo-header *order* is proxy-authored (the wire-observed order is
+// discarded on the Send path — HPACK re-encodes from the structured event),
+// so selecting it by fingerprint is not a normalization of wire-real data
+// (CLAUDE.md MITM Principle #1 applies to real headers, appended verbatim by
+// the caller after these pseudo-headers). USK-1007:
+//
+//   - H2FingerprintDefault (Chrome-shaped): :method :scheme :authority :path
+//   - H2FingerprintFirefox:                 :method :path :authority :scheme
+//
+// :authority is emitted only when non-empty (both orders). :protocol is
+// appended last for extended CONNECT (RFC 8441 §4), unchanged across
+// fingerprints.
+func appendRequestPseudoHeaders(out []hpack.HeaderField, evt *H2HeadersEvent, fp H2Fingerprint) []hpack.HeaderField {
 	method := evt.Method
 	if method == "" {
 		method = "GET"
 	}
-	out = append(out, hpack.HeaderField{Name: ":method", Value: method})
 	scheme := evt.Scheme
 	if scheme == "" {
 		scheme = "https"
-	}
-	out = append(out, hpack.HeaderField{Name: ":scheme", Value: scheme})
-	if evt.Authority != "" {
-		out = append(out, hpack.HeaderField{Name: ":authority", Value: evt.Authority})
 	}
 	path := evt.Path
 	if path == "" {
@@ -674,7 +706,29 @@ func appendRequestPseudoHeaders(out []hpack.HeaderField, evt *H2HeadersEvent) []
 	if evt.RawQuery != "" {
 		path = path + "?" + evt.RawQuery
 	}
-	out = append(out, hpack.HeaderField{Name: ":path", Value: path})
+
+	methodField := hpack.HeaderField{Name: ":method", Value: method}
+	schemeField := hpack.HeaderField{Name: ":scheme", Value: scheme}
+	pathField := hpack.HeaderField{Name: ":path", Value: path}
+	hasAuthority := evt.Authority != ""
+	authorityField := hpack.HeaderField{Name: ":authority", Value: evt.Authority}
+
+	if fp == H2FingerprintFirefox {
+		// Firefox: :method :path :authority :scheme
+		out = append(out, methodField, pathField)
+		if hasAuthority {
+			out = append(out, authorityField)
+		}
+		out = append(out, schemeField)
+	} else {
+		// Default (Chrome-shaped): :method :scheme :authority :path
+		out = append(out, methodField, schemeField)
+		if hasAuthority {
+			out = append(out, authorityField)
+		}
+		out = append(out, pathField)
+	}
+
 	// RFC 8441 §4: extended CONNECT carries :protocol on the request.
 	// Emit it only when the event actually populates the field — this
 	// keeps classic CONNECT (Method=CONNECT, ConnectProtocol="")

--- a/internal/layer/http2/fingerprint.go
+++ b/internal/layer/http2/fingerprint.go
@@ -1,0 +1,140 @@
+package http2
+
+import (
+	"strings"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/frame"
+)
+
+// H2Fingerprint selects the browser-shaped HTTP/2 send-fingerprint a
+// ClientRole (upstream) Layer presents to the peer. Cloudflare / Akamai and
+// similar anti-bot frontends fingerprint the *HTTP/2* behaviour of a client
+// (SETTINGS values + order, the connection-level WINDOW_UPDATE increment, and
+// the request pseudo-header order) in addition to the TLS ClientHello. For a
+// MITM proxy to present a coherent browser identity, the proxy's own upstream
+// H2 shape must match the browser it claims to be via tls_fingerprint.
+//
+// Only H2FingerprintFirefox diverges from the historical (Chrome-ish) shape;
+// every other value — including chrome / edge / safari / random / none / unset
+// — resolves to H2FingerprintDefault and keeps the pre-USK-1007 wire output
+// byte-for-byte. See docs/rfc/envelope.md §3.4.
+type H2Fingerprint int
+
+const (
+	// H2FingerprintDefault is the historical Chrome-shaped ClientRole H2
+	// send-fingerprint. It is the fallback for every profile except
+	// "firefox" and for every ServerRole Layer.
+	H2FingerprintDefault H2Fingerprint = iota
+	// H2FingerprintFirefox emits a Firefox-shaped ClientRole H2
+	// send-fingerprint (SETTINGS, WINDOW_UPDATE increment, pseudo-header
+	// order). Applies to the upstream (ClientRole) send-shape only.
+	H2FingerprintFirefox
+)
+
+// Firefox HTTP/2 wire constants.
+//
+// Pinned against a Firefox 120 capture (coherent with the uTLS Firefox_120
+// ClientHello selected by tls_fingerprint=firefox, USK-1014). The Akamai
+// passive-HTTP/2 fingerprint for this shape is:
+//
+//	1:65536;2:0;4:131072;5:16384|12517377|0|m,p,a,s
+//
+// decoded as SETTINGS HEADER_TABLE_SIZE=65536, ENABLE_PUSH=0,
+// INITIAL_WINDOW_SIZE=131072, MAX_FRAME_SIZE=16384 (in that wire order;
+// MAX_CONCURRENT_STREAMS and MAX_HEADER_LIST_SIZE are not sent); a stream-0
+// WINDOW_UPDATE increment of 12517377; no PRIORITY tree (deferred, USK-1018);
+// and request pseudo-header order :method :path :authority :scheme.
+const (
+	firefoxHeaderTableSize   uint32 = 65536
+	firefoxInitialWindowSize uint32 = 131072
+	firefoxMaxFrameSize      uint32 = 16384
+
+	// firefoxConnWindowIncrement is the stream-0 WINDOW_UPDATE increment
+	// Firefox sends immediately after its SETTINGS frame, raising the
+	// connection-level receive window from the RFC 9113 default of 65535 to
+	// 12 MiB (12582912). 12582912 - 65535 = 12517377.
+	firefoxConnWindowIncrement uint32 = 12517377
+)
+
+// resolveH2Fingerprint maps a tls_fingerprint profile string to the H2
+// send-fingerprint the Layer should present. Firefox shaping applies to the
+// upstream (ClientRole) send-shape only; ServerRole (client-facing) Layers
+// always use the default shape. Unknown / empty profiles fall back to the
+// default with no error (mirrors the uTLS layer's fallback, USK-1007 U2).
+func resolveH2Fingerprint(profile string, role Role) H2Fingerprint {
+	if role != ClientRole {
+		return H2FingerprintDefault
+	}
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "firefox":
+		return H2FingerprintFirefox
+	default:
+		return H2FingerprintDefault
+	}
+}
+
+// firefoxClientSettings returns the local SETTINGS a Firefox-shaped
+// ClientRole Layer applies (and therefore both advertises on the wire and
+// enforces for receive-side flow control). Unlike the default ClientRole
+// path — which advertises a 16 MiB stream window — Firefox advertises a
+// 131072-byte stream window, so the local settings must match to keep the
+// flow-control accounting coherent with what the wire announced.
+//
+// EnablePush is left 0 here; applyEnablePushDefault re-affirms it for
+// ClientRole per RFC 9113 §6.5.2. MaxConcurrentStreams / MaxHeaderListSize
+// are intentionally left 0 so firefoxSettingsFrame omits them from the wire.
+func firefoxClientSettings() Settings {
+	return Settings{
+		HeaderTableSize:   firefoxHeaderTableSize,
+		EnablePush:        0,
+		InitialWindowSize: firefoxInitialWindowSize,
+		MaxFrameSize:      firefoxMaxFrameSize,
+	}
+}
+
+// firefoxSettingsFrame serializes s into the Firefox SETTINGS wire order:
+// HEADER_TABLE_SIZE (0x1), ENABLE_PUSH (0x2), INITIAL_WINDOW_SIZE (0x4),
+// MAX_FRAME_SIZE (0x5). MAX_CONCURRENT_STREAMS is dropped entirely (Firefox
+// does not advertise it). MAX_HEADER_LIST_SIZE is emitted only when a caller
+// explicitly set a non-zero value (the pure Firefox shape leaves it 0 and
+// therefore off the wire), preserving the same conditional-emission contract
+// settingsToFrame applies for the default shape (e.g. the gRPC layer's
+// WithMaxHeaderListSize).
+func firefoxSettingsFrame(s Settings) []frame.Setting {
+	out := []frame.Setting{
+		{ID: frame.SettingHeaderTableSize, Value: s.HeaderTableSize},
+		{ID: frame.SettingEnablePush, Value: s.EnablePush},
+		{ID: frame.SettingInitialWindowSize, Value: s.InitialWindowSize},
+		{ID: frame.SettingMaxFrameSize, Value: s.MaxFrameSize},
+	}
+	if s.MaxHeaderListSize != 0 {
+		out = append(out, frame.Setting{
+			ID:    frame.SettingMaxHeaderListSize,
+			Value: s.MaxHeaderListSize,
+		})
+	}
+	return out
+}
+
+// defaultLocalSettings returns the local SETTINGS a Layer applies when the
+// caller did not supply an explicit WithInitialSettings override, selected by
+// fingerprint. The default (Chrome-shaped) path advertises a 16 MiB stream
+// window; the Firefox path advertises Firefox's 131072-byte window.
+func defaultLocalSettings(fp H2Fingerprint) Settings {
+	if fp == H2FingerprintFirefox {
+		return firefoxClientSettings()
+	}
+	def := DefaultSettings()
+	def.InitialWindowSize = defaultLargeStreamWindow
+	return def
+}
+
+// connWindowIncrement returns the stream-0 WINDOW_UPDATE increment sent after
+// the preface SETTINGS, selected by fingerprint. Default raises the
+// connection window to 16 MiB; Firefox raises it to 12 MiB.
+func connWindowIncrement(fp H2Fingerprint) uint32 {
+	if fp == H2FingerprintFirefox {
+		return firefoxConnWindowIncrement
+	}
+	return uint32(defaultLargeConnWindow - defaultConnectionWindowSize)
+}

--- a/internal/layer/http2/fingerprint_test.go
+++ b/internal/layer/http2/fingerprint_test.go
@@ -1,0 +1,385 @@
+package http2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/envelope"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/frame"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/hpack"
+)
+
+// chromeConnWindowIncrement is the default (Chrome-shaped) stream-0
+// WINDOW_UPDATE increment: 16 MiB - 65535.
+const chromeConnWindowIncrement = uint32(defaultLargeConnWindow - defaultConnectionWindowSize)
+
+// TestResolveH2Fingerprint verifies that only "firefox" on a ClientRole
+// Layer resolves to the Firefox shape; every other profile and every
+// ServerRole Layer resolves to the default (USK-1007 U1/U2).
+func TestResolveH2Fingerprint(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		role    Role
+		want    H2Fingerprint
+	}{
+		{"firefox_client", "firefox", ClientRole, H2FingerprintFirefox},
+		{"firefox_mixed_case_client", "FireFox", ClientRole, H2FingerprintFirefox},
+		{"firefox_padded_client", "  firefox  ", ClientRole, H2FingerprintFirefox},
+		{"firefox_server_ignored", "firefox", ServerRole, H2FingerprintDefault},
+		{"chrome_client", "chrome", ClientRole, H2FingerprintDefault},
+		{"edge_client", "edge", ClientRole, H2FingerprintDefault},
+		{"safari_client", "safari", ClientRole, H2FingerprintDefault},
+		{"random_client", "random", ClientRole, H2FingerprintDefault},
+		{"none_client", "none", ClientRole, H2FingerprintDefault},
+		{"empty_client", "", ClientRole, H2FingerprintDefault},
+		{"unknown_client", "brave", ClientRole, H2FingerprintDefault},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveH2Fingerprint(tt.profile, tt.role); got != tt.want {
+				t.Errorf("resolveH2Fingerprint(%q, %v) = %d, want %d", tt.profile, tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFirefoxSettingsFrame_GoldenOrder pins the Firefox SETTINGS wire order
+// and values against the FF120 capture: HEADER_TABLE_SIZE=65536,
+// ENABLE_PUSH=0, INITIAL_WINDOW_SIZE=131072, MAX_FRAME_SIZE=16384, with
+// MAX_CONCURRENT_STREAMS dropped.
+func TestFirefoxSettingsFrame_GoldenOrder(t *testing.T) {
+	got := firefoxSettingsFrame(firefoxClientSettings())
+	want := []frame.Setting{
+		{ID: frame.SettingHeaderTableSize, Value: 65536},
+		{ID: frame.SettingEnablePush, Value: 0},
+		{ID: frame.SettingInitialWindowSize, Value: 131072},
+		{ID: frame.SettingMaxFrameSize, Value: 16384},
+	}
+	assertSettingsEqual(t, got, want)
+
+	// MAX_CONCURRENT_STREAMS must never appear.
+	if _, ok := findSetting(got, frame.SettingMaxConcurrentStreams); ok {
+		t.Errorf("firefoxSettingsFrame emitted MAX_CONCURRENT_STREAMS, want absent: %+v", got)
+	}
+}
+
+// TestFirefoxSettingsFrame_MaxHeaderListSizeConditional confirms the
+// conditional-emission contract carries over: MAX_HEADER_LIST_SIZE is
+// appended only when explicitly non-zero (e.g. the gRPC WithMaxHeaderListSize
+// path), never in the pure Firefox shape.
+func TestFirefoxSettingsFrame_MaxHeaderListSizeConditional(t *testing.T) {
+	s := firefoxClientSettings()
+	s.MaxHeaderListSize = 262144
+	got := firefoxSettingsFrame(s)
+	v, ok := findSetting(got, frame.SettingMaxHeaderListSize)
+	if !ok || v != 262144 {
+		t.Fatalf("MAX_HEADER_LIST_SIZE = (%d, %v), want (262144, true); got %+v", v, ok, got)
+	}
+	// It must be appended last, after MAX_FRAME_SIZE.
+	if got[len(got)-1].ID != frame.SettingMaxHeaderListSize {
+		t.Errorf("MAX_HEADER_LIST_SIZE not emitted last: %+v", got)
+	}
+}
+
+// TestConnWindowIncrement verifies the fingerprint-selected stream-0
+// WINDOW_UPDATE increment.
+func TestConnWindowIncrement(t *testing.T) {
+	if got := connWindowIncrement(H2FingerprintFirefox); got != firefoxConnWindowIncrement {
+		t.Errorf("connWindowIncrement(firefox) = %d, want %d", got, firefoxConnWindowIncrement)
+	}
+	if got := connWindowIncrement(H2FingerprintDefault); got != chromeConnWindowIncrement {
+		t.Errorf("connWindowIncrement(default) = %d, want %d", got, chromeConnWindowIncrement)
+	}
+}
+
+// TestDefaultLocalSettings verifies the fingerprint-selected local SETTINGS
+// applied when no WithInitialSettings override is supplied.
+func TestDefaultLocalSettings(t *testing.T) {
+	ff := defaultLocalSettings(H2FingerprintFirefox)
+	if ff.HeaderTableSize != firefoxHeaderTableSize ||
+		ff.InitialWindowSize != firefoxInitialWindowSize ||
+		ff.MaxFrameSize != firefoxMaxFrameSize {
+		t.Errorf("defaultLocalSettings(firefox) = %+v, want firefox values", ff)
+	}
+
+	def := defaultLocalSettings(H2FingerprintDefault)
+	if def.InitialWindowSize != defaultLargeStreamWindow {
+		t.Errorf("defaultLocalSettings(default) InitialWindowSize = %d, want %d (16 MiB)",
+			def.InitialWindowSize, defaultLargeStreamWindow)
+	}
+	if def.HeaderTableSize != defaultHeaderTableSize {
+		t.Errorf("defaultLocalSettings(default) HeaderTableSize = %d, want %d",
+			def.HeaderTableSize, defaultHeaderTableSize)
+	}
+}
+
+// TestLayer_ClientRole_FirefoxSettings_Wire drives the full New() boot with
+// WithH2Fingerprint("firefox") and asserts the wire SETTINGS frame's exact
+// order+values and the conn-level WINDOW_UPDATE increment (12517377).
+func TestLayer_ClientRole_FirefoxSettings_Wire(t *testing.T) {
+	_, peer, cleanup := startClientLayer(t, WithH2Fingerprint("firefox"))
+	defer cleanup()
+
+	params, inc := readInitialSettingsAndConnWindow(t, peer)
+
+	want := []frame.Setting{
+		{ID: frame.SettingHeaderTableSize, Value: 65536},
+		{ID: frame.SettingEnablePush, Value: 0},
+		{ID: frame.SettingInitialWindowSize, Value: 131072},
+		{ID: frame.SettingMaxFrameSize, Value: 16384},
+	}
+	assertSettingsEqual(t, params, want)
+
+	if _, ok := findSetting(params, frame.SettingMaxConcurrentStreams); ok {
+		t.Errorf("firefox ClientRole SETTINGS contains MAX_CONCURRENT_STREAMS, want absent: %+v", params)
+	}
+	if inc != firefoxConnWindowIncrement {
+		t.Errorf("firefox conn WINDOW_UPDATE increment = %d, want %d", inc, firefoxConnWindowIncrement)
+	}
+}
+
+// TestLayer_ClientRole_DefaultSettings_NoRegression locks the pre-USK-1007
+// Chrome-shaped ClientRole wire output for the unset and explicit-"chrome"
+// cases. Any drift here is a backward-compat break.
+func TestLayer_ClientRole_DefaultSettings_NoRegression(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []Option
+	}{
+		{"unset", nil},
+		{"chrome", []Option{WithH2Fingerprint("chrome")}},
+		{"unknown_profile", []Option{WithH2Fingerprint("brave")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, peer, cleanup := startClientLayer(t, tc.opts...)
+			defer cleanup()
+
+			params, inc := readInitialSettingsAndConnWindow(t, peer)
+			want := []frame.Setting{
+				{ID: frame.SettingHeaderTableSize, Value: defaultHeaderTableSize},
+				{ID: frame.SettingEnablePush, Value: 0},
+				{ID: frame.SettingMaxConcurrentStreams, Value: defaultMaxConcurrentStreams},
+				{ID: frame.SettingInitialWindowSize, Value: defaultLargeStreamWindow},
+				{ID: frame.SettingMaxFrameSize, Value: defaultMaxFrameSize},
+			}
+			assertSettingsEqual(t, params, want)
+			if inc != chromeConnWindowIncrement {
+				t.Errorf("default conn WINDOW_UPDATE increment = %d, want %d", inc, chromeConnWindowIncrement)
+			}
+		})
+	}
+}
+
+// TestLayer_ServerRole_FirefoxIgnored verifies WithH2Fingerprint("firefox")
+// has no effect on a ServerRole (client-facing) Layer — browser fingerprinting
+// concerns the upstream send-shape only.
+func TestLayer_ServerRole_FirefoxIgnored(t *testing.T) {
+	_, peer, cleanup := startServerLayer(t, WithH2Fingerprint("firefox"))
+	defer cleanup()
+
+	params := readInitialSettings(t, peer)
+	// ServerRole omits ENABLE_PUSH (RFC 9113 §7.2.2, USK-825) and advertises
+	// the default header table size — not the Firefox 65536.
+	v, ok := findSetting(params, frame.SettingHeaderTableSize)
+	if !ok || v != defaultHeaderTableSize {
+		t.Errorf("ServerRole HEADER_TABLE_SIZE = (%d, %v), want (%d, true) — firefox must not apply",
+			v, ok, defaultHeaderTableSize)
+	}
+	if _, ok := findSetting(params, frame.SettingEnablePush); ok {
+		t.Errorf("ServerRole SETTINGS contains ENABLE_PUSH, want absent (firefox must not apply): %+v", params)
+	}
+}
+
+// TestAppendRequestPseudoHeaders_Order verifies the pseudo-header order the
+// wire encoder produces for each fingerprint via the exported
+// BuildHeaderFieldsFromEventWithFingerprint, including the backward-compatible
+// 2-arg default, the empty-:authority case, and extended-CONNECT :protocol.
+func TestAppendRequestPseudoHeaders_Order(t *testing.T) {
+	base := &H2HeadersEvent{Method: "GET", Scheme: "https", Authority: "example.com", Path: "/x"}
+	env := &envelope.Envelope{Direction: envelope.Send}
+
+	t.Run("firefox_order", func(t *testing.T) {
+		fields := BuildHeaderFieldsFromEventWithFingerprint(env, base, H2FingerprintFirefox)
+		assertPseudoOrder(t, fields, []string{":method", ":path", ":authority", ":scheme"})
+	})
+	t.Run("default_order", func(t *testing.T) {
+		fields := BuildHeaderFieldsFromEventWithFingerprint(env, base, H2FingerprintDefault)
+		assertPseudoOrder(t, fields, []string{":method", ":scheme", ":authority", ":path"})
+	})
+	t.Run("backward_compat_2arg_is_default", func(t *testing.T) {
+		fields := BuildHeaderFieldsFromEvent(env, base)
+		assertPseudoOrder(t, fields, []string{":method", ":scheme", ":authority", ":path"})
+	})
+	t.Run("firefox_empty_authority", func(t *testing.T) {
+		evt := &H2HeadersEvent{Method: "GET", Scheme: "https", Path: "/"}
+		fields := BuildHeaderFieldsFromEventWithFingerprint(env, evt, H2FingerprintFirefox)
+		assertPseudoOrder(t, fields, []string{":method", ":path", ":scheme"})
+	})
+	t.Run("firefox_extended_connect_protocol_last", func(t *testing.T) {
+		evt := &H2HeadersEvent{Method: "CONNECT", Scheme: "https", Authority: "example.com", Path: "/", ConnectProtocol: "websocket"}
+		fields := BuildHeaderFieldsFromEventWithFingerprint(env, evt, H2FingerprintFirefox)
+		assertPseudoOrder(t, fields, []string{":method", ":path", ":authority", ":scheme", ":protocol"})
+	})
+}
+
+// TestLayer_Firefox_NativeSend_PseudoOrder is the end-to-end wire assertion:
+// a firefox ClientRole Layer's native send path (sendHeadersEvent →
+// c.layer.h2Fingerprint) must place the request pseudo-headers on the wire in
+// Firefox order. The default (chrome) counterpart proves no regression.
+func TestLayer_Firefox_NativeSend_PseudoOrder(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []Option
+		want []string
+	}{
+		{"firefox", []Option{WithH2Fingerprint("firefox")}, []string{":method", ":path", ":authority", ":scheme"}},
+		{"default", nil, []string{":method", ":scheme", ":authority", ":path"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l, peer, cleanup := startClientLayer(t, tc.opts...)
+			defer cleanup()
+			peer.consumePeerSettings(t)
+
+			ch, err := l.OpenStream(context.Background())
+			if err != nil {
+				t.Fatalf("OpenStream: %v", err)
+			}
+			go func() {
+				_ = ch.Send(context.Background(), &envelope.Envelope{
+					Direction: envelope.Send,
+					Message: &H2HeadersEvent{
+						Method: "GET", Scheme: "https", Authority: "example.com", Path: "/p",
+						EndStream: true,
+					},
+				})
+			}()
+
+			fields := readHeadersFields(t, peer)
+			got := pseudoNames(fields)
+			assertStringSliceEqual(t, got, tc.want)
+		})
+	}
+}
+
+// --- helpers ---
+
+func assertSettingsEqual(t *testing.T, got, want []frame.Setting) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("SETTINGS length = %d, want %d\n got=%+v\nwant=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].ID != want[i].ID || got[i].Value != want[i].Value {
+			t.Fatalf("SETTINGS[%d] = {ID:%d Value:%d}, want {ID:%d Value:%d}\n got=%+v\nwant=%+v",
+				i, got[i].ID, got[i].Value, want[i].ID, want[i].Value, got, want)
+		}
+	}
+}
+
+// readInitialSettingsAndConnWindow drains frames until it has captured the
+// first non-ACK SETTINGS params and the first stream-0 WINDOW_UPDATE
+// increment, returning both.
+func readInitialSettingsAndConnWindow(t *testing.T, p *h2Peer) ([]frame.Setting, uint32) {
+	t.Helper()
+	var params []frame.Setting
+	var inc uint32
+	haveSettings := false
+	haveWU := false
+	deadline := time.Now().Add(2 * time.Second)
+	for (!haveSettings || !haveWU) && time.Now().Before(deadline) {
+		f, err := p.rd.ReadFrame()
+		if err != nil {
+			t.Fatalf("read peer setup: %v", err)
+		}
+		switch f.Header.Type {
+		case frame.TypeSettings:
+			if f.Header.Flags.Has(frame.FlagAck) {
+				continue
+			}
+			sp, perr := f.SettingsParams()
+			if perr != nil {
+				t.Fatalf("SettingsParams: %v", perr)
+			}
+			params = sp
+			haveSettings = true
+		case frame.TypeWindowUpdate:
+			if f.Header.StreamID != 0 {
+				continue
+			}
+			v, werr := f.WindowUpdateIncrement()
+			if werr != nil {
+				t.Fatalf("WindowUpdateIncrement: %v", werr)
+			}
+			inc = v
+			haveWU = true
+		}
+	}
+	if !haveSettings || !haveWU {
+		t.Fatalf("did not observe both SETTINGS and conn WINDOW_UPDATE within deadline (settings=%v, wu=%v)",
+			haveSettings, haveWU)
+	}
+	return params, inc
+}
+
+// readHeadersFields reads frames from the peer until the first HEADERS frame,
+// then HPACK-decodes its block. A 65536-byte decoder table is used so the
+// firefox layer's larger encoder table never trips a table-size-update limit.
+func readHeadersFields(t *testing.T, p *h2Peer) []hpack.HeaderField {
+	t.Helper()
+	dec := hpack.NewDecoder(65536)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f, err := p.rd.ReadFrame()
+		if err != nil {
+			t.Fatalf("read HEADERS: %v", err)
+		}
+		if f.Header.Type != frame.TypeHeaders {
+			continue
+		}
+		block, berr := f.HeaderBlockFragment()
+		if berr != nil {
+			t.Fatalf("HeaderBlockFragment: %v", berr)
+		}
+		fields, derr := dec.Decode(block)
+		if derr != nil {
+			t.Fatalf("hpack decode: %v", derr)
+		}
+		return fields
+	}
+	t.Fatal("did not observe HEADERS within deadline")
+	return nil
+}
+
+// pseudoNames returns the names of the leading pseudo-header fields (":"
+// prefix) in wire order.
+func pseudoNames(fields []hpack.HeaderField) []string {
+	var out []string
+	for _, f := range fields {
+		if len(f.Name) == 0 || f.Name[0] != ':' {
+			break
+		}
+		out = append(out, f.Name)
+	}
+	return out
+}
+
+func assertPseudoOrder(t *testing.T, fields []hpack.HeaderField, want []string) {
+	t.Helper()
+	assertStringSliceEqual(t, pseudoNames(fields), want)
+}
+
+func assertStringSliceEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("pseudo-header order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("pseudo-header order = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/layer/http2/layer.go
+++ b/internal/layer/http2/layer.go
@@ -58,6 +58,11 @@ type options struct {
 	maxBody              int64
 	stateReleaser        pluginv2.StateReleaser
 	goAwayObserver       func()
+	// h2FingerprintProfile is the raw tls_fingerprint value (e.g.
+	// "firefox") driving the upstream (ClientRole) HTTP/2 send-shape. Empty
+	// / unknown / non-firefox values resolve to H2FingerprintDefault. See
+	// WithH2Fingerprint and resolveH2Fingerprint (fingerprint.go).
+	h2FingerprintProfile string
 	// enableConnectProtocol overrides the ServerRole-only default
 	// advertisement of SETTINGS_ENABLE_CONNECT_PROTOCOL. Tracked as a
 	// pointer so the zero value of options can be distinguished from
@@ -102,6 +107,18 @@ func WithMaxConcurrentStreams(n uint32) Option {
 // the decoder will accept. 0 = use HPACK's defaultMaxHeaderListSize.
 func WithMaxHeaderListSize(n uint32) Option {
 	return func(o *options) { o.maxHeaderListSize = n }
+}
+
+// WithH2Fingerprint selects the browser-shaped HTTP/2 send-fingerprint the
+// upstream (ClientRole) Layer presents to the peer, sourced from the
+// existing tls_fingerprint value (BuildConfig.EffectiveTLSFingerprint). Only
+// "firefox" diverges from the historical (Chrome-shaped) behaviour; every
+// other value — chrome / edge / safari / random / none / unknown / empty —
+// keeps the pre-USK-1007 SETTINGS, WINDOW_UPDATE increment, and pseudo-header
+// order byte-for-byte. The profile has no effect on ServerRole (client-facing)
+// Layers: browser fingerprinting concerns the proxy's *upstream* send-shape.
+func WithH2Fingerprint(profile string) Option {
+	return func(o *options) { o.h2FingerprintProfile = profile }
 }
 
 // WithBodySpillDir records the directory used for body spill temp files.
@@ -227,6 +244,12 @@ type Layer struct {
 	encoder     *hpack.Encoder
 
 	encoderTableSize uint32
+
+	// h2Fingerprint is the resolved browser send-fingerprint for this Layer
+	// (set once in New). It drives the request pseudo-header order emitted by
+	// the native send path (sendHeadersEvent). ClientRole-only: ServerRole
+	// Layers always resolve to H2FingerprintDefault.
+	h2Fingerprint H2Fingerprint
 
 	mu         sync.Mutex
 	channels   map[uint32]*channel
@@ -547,6 +570,12 @@ func New(conn net.Conn, streamID string, role Role, opts ...Option) (*Layer, err
 		opt(&o)
 	}
 
+	// USK-1007: resolve the browser send-fingerprint once. Firefox shaping
+	// applies to the upstream (ClientRole) send-shape only; every other
+	// profile (and every ServerRole Layer) resolves to the default
+	// Chrome-shaped behaviour, keeping the pre-USK-1007 wire output intact.
+	fp := resolveH2Fingerprint(o.h2FingerprintProfile, role)
+
 	httpConn := NewConn()
 	if o.initialSettings != nil {
 		settings := *o.initialSettings
@@ -556,11 +585,14 @@ func New(conn net.Conn, streamID string, role Role, opts ...Option) (*Layer, err
 			return nil, err
 		}
 	} else {
-		def := DefaultSettings()
-		def.InitialWindowSize = defaultLargeStreamWindow
+		def := defaultLocalSettings(fp)
 		// Apply per-field MaxConcurrentStreams override only when the
 		// caller did not supply a full WithInitialSettings; the explicit
-		// override wins per the WithMaxConcurrentStreams contract.
+		// override wins per the WithMaxConcurrentStreams contract. (The
+		// Firefox shape drops MAX_CONCURRENT_STREAMS from the wire regardless
+		// — firefoxSettingsFrame never emits it — but honouring the field
+		// here keeps the local-settings accounting consistent for the
+		// unusual firefox+WithMaxConcurrentStreams combination.)
 		if o.maxConcurrentStreams != 0 {
 			def.MaxConcurrentStreams = o.maxConcurrentStreams
 		}
@@ -598,6 +630,7 @@ func New(conn net.Conn, streamID string, role Role, opts ...Option) (*Layer, err
 		windowUpdated:      make(chan struct{}, 1),
 		nextClientStreamID: 1,
 		encoderTableSize:   local.HeaderTableSize,
+		h2Fingerprint:      fp,
 	}
 
 	if err := l.runPreface(); err != nil {
@@ -618,10 +651,10 @@ func New(conn net.Conn, streamID string, role Role, opts ...Option) (*Layer, err
 	go l.readerLoop()
 
 	l.enqueueWrite(writeRequest{settings: &writeSettings{
-		params: settingsToFrame(local, role),
+		params: settingsToFrame(local, role, fp),
 	}})
 
-	bump := uint32(defaultLargeConnWindow - defaultConnectionWindowSize)
+	bump := connWindowIncrement(fp)
 	if err := l.conn.IncrementRecvWindow(bump); err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -824,7 +857,16 @@ func (l *Layer) runPreface() error {
 // initial SETTINGS frame entirely. This keeps the wire output identical
 // to the pre-USK-764 behaviour for endpoints that do not support extended
 // CONNECT.
-func settingsToFrame(s Settings, role Role) []frame.Setting {
+//
+// USK-1007: when fp == H2FingerprintFirefox on a ClientRole Layer, the
+// Firefox-shaped ordered set is emitted instead (firefoxSettingsFrame) —
+// HEADER_TABLE_SIZE, ENABLE_PUSH, INITIAL_WINDOW_SIZE, MAX_FRAME_SIZE, with
+// MAX_CONCURRENT_STREAMS dropped. Every other fingerprint keeps the default
+// (Chrome-shaped) emission below byte-for-byte.
+func settingsToFrame(s Settings, role Role, fp H2Fingerprint) []frame.Setting {
+	if fp == H2FingerprintFirefox && role == ClientRole {
+		return firefoxSettingsFrame(s)
+	}
 	out := []frame.Setting{
 		{ID: frame.SettingHeaderTableSize, Value: s.HeaderTableSize},
 	}


### PR DESCRIPTION
## Summary

Make the proxy's upstream (ClientRole) HTTP/2 connection present a **Firefox-shaped fingerprint** so Cloudflare/Akamai read a coherent browser identity (they fingerprint H2 behaviour, not just TLS). Driven entirely from the **existing `tls_fingerprint` value** — no new config/Manager/MCP surface.

Firefox distinguishers vs the current (Chrome-ish) shape, all upstream-send-shape only (`env.Raw` untouched):

| Authority | Firefox | Default (chrome/edge/safari/random/none/unset) |
|-----------|---------|-----------------------------------------------|
| SETTINGS order+values | `HEADER_TABLE_SIZE=65536, ENABLE_PUSH=0, INITIAL_WINDOW_SIZE=131072, MAX_FRAME_SIZE=16384` (MAX_CONCURRENT_STREAMS dropped) | current: `HEADER_TABLE_SIZE=4096, ENABLE_PUSH=0, MAX_CONCURRENT_STREAMS=500, INITIAL_WINDOW_SIZE=16MiB, MAX_FRAME_SIZE=16384` |
| Conn WINDOW_UPDATE increment | `12517377` (12 MiB window) | `16711681` (16 MiB window) |
| Request pseudo-header order | `:method :path :authority :scheme` | `:method :scheme :authority :path` |

Pinned against an FF120 capture (coherent with the uTLS `Firefox_120` ClientHello of USK-1014); Akamai H2 fingerprint `1:65536;2:0;4:131072;5:16384|12517377|0|m,p,a,s`.

## Implementation

- **New `internal/layer/http2/fingerprint.go`** — `H2Fingerprint` profile (`resolveH2Fingerprint`, `firefoxSettingsFrame`, `firefoxClientSettings`, `defaultLocalSettings`, `connWindowIncrement`). Ordered `[]frame.Setting` (never map/struct-field derived). Firefox applies to ClientRole only; unknown/empty → chrome fallback (no error, mirrors uTLS layer).
- `settingsToFrame`, the preface WINDOW_UPDATE bump, and `appendRequestPseudoHeaders` are made fingerprint-aware; the Layer resolves its fingerprint once in `New` and the native send path (`sendHeadersEvent`) threads it via `c.layer.h2Fingerprint`.
- New `WithH2Fingerprint` option sourced from `cfg.EffectiveTLSFingerprint()` at **all four** upstream ClientRole dial seams: `stack_builder.go` (pool dial), `connect_inner_dispatch.go` (h2c), `stack_builder_target_override.go` (forward), and **`h2_redial.go`** (GOAWAY redial — preserves the USK-991 browser-parity north-star across redials).
- Aggregated-HTTP/2 live send already routes through the native inner channel, so it is firefox-shaped with no extra wiring.
- Default/backward-compat branches are byte-for-byte unchanged; the h2 pool key already folds `EffectiveTLSFingerprint()`.
- docs/rfc/envelope.md §3.4.3 added, incl. the deferred PRIORITY note.

## Test plan

`make build` / `make lint` / `make test` all green. New `fingerprint_test.go`:
- `resolveH2Fingerprint` table (firefox client/server, chrome/edge/safari/random/none/empty/unknown, case+trim).
- Golden `firefoxSettingsFrame` order+values; MAX_HEADER_LIST_SIZE conditional; `connWindowIncrement`; `defaultLocalSettings`.
- Wire boot: firefox SETTINGS exact order + WINDOW_UPDATE=12517377; **no-regression** default/chrome/unknown → chrome SETTINGS + 16 MiB; ServerRole ignores firefox.
- Pseudo-order via `BuildHeaderFieldsFromEventWithFingerprint` (firefox/default/2-arg backward-compat/empty-authority/extended-CONNECT `:protocol`).
- End-to-end native-send: firefox ClientRole Layer puts Firefox pseudo-order on the wire (HPACK-decoded), plus chrome counterpart.

## Known limitations (reviewer notes)

- **PRIORITY frames / stream-dependency tree — deferred to USK-1018** (RFC 9113 deprecated the scheme; high engine cost). Acceptance is verifiable on SETTINGS + WINDOW_UPDATE + pseudo-order without it.
- **safari / edge / random** get coherent TLS but Chrome-shaped H2 today (only `firefox` has an H2 profile; independent `h2_fingerprint` axis deferred to M48).
- The offline **recorded modified-variant** re-encode (`httpaggregator.EncodeWireBytes`, `RecordStep` diagnostic bytes for a rule/plugin-mutated request) uses the default pseudo-order regardless of fingerprint. The **live wire is always correct** (re-decomposed from the structured `HTTPMessage` through the fingerprint-aware native send path). Wiring per-connection fingerprint into the shared per-stack `WireEncoderRegistry` needs envelope-carried or per-connection registry plumbing (out of this Issue's surface); documented as a follow-up in §3.4.3.

Resolves USK-1007
Linear: https://linear.app/usk6666/issue/USK-1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fv5e3Z8CgsApXehuaZhoae