### PR TITLE
feat(tls): capture client ClientHello JA3/JA4 (USK-1015)

### DIFF
--- a/internal/connector/connect_handler.go
+++ b/internal/connector/connect_handler.go
@@ -331,8 +331,7 @@ func runTLSMITM(
 	// USK-997: sniff-first peek. Test-only DisableClientHelloPeek bypasses.
 	var peeked ClientHelloPeek
 	if buildCfg == nil || !buildCfg.DisableClientHelloPeek {
-		sni, alpn := peekClientHelloSNIAndALPN(pc)
-		peeked = ClientHelloPeek{SNI: sni, ALPN: alpn}
+		peeked = peekClientHelloSNIAndALPN(pc)
 	}
 
 	stack, clientSnap, upstreamSnap, err := BuildConnectionStack(ctx, pc, target, buildCfg, peeked)

--- a/internal/connector/stack_builder.go
+++ b/internal/connector/stack_builder.go
@@ -640,6 +640,17 @@ type ClientHelloPeek struct {
 	// "forward this list verbatim to upstream and advertise upstream's
 	// pick back to the client".
 	ALPN []string
+
+	// ClientJA3 / ClientJA4 are the client's ClientHello fingerprints
+	// computed from the same peek buffer (USK-1015). Empty when the peek
+	// failed, the ClientHello was malformed, or it exceeded the peek cap.
+	// Unlike ALPN these are pure observation overlay — they never steer
+	// the build path; performClientMITM stamps them onto the client-facing
+	// TLSSnapshot so plugins / flow recording can surface them. Capture
+	// only: mirroring the client fingerprint to the upstream dial is
+	// unimplemented (deferred).
+	ClientJA3 string
+	ClientJA4 string
 }
 
 // BuildConnectionStack constructs a ConnectionStack for the given CONNECT
@@ -959,10 +970,10 @@ func buildALPNRoutedStack(
 
 	if cacheHit {
 		clientTLSConn, upstreamConn, clientSnap, upstreamSnap, err = buildCacheHitPath(
-			ctx, clientConn, target, host, cachedALPN, cacheKey, hostTLS, cfg)
+			ctx, clientConn, target, host, cachedALPN, cacheKey, peeked, hostTLS, cfg)
 	} else {
 		clientTLSConn, upstreamConn, clientSnap, upstreamSnap, err = buildCacheMissPath(
-			ctx, clientConn, target, host, cacheKey, hostTLS, cfg)
+			ctx, clientConn, target, host, cacheKey, peeked, hostTLS, cfg)
 	}
 	if err != nil {
 		return nil, nil, nil, err
@@ -1025,11 +1036,12 @@ func buildCacheHitPath(
 	clientConn net.Conn,
 	target, host, cachedALPN string,
 	cacheKey ALPNCacheKey,
+	peeked ClientHelloPeek,
 	hostTLS *resolvedTLS,
 	cfg *BuildConfig,
 ) (clientTLSConn net.Conn, upstreamConn net.Conn, clientSnap, upstreamSnap *envelope.TLSSnapshot, err error) {
 	clientOffers := clientALPNOffersForUpstream(cachedALPN)
-	clientTLSConn, clientSnap, err = performClientMITM(ctx, clientConn, host, clientOffers, cfg)
+	clientTLSConn, clientSnap, err = performClientMITM(ctx, clientConn, host, clientOffers, peeked, cfg)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -1104,6 +1116,7 @@ func buildCacheMissPath(
 	clientConn net.Conn,
 	target, host string,
 	cacheKey ALPNCacheKey,
+	peeked ClientHelloPeek,
 	hostTLS *resolvedTLS,
 	cfg *BuildConfig,
 ) (clientTLSConn net.Conn, upstreamConn net.Conn, clientSnap, upstreamSnap *envelope.TLSSnapshot, err error) {
@@ -1135,7 +1148,7 @@ func buildCacheMissPath(
 	// a non-empty protocol the proxy can dispatch on. See function comment
 	// for the rationale (USK-793).
 	clientOffers := clientALPNOffersForUpstream(upstreamALPN)
-	clientTLSConn, clientSnap, err = performClientMITM(ctx, clientConn, host, clientOffers, cfg)
+	clientTLSConn, clientSnap, err = performClientMITM(ctx, clientConn, host, clientOffers, peeked, cfg)
 	if err != nil {
 		upstreamConn.Close()
 		return nil, nil, nil, nil, err
@@ -1235,7 +1248,7 @@ func buildSniffFirstStack(
 	clientOffers := mitmAdvertiseFromUpstreamPick(upstreamALPN)
 
 	// Step 3: client MITM TLS handshake.
-	clientTLSConn, clientSnap, err := performClientMITM(ctx, clientConn, host, clientOffers, cfg)
+	clientTLSConn, clientSnap, err := performClientMITM(ctx, clientConn, host, clientOffers, peeked, cfg)
 	if err != nil {
 		_ = upstreamConn.Close()
 		return nil, nil, nil, err
@@ -1346,7 +1359,7 @@ func buildPoolHitFastPath(
 		clientOffers = []string{ALPNProtocolH2}
 	}
 
-	clientTLSConn, clientSnap, err := performClientMITM(ctx, clientConn, host, clientOffers, cfg)
+	clientTLSConn, clientSnap, err := performClientMITM(ctx, clientConn, host, clientOffers, peeked, cfg)
 	if err != nil {
 		// Release the pool reservation — Layer is healthy, we just didn't
 		// complete the client-side handshake. Put (not Evict) keeps the
@@ -1489,11 +1502,19 @@ func fallbackPoolHitToFreshDial(
 // An empty / nil alpnOffers leaves NextProtos unset so the client never sees
 // the ALPN extension; the client will speak whatever default it prefers
 // (HTTP/1.x for browsers and curl).
+//
+// peek carries the client's ClientHello fingerprints (USK-1015). They are
+// stamped onto the returned client-facing TLSSnapshot uniformly for every
+// MITM build branch (sniff-first, cache-hit, cache-miss, pool-hit, fallback)
+// so plugin / flow surfaces see the client's JA3/JA4 regardless of ALPN.
+// A zero-value peek leaves the fingerprint fields empty (forward callers,
+// tests).
 func performClientMITM(
 	ctx context.Context,
 	clientConn net.Conn,
 	host string,
 	alpnOffers []string,
+	peek ClientHelloPeek,
 	cfg *BuildConfig,
 ) (net.Conn, *envelope.TLSSnapshot, error) {
 	// USK-813: count entries for the test-only ClientMITMHandshakeCount
@@ -1520,6 +1541,15 @@ func performClientMITM(
 	tlsConn, clientSnap, err := tlslayer.Server(ctx, clientConn, serverTLSCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: %w", ErrClientTLSMITMHandshake, err)
+	}
+	// USK-1015: stamp the client's ClientHello fingerprints onto the
+	// client-facing snapshot BEFORE firing the on_handshake hook so plugins
+	// observe ja3/ja4. ClientFingerprint mirrors ClientJA4 for the legacy
+	// `client_fingerprint` plugin key. Never applied to the upstream snapshot.
+	if clientSnap != nil {
+		clientSnap.ClientJA3 = peek.ClientJA3
+		clientSnap.ClientJA4 = peek.ClientJA4
+		clientSnap.ClientFingerprint = peek.ClientJA4
 	}
 	fireTLSHandshakeHook(ctx, cfg, "server", clientSnap)
 	return tlsConn, clientSnap, nil

--- a/internal/connector/stack_builder_sniff_first_test.go
+++ b/internal/connector/stack_builder_sniff_first_test.go
@@ -80,9 +80,9 @@ func TestPeekClientHelloSNIAndALPN_NotPeekConn(t *testing.T) {
 	defer a.Close()
 	defer b.Close()
 
-	sni, alpn := peekClientHelloSNIAndALPN(a)
-	if sni != "" || alpn != nil {
-		t.Errorf("non-PeekConn: got (%q, %v), want (\"\", nil)", sni, alpn)
+	peeked := peekClientHelloSNIAndALPN(a)
+	if peeked.SNI != "" || peeked.ALPN != nil {
+		t.Errorf("non-PeekConn: got (%q, %v), want (\"\", nil)", peeked.SNI, peeked.ALPN)
 	}
 }
 
@@ -95,9 +95,9 @@ func TestPeekClientHelloSNIAndALPN_ClosedPeekConn(t *testing.T) {
 	_ = b.Close() // peer close → peek sees EOF
 	_ = a.Close()
 
-	sni, alpn := peekClientHelloSNIAndALPN(pc)
-	if sni != "" || alpn != nil {
-		t.Errorf("closed conn: got (%q, %v), want (\"\", nil)", sni, alpn)
+	peeked := peekClientHelloSNIAndALPN(pc)
+	if peeked.SNI != "" || peeked.ALPN != nil {
+		t.Errorf("closed conn: got (%q, %v), want (\"\", nil)", peeked.SNI, peeked.ALPN)
 	}
 }
 
@@ -114,9 +114,9 @@ func TestPeekClientHelloSNIAndALPN_NonTLSBytes(t *testing.T) {
 		_, _ = b.Write([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n"))
 	}()
 
-	sni, alpn := peekClientHelloSNIAndALPN(pc)
-	if sni != "" || alpn != nil {
-		t.Errorf("non-TLS bytes: got (%q, %v), want (\"\", nil)", sni, alpn)
+	peeked := peekClientHelloSNIAndALPN(pc)
+	if peeked.SNI != "" || peeked.ALPN != nil {
+		t.Errorf("non-TLS bytes: got (%q, %v), want (\"\", nil)", peeked.SNI, peeked.ALPN)
 	}
 	_ = b.Close()
 }
@@ -148,12 +148,16 @@ func TestPeekClientHelloSNIAndALPN_ValidClientHello(t *testing.T) {
 		_ = conn.Close()
 	}()
 
-	sni, alpn := peekClientHelloSNIAndALPN(pc)
-	if sni != wantSNI {
-		t.Errorf("sni = %q, want %q", sni, wantSNI)
+	peeked := peekClientHelloSNIAndALPN(pc)
+	if peeked.SNI != wantSNI {
+		t.Errorf("sni = %q, want %q", peeked.SNI, wantSNI)
 	}
-	if !reflect.DeepEqual(alpn, wantALPN) {
-		t.Errorf("alpn = %v, want %v", alpn, wantALPN)
+	if !reflect.DeepEqual(peeked.ALPN, wantALPN) {
+		t.Errorf("alpn = %v, want %v", peeked.ALPN, wantALPN)
+	}
+	// USK-1015: a real ClientHello yields non-empty JA3/JA4.
+	if peeked.ClientJA3 == "" || peeked.ClientJA4 == "" {
+		t.Errorf("expected non-empty fingerprints, got ja3=%q ja4=%q", peeked.ClientJA3, peeked.ClientJA4)
 	}
 
 	_ = a.Close()
@@ -181,12 +185,12 @@ func TestPeekClientHelloSNIAndALPN_SNIOnlyNoALPN(t *testing.T) {
 		_ = conn.Close()
 	}()
 
-	sni, alpn := peekClientHelloSNIAndALPN(pc)
-	if sni != wantSNI {
-		t.Errorf("sni = %q, want %q", sni, wantSNI)
+	peeked := peekClientHelloSNIAndALPN(pc)
+	if peeked.SNI != wantSNI {
+		t.Errorf("sni = %q, want %q", peeked.SNI, wantSNI)
 	}
-	if alpn != nil {
-		t.Errorf("alpn = %v, want nil (no extension)", alpn)
+	if peeked.ALPN != nil {
+		t.Errorf("alpn = %v, want nil (no extension)", peeked.ALPN)
 	}
 
 	_ = a.Close()
@@ -385,8 +389,7 @@ func runBuildConnectionStackSniffFirstWithCfg(
 		pc := NewPeekConn(serverConn)
 		// Drive the sniff manually here (we're calling
 		// BuildConnectionStack directly, not via runTLSMITM).
-		sni, alpn := peekClientHelloSNIAndALPN(pc)
-		peeked := ClientHelloPeek{SNI: sni, ALPN: alpn}
+		peeked := peekClientHelloSNIAndALPN(pc)
 		s, cs, us, bErr := BuildConnectionStack(context.Background(), pc, target, buildCfg, peeked)
 		var cALPN, uALPN string
 		if cs != nil {

--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -721,7 +721,10 @@ func PerformClientMITM(
 	if host == "" {
 		return nil, nil, fmt.Errorf("connector: PerformClientMITM: empty host")
 	}
-	return performClientMITM(ctx, clientConn, host, alpnOffers, cfg)
+	// USK-1015: forward callers have no client ClientHello peek (the accepted
+	// connection's first TLS bytes are consumed by tlslayer.Server inside
+	// performClientMITM), so no JA3/JA4 is available — pass a zero-value peek.
+	return performClientMITM(ctx, clientConn, host, alpnOffers, ClientHelloPeek{}, cfg)
 }
 
 // DialUpstreamWithALPN is the exported wrapper for the package-private

--- a/internal/connector/tls_clienthello_fingerprint_test.go
+++ b/internal/connector/tls_clienthello_fingerprint_test.go
@@ -1,0 +1,64 @@
+package connector
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+)
+
+// TestPeekClientHelloSNIAndALPN_Fingerprints verifies the sniff-first peek
+// computes non-empty JA3/JA4 for a real ClientHello (USK-1015).
+func TestPeekClientHelloSNIAndALPN_Fingerprints(t *testing.T) {
+	a, b := net.Pipe()
+	pc := NewPeekConn(a)
+
+	go func() {
+		conn := tls.Client(b, &tls.Config{
+			ServerName:         "fp.example.com",
+			NextProtos:         []string{"h2", "http/1.1"},
+			InsecureSkipVerify: true, //nolint:gosec // test
+		})
+		_ = conn.HandshakeContext(context.Background())
+		_ = conn.Close()
+	}()
+
+	peeked := peekClientHelloSNIAndALPN(pc)
+	if peeked.ClientJA3 == "" || peeked.ClientJA4 == "" {
+		t.Errorf("expected non-empty fingerprints, got ja3=%q ja4=%q", peeked.ClientJA3, peeked.ClientJA4)
+	}
+	if len(peeked.ClientJA3) != 32 {
+		t.Errorf("JA3 = %q, want 32-char md5 hex", peeked.ClientJA3)
+	}
+
+	_ = a.Close()
+	_ = b.Close()
+}
+
+// TestPeekClientHelloSNI_PassthroughFingerprints verifies the passthrough
+// SNI peek also computes JA3/JA4 (decision #9 — the ClientHello is on the
+// wire in the clear even under passthrough).
+func TestPeekClientHelloSNI_PassthroughFingerprints(t *testing.T) {
+	a, b := net.Pipe()
+	pc := NewPeekConn(a)
+
+	go func() {
+		conn := tls.Client(b, &tls.Config{
+			ServerName:         "pass.example.com",
+			InsecureSkipVerify: true, //nolint:gosec // test
+		})
+		_ = conn.HandshakeContext(context.Background())
+		_ = conn.Close()
+	}()
+
+	sni, ja3, ja4 := peekClientHelloSNI(pc)
+	if sni != "pass.example.com" {
+		t.Errorf("sni = %q, want pass.example.com", sni)
+	}
+	if ja3 == "" || ja4 == "" {
+		t.Errorf("expected non-empty passthrough fingerprints, got ja3=%q ja4=%q", ja3, ja4)
+	}
+
+	_ = a.Close()
+	_ = b.Close()
+}

--- a/internal/connector/tls_clienthello_peek.go
+++ b/internal/connector/tls_clienthello_peek.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net"
 	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/tlsfingerprint"
 )
 
 // peekClientHelloSNIAndALPN reads the first TLS record from clientConn
@@ -50,14 +52,21 @@ import (
 // peek window + deadline pattern but differ in what they extract;
 // keeping them as separate entry points keeps the passthrough hot path
 // (which never needs ALPN) on the smaller, one-purpose function.
-func peekClientHelloSNIAndALPN(clientConn net.Conn) (sni string, alpn []string) {
+//
+// USK-1015: the peek also computes the client's JA3/JA4 fingerprints from
+// the same buffered ClientHello (no extra read, no consumption). The
+// fingerprints are pure observation overlay carried on the returned
+// ClientHelloPeek; they never steer the build path. When the peek fails,
+// the ClientHello is malformed, or it exceeds the peek cap the fingerprint
+// fields stay empty — consistent with the SNI/ALPN fallback semantics.
+func peekClientHelloSNIAndALPN(clientConn net.Conn) ClientHelloPeek {
 	pc, ok := clientConn.(*PeekConn)
 	if !ok {
-		return "", nil
+		return ClientHelloPeek{}
 	}
 	if err := pc.SetReadDeadline(time.Now().Add(clientHelloPeekTimeout)); err != nil {
 		slog.Debug("connector: client hello peek deadline arm failed", "error", err)
-		return "", nil
+		return ClientHelloPeek{}
 	}
 	defer func() {
 		// Clear the deadline regardless of peek outcome so the subsequent
@@ -81,20 +90,22 @@ func peekClientHelloSNIAndALPN(clientConn net.Conn) (sni string, alpn []string) 
 	headerBuf, err := pc.Peek(recordHeaderLen)
 	if err != nil && len(headerBuf) == 0 {
 		slog.Debug("connector: client hello header peek failed", "error", err)
-		return "", nil
+		return ClientHelloPeek{}
 	}
 	if len(headerBuf) < recordHeaderLen {
 		// Truncated header — treat as "no ClientHello"; same as the
 		// errClientHelloIncomplete fall-through below.
-		return "", nil
+		return ClientHelloPeek{}
 	}
 	// TLS record length is bytes [3:5] (big-endian uint16).
 	recordLen := int(headerBuf[3])<<8 | int(headerBuf[4])
 	wantBytes := recordHeaderLen + recordLen
 	if wantBytes > clientHelloPeekSize {
 		// ClientHello larger than our hard cap — fall back silently
-		// (Slowloris safety; Resolved Decision #21).
-		return "", nil
+		// (Slowloris safety; Resolved Decision #21). The fingerprint is
+		// simply not computed for oversized ClientHellos (USK-1015 known
+		// limitation), matching today's SNI/ALPN fallback.
+		return ClientHelloPeek{}
 	}
 	buf, err := pc.Peek(wantBytes)
 	if err != nil && len(buf) == 0 {
@@ -102,8 +113,13 @@ func peekClientHelloSNIAndALPN(clientConn net.Conn) (sni string, alpn []string) 
 		// so the caller's existing path (cache hit / miss / pool) handles
 		// the connection. Debug-logged because routine on the wire.
 		slog.Debug("connector: client hello peek failed", "error", err)
-		return "", nil
+		return ClientHelloPeek{}
 	}
+
+	// USK-1015: compute JA3/JA4 from the same buffered ClientHello. Pure
+	// overlay — the peek leaves the bytes for the real handshake untouched.
+	// Fail-soft: a malformed hello yields empty fingerprints.
+	ja3, ja4 := tlsfingerprint.Compute(buf)
 
 	// Parse extensions block once via the shared helper (USK-996 extracted
 	// this seam specifically so SNI + ALPN share the TLS framing dance).
@@ -113,7 +129,10 @@ func peekClientHelloSNIAndALPN(clientConn net.Conn) (sni string, alpn []string) 
 			slog.Debug("connector: client hello extensions parse failed",
 				"error", extErr, "buffered", len(buf))
 		}
-		return "", nil
+		// Even when SNI/ALPN extraction fails we may still have valid
+		// fingerprints (e.g. a hello with no extensions block). Return them
+		// so ALPN-less / HTTP/1.1-only clients still get JA3/JA4.
+		return ClientHelloPeek{ClientJA3: ja3, ClientJA4: ja4}
 	}
 
 	// SNI: empty (no extension) and parse error both fold into "" — the
@@ -138,5 +157,10 @@ func peekClientHelloSNIAndALPN(clientConn net.Conn) (sni string, alpn []string) 
 		alpnList = nil
 	}
 
-	return sni, alpnList
+	return ClientHelloPeek{
+		SNI:       sni,
+		ALPN:      alpnList,
+		ClientJA3: ja3,
+		ClientJA4: ja4,
+	}
 }

--- a/internal/connector/tls_passthrough.go
+++ b/internal/connector/tls_passthrough.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/tlsfingerprint"
 )
 
 // PassthroughObservation captures everything the proxy could observe about
@@ -48,6 +50,15 @@ type PassthroughObservation struct {
 	// empty when the dial itself failed (in which case OnComplete is
 	// invoked with Outcome="failed" and OnStart never fired).
 	UpstreamAddr string
+
+	// ClientJA3 / ClientJA4 are the client's ClientHello fingerprints
+	// computed from the SNI peek buffer (USK-1015). Empty when the peek
+	// failed or the ClientHello was malformed. Under passthrough the proxy
+	// never decrypts the tunnel, but the ClientHello is sent in the clear
+	// before the encrypted handshake body, so the fingerprint is a legal
+	// observation (unlike ALPN / negotiated version, which are not).
+	ClientJA3 string
+	ClientJA4 string
 
 	// TargetHost is the hostname portion of the CONNECT / SOCKS5 target
 	// authority the client requested (without ":port"). Unlike
@@ -184,13 +195,15 @@ func relayTLSPassthroughWithObserver(
 	// Best-effort SNI peek before the relay starts. The peek is bounded by
 	// passthroughSNIPeekTimeout so a misbehaving client cannot stall the
 	// relay forever; failure is logged and the audit flow records SNI="".
-	var sni string
+	var sni, clientJA3, clientJA4 string
 	if observer != nil {
-		sni = peekClientHelloSNI(clientConn)
+		sni, clientJA3, clientJA4 = peekClientHelloSNI(clientConn)
 	}
 
 	obs := PassthroughObservation{
 		SNI:          sni,
+		ClientJA3:    clientJA3,
+		ClientJA4:    clientJA4,
 		LocalAddr:    netAddrString(clientConn.LocalAddr()),
 		RemoteAddr:   netAddrString(clientConn.RemoteAddr()),
 		UpstreamAddr: netAddrString(upstreamConn.RemoteAddr()),
@@ -244,14 +257,21 @@ func relayTLSPassthroughWithObserver(
 // underlying conn under the deadline, and leaving the deadline armed
 // would cause the relay's first io.Copy read to fail with a deadline
 // error before any TLS bytes flowed.
-func peekClientHelloSNI(clientConn net.Conn) string {
+//
+// USK-1015: the peek also computes the client's JA3/JA4 fingerprints from
+// the same buffer. Under passthrough the proxy never decrypts the tunnel,
+// but the ClientHello is on the wire in the clear, so the fingerprint is a
+// legal observation (added ONLY here; ALPN / negotiated version stay absent
+// to keep the "no fabricated data" contract). Empty on any peek/parse
+// failure, matching the SNI fallback.
+func peekClientHelloSNI(clientConn net.Conn) (sni, ja3, ja4 string) {
 	pc, ok := clientConn.(*PeekConn)
 	if !ok {
-		return ""
+		return "", "", ""
 	}
 	if err := pc.SetReadDeadline(time.Now().Add(clientHelloPeekTimeout)); err != nil {
 		slog.Debug("connector: passthrough SNI peek deadline arm failed", "error", err)
-		return ""
+		return "", "", ""
 	}
 	defer func() {
 		// Clear the deadline regardless of peek outcome so the relay's
@@ -266,13 +286,14 @@ func peekClientHelloSNI(clientConn net.Conn) string {
 		// either see a closed conn and return promptly, or unblock on
 		// the next byte the client sends).
 		slog.Debug("connector: passthrough SNI peek failed", "error", err)
-		return ""
+		return "", "", ""
 	}
+	ja3, ja4 = tlsfingerprint.Compute(buf)
 	sni, parseErr := parseClientHelloSNI(buf)
 	if parseErr != nil && !errors.Is(parseErr, errNotClientHello) && !errors.Is(parseErr, errClientHelloIncomplete) {
 		slog.Debug("connector: passthrough SNI parse failed", "error", parseErr, "buffered", len(buf))
 	}
-	return sni
+	return sni, ja3, ja4
 }
 
 // netAddrString returns a.String() or empty when a is nil.

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -333,12 +333,26 @@ type EnvelopeContext struct {
 // It is immutable after construction and safe to share across envelopes
 // on the same connection.
 type TLSSnapshot struct {
-	SNI               string
-	ALPN              string
-	PeerCertificate   *x509.Certificate
-	ClientFingerprint string // JA3 or JA4 hash of the client's ClientHello
-	Version           uint16
-	CipherSuite       uint16
+	SNI             string
+	ALPN            string
+	PeerCertificate *x509.Certificate
+	// ClientFingerprint is the client's ClientHello fingerprint exposed to
+	// plugins via the legacy `client_fingerprint` dict key. It is set to
+	// ClientJA4 for back-compat; prefer ClientJA3 / ClientJA4 for the
+	// explicit forms (USK-1015).
+	ClientFingerprint string
+	// ClientJA3 is the MD5 JA3 fingerprint of the client's ClientHello, or
+	// empty when the proxy did not observe / could not parse it (e.g. no
+	// ClientHello peek, malformed hello, or a ClientHello larger than the
+	// peek cap). Populated only on the CLIENT-facing MITM snapshot; the
+	// proxy's own outbound (upstream) ClientHello is never fingerprinted
+	// into this field (USK-1015).
+	ClientJA3 string
+	// ClientJA4 is the JA4 (TLS client) fingerprint of the client's
+	// ClientHello. Same population/empty semantics as ClientJA3.
+	ClientJA4   string
+	Version     uint16
+	CipherSuite uint16
 }
 
 // VersionName returns a human-readable TLS version string

--- a/internal/envelope/tls_handshake.go
+++ b/internal/envelope/tls_handshake.go
@@ -57,6 +57,16 @@ type TLSHandshakeMessage struct {
 	// the extension — case-preserved per the wire (no normalization).
 	SNI string
 
+	// ClientJA3 / ClientJA4 are the client's ClientHello fingerprints
+	// (USK-1015), computed from the same peek buffer that yields SNI. Unlike
+	// ALPN and the negotiated TLS version — which are intentionally absent
+	// because the proxy does not see them under passthrough — the ClientHello
+	// itself is on the wire in the clear before the encrypted handshake body,
+	// so its fingerprint is a legal observation and does not fabricate data.
+	// Empty when the peek failed or the ClientHello was malformed.
+	ClientJA3 string
+	ClientJA4 string
+
 	// LocalAddr is the proxy-side local address of the client-facing TCP
 	// socket, formatted as host:port (net.Addr.String()). For an IPv4
 	// listener bound to "127.0.0.1:8080" with ephemeral upstream port, the

--- a/internal/flow/export.go
+++ b/internal/flow/export.go
@@ -113,6 +113,8 @@ type ExportConnInfo struct {
 	TLSCipher            string `json:"tls_cipher,omitempty"`
 	TLSALPN              string `json:"tls_alpn,omitempty"`
 	TLSServerCertSubject string `json:"tls_server_cert_subject,omitempty"`
+	TLSClientJA3         string `json:"tls_client_ja3,omitempty"`
+	TLSClientJA4         string `json:"tls_client_ja4,omitempty"`
 }
 
 // ExportFlow is the JSON-serializable representation of a Flow.
@@ -233,6 +235,8 @@ func streamToExport(s *Stream) *ExportStream {
 			TLSCipher:            s.ConnInfo.TLSCipher,
 			TLSALPN:              s.ConnInfo.TLSALPN,
 			TLSServerCertSubject: s.ConnInfo.TLSServerCertSubject,
+			TLSClientJA3:         s.ConnInfo.TLSClientJA3,
+			TLSClientJA4:         s.ConnInfo.TLSClientJA4,
 		}
 	}
 	return es

--- a/internal/flow/export_import_test.go
+++ b/internal/flow/export_import_test.go
@@ -44,6 +44,8 @@ func makeTestSession(t *testing.T, store *SQLiteStore, id, protocol, urlStr stri
 			TLSCipher:            "TLS_AES_128_GCM_SHA256",
 			TLSALPN:              "h2",
 			TLSServerCertSubject: "CN=example.com",
+			TLSClientJA3:         "4b808534aaed88ea8efee030f1b46c4d",
+			TLSClientJA4:         "t13d0508h2_e133e205ac38_4e31876e0826",
 		},
 	}
 	if err := store.SaveStream(ctx, fl); err != nil {
@@ -148,6 +150,15 @@ func TestExportImportRoundTrip(t *testing.T) {
 		if origSess.ConnInfo != nil && importedSess.ConnInfo != nil {
 			if origSess.ConnInfo.TLSVersion != importedSess.ConnInfo.TLSVersion {
 				t.Errorf("session %s TLSVersion mismatch", id)
+			}
+			// USK-1015: client fingerprint columns survive export/import.
+			if origSess.ConnInfo.TLSClientJA3 != importedSess.ConnInfo.TLSClientJA3 {
+				t.Errorf("session %s TLSClientJA3 mismatch: got %q want %q", id,
+					importedSess.ConnInfo.TLSClientJA3, origSess.ConnInfo.TLSClientJA3)
+			}
+			if origSess.ConnInfo.TLSClientJA4 != importedSess.ConnInfo.TLSClientJA4 {
+				t.Errorf("session %s TLSClientJA4 mismatch: got %q want %q", id,
+					importedSess.ConnInfo.TLSClientJA4, origSess.ConnInfo.TLSClientJA4)
 			}
 		}
 
@@ -1032,6 +1043,8 @@ func TestExportImportRoundTrip_WithValidateIDs(t *testing.T) {
 			TLSCipher:            "TLS_AES_128_GCM_SHA256",
 			TLSALPN:              "h2",
 			TLSServerCertSubject: "CN=example.com",
+			TLSClientJA3:         "4b808534aaed88ea8efee030f1b46c4d",
+			TLSClientJA4:         "t13d0508h2_e133e205ac38_4e31876e0826",
 		},
 	}
 	if err := store.SaveStream(ctx, fl); err != nil {

--- a/internal/flow/import.go
+++ b/internal/flow/import.go
@@ -282,6 +282,8 @@ func exportToStream(es *ExportStream) (*Stream, error) {
 			TLSCipher:            es.ConnInfo.TLSCipher,
 			TLSALPN:              es.ConnInfo.TLSALPN,
 			TLSServerCertSubject: es.ConnInfo.TLSServerCertSubject,
+			TLSClientJA3:         es.ConnInfo.TLSClientJA3,
+			TLSClientJA4:         es.ConnInfo.TLSClientJA4,
 		}
 	}
 

--- a/internal/flow/schema.go
+++ b/internal/flow/schema.go
@@ -489,6 +489,17 @@ CREATE TABLE IF NOT EXISTS fuzz_macro_results (
 CREATE INDEX IF NOT EXISTS idx_fuzz_macro_results_fuzz_id ON fuzz_macro_results(fuzz_id);
 `
 
+// schemaV18 adds the client TLS ClientHello fingerprint columns to streams
+// (USK-1015): tls_client_ja3 (MD5 JA3) and tls_client_ja4 (JA4). Populated
+// by RecordStep from the client-facing MITM TLSSnapshot, which the connector
+// stamps from the ClientHello peek. Empty for non-TLS streams, for streams
+// whose ClientHello exceeded the peek cap, and for rows backfilled from
+// earlier schema versions. Additive ALTER TABLE — no FK toggle needed.
+const schemaV18 = `
+ALTER TABLE streams ADD COLUMN tls_client_ja3 TEXT NOT NULL DEFAULT '';
+ALTER TABLE streams ADD COLUMN tls_client_ja4 TEXT NOT NULL DEFAULT '';
+`
+
 var migrations = map[int]string{
 	1:  schemaV1,
 	2:  schemaV2,
@@ -507,6 +518,7 @@ var migrations = map[int]string{
 	15: schemaV15,
 	16: schemaV16,
 	17: schemaV17,
+	18: schemaV18,
 }
 
 func migrate(ctx context.Context, db *sql.DB) error {

--- a/internal/flow/sqlite.go
+++ b/internal/flow/sqlite.go
@@ -140,7 +140,7 @@ func (s *SQLiteStore) saveStreamSync(ctx context.Context, st *Stream) error {
 		tags = string(tagsJSON)
 	}
 
-	var clientAddr, serverAddr, tlsVersion, tlsCipher, tlsALPN, tlsCertSubject string
+	var clientAddr, serverAddr, tlsVersion, tlsCipher, tlsALPN, tlsCertSubject, tlsClientJA3, tlsClientJA4 string
 	if st.ConnInfo != nil {
 		clientAddr = st.ConnInfo.ClientAddr
 		serverAddr = st.ConnInfo.ServerAddr
@@ -148,6 +148,8 @@ func (s *SQLiteStore) saveStreamSync(ctx context.Context, st *Stream) error {
 		tlsCipher = st.ConnInfo.TLSCipher
 		tlsALPN = st.ConnInfo.TLSALPN
 		tlsCertSubject = st.ConnInfo.TLSServerCertSubject
+		tlsClientJA3 = st.ConnInfo.TLSClientJA3
+		tlsClientJA4 = st.ConnInfo.TLSClientJA4
 	}
 
 	state := st.State
@@ -165,8 +167,8 @@ func (s *SQLiteStore) saveStreamSync(ctx context.Context, st *Stream) error {
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO streams (id, conn_id, protocol, scheme, state, timestamp, duration_ms, tags, client_addr, server_addr, tls_version, tls_cipher, tls_alpn, tls_server_cert_subject, blocked_by, send_ms, wait_ms, receive_ms, failure_reason, origin)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO streams (id, conn_id, protocol, scheme, state, timestamp, duration_ms, tags, client_addr, server_addr, tls_version, tls_cipher, tls_alpn, tls_server_cert_subject, blocked_by, send_ms, wait_ms, receive_ms, failure_reason, origin, tls_client_ja3, tls_client_ja4)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		st.ID,
 		st.ConnID,
 		st.Protocol,
@@ -187,6 +189,8 @@ func (s *SQLiteStore) saveStreamSync(ctx context.Context, st *Stream) error {
 		st.ReceiveMs,
 		st.FailureReason,
 		string(origin),
+		tlsClientJA3,
+		tlsClientJA4,
 	)
 	if err != nil {
 		return fmt.Errorf("insert stream: %w", err)
@@ -337,6 +341,8 @@ func buildStreamUpdateSets(update StreamUpdate) ([]string, []interface{}, error)
 	addString("tls_cipher", update.TLSCipher)
 	addString("tls_alpn", update.TLSALPN)
 	addString("tls_server_cert_subject", update.TLSServerCertSubject)
+	addString("tls_client_ja3", update.TLSClientJA3)
+	addString("tls_client_ja4", update.TLSClientJA4)
 	addInt64("send_ms", update.SendMs)
 	addInt64("wait_ms", update.WaitMs)
 	addInt64("receive_ms", update.ReceiveMs)
@@ -415,7 +421,7 @@ func ValidateStreamID(id string) error {
 }
 
 // streamColumns is the list of columns selected in stream queries.
-const streamColumns = `id, conn_id, protocol, scheme, state, timestamp, duration_ms, tags, client_addr, server_addr, tls_version, tls_cipher, tls_alpn, tls_server_cert_subject, blocked_by, send_ms, wait_ms, receive_ms, failure_reason, origin`
+const streamColumns = `id, conn_id, protocol, scheme, state, timestamp, duration_ms, tags, client_addr, server_addr, tls_version, tls_cipher, tls_alpn, tls_server_cert_subject, blocked_by, send_ms, wait_ms, receive_ms, failure_reason, origin, tls_client_ja3, tls_client_ja4`
 
 // buildStreamWhereClause constructs a SQL WHERE clause from StreamListOptions.
 // Method, URLPattern, StatusCode, and HTTPVersion are matched via EXISTS
@@ -1157,6 +1163,17 @@ type scannable interface {
 	Scan(dest ...interface{}) error
 }
 
+// connInfoFromColumns returns a pointer to ci when any field is populated,
+// or nil when the row carried no connection metadata at all. Kept out of
+// scanStream to bound that function's cyclomatic complexity as the TLS
+// column set grows.
+func connInfoFromColumns(ci ConnectionInfo) *ConnectionInfo {
+	if ci == (ConnectionInfo{}) {
+		return nil
+	}
+	return &ci
+}
+
 func scanStream(row scannable) (*Stream, error) {
 	var (
 		st             Stream
@@ -1175,6 +1192,8 @@ func scanStream(row scannable) (*Stream, error) {
 		receiveMs      sql.NullInt64
 		failureReason  string
 		origin         string
+		tlsClientJA3   string
+		tlsClientJA4   string
 	)
 
 	err := row.Scan(
@@ -1198,6 +1217,8 @@ func scanStream(row scannable) (*Stream, error) {
 		&receiveMs,
 		&failureReason,
 		&origin,
+		&tlsClientJA3,
+		&tlsClientJA4,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -1220,16 +1241,16 @@ func scanStream(row scannable) (*Stream, error) {
 	st.Timestamp = ts
 	st.Duration = time.Duration(durationMs) * time.Millisecond
 
-	if clientAddr != "" || serverAddr != "" || tlsVersion != "" || tlsCipher != "" || tlsALPN != "" || tlsCertSubject != "" {
-		st.ConnInfo = &ConnectionInfo{
-			ClientAddr:           clientAddr,
-			ServerAddr:           serverAddr,
-			TLSVersion:           tlsVersion,
-			TLSCipher:            tlsCipher,
-			TLSALPN:              tlsALPN,
-			TLSServerCertSubject: tlsCertSubject,
-		}
-	}
+	st.ConnInfo = connInfoFromColumns(ConnectionInfo{
+		ClientAddr:           clientAddr,
+		ServerAddr:           serverAddr,
+		TLSVersion:           tlsVersion,
+		TLSCipher:            tlsCipher,
+		TLSALPN:              tlsALPN,
+		TLSServerCertSubject: tlsCertSubject,
+		TLSClientJA3:         tlsClientJA3,
+		TLSClientJA4:         tlsClientJA4,
+	})
 
 	st.BlockedBy = blockedBy
 	st.FailureReason = failureReason

--- a/internal/flow/sqlite_test.go
+++ b/internal/flow/sqlite_test.go
@@ -154,6 +154,8 @@ func TestSQLiteStore_ConnInfo(t *testing.T) {
 			TLSCipher:            "TLS_AES_128_GCM_SHA256",
 			TLSALPN:              "h2",
 			TLSServerCertSubject: "CN=example.com",
+			TLSClientJA3:         "4b808534aaed88ea8efee030f1b46c4d",
+			TLSClientJA4:         "t13d0508h2_e133e205ac38_4e31876e0826",
 		},
 	}
 
@@ -174,6 +176,56 @@ func TestSQLiteStore_ConnInfo(t *testing.T) {
 	}
 	if got.ConnInfo.TLSVersion != "TLS 1.3" {
 		t.Errorf("TLSVersion = %q, want %q", got.ConnInfo.TLSVersion, "TLS 1.3")
+	}
+	// USK-1015: client ClientHello fingerprint columns round-trip.
+	if got.ConnInfo.TLSClientJA3 != "4b808534aaed88ea8efee030f1b46c4d" {
+		t.Errorf("TLSClientJA3 = %q, want %q", got.ConnInfo.TLSClientJA3, "4b808534aaed88ea8efee030f1b46c4d")
+	}
+	if got.ConnInfo.TLSClientJA4 != "t13d0508h2_e133e205ac38_4e31876e0826" {
+		t.Errorf("TLSClientJA4 = %q, want %q", got.ConnInfo.TLSClientJA4, "t13d0508h2_e133e205ac38_4e31876e0826")
+	}
+}
+
+// TestSQLiteStore_UpdateStreamClientFingerprint verifies the UpdateStream
+// path (used by RecordStep's Send-side projection) sets only the JA3/JA4
+// columns without clobbering the upstream TLS columns (USK-1015).
+func TestSQLiteStore_UpdateStreamClientFingerprint(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	fl := &Stream{Protocol: "HTTPS", Timestamp: time.Now().UTC()}
+	if err := store.SaveStream(ctx, fl); err != nil {
+		t.Fatalf("SaveStream: %v", err)
+	}
+	// First the upstream-side TLS projection (Receive path).
+	if err := store.UpdateStream(ctx, fl.ID, StreamUpdate{
+		TLSVersion:           "TLS 1.3",
+		TLSServerCertSubject: "CN=example.com",
+	}); err != nil {
+		t.Fatalf("UpdateStream(upstream): %v", err)
+	}
+	// Then the client fingerprint projection (Send path) — must not clobber.
+	if err := store.UpdateStream(ctx, fl.ID, StreamUpdate{
+		TLSClientJA3: "ja3hash",
+		TLSClientJA4: "t13d0508h2_aaaaaaaaaaaa_bbbbbbbbbbbb",
+	}); err != nil {
+		t.Fatalf("UpdateStream(fingerprint): %v", err)
+	}
+
+	got, err := store.GetStream(ctx, fl.ID)
+	if err != nil {
+		t.Fatalf("GetStream: %v", err)
+	}
+	if got.ConnInfo == nil {
+		t.Fatal("ConnInfo is nil")
+	}
+	if got.ConnInfo.TLSVersion != "TLS 1.3" || got.ConnInfo.TLSServerCertSubject != "CN=example.com" {
+		t.Errorf("upstream TLS columns clobbered: version=%q subject=%q",
+			got.ConnInfo.TLSVersion, got.ConnInfo.TLSServerCertSubject)
+	}
+	if got.ConnInfo.TLSClientJA3 != "ja3hash" || got.ConnInfo.TLSClientJA4 != "t13d0508h2_aaaaaaaaaaaa_bbbbbbbbbbbb" {
+		t.Errorf("fingerprint columns = (%q, %q)", got.ConnInfo.TLSClientJA3, got.ConnInfo.TLSClientJA4)
 	}
 }
 

--- a/internal/flow/types.go
+++ b/internal/flow/types.go
@@ -124,6 +124,14 @@ type ConnectionInfo struct {
 	// TLSServerCertSubject is the subject DN of the upstream server's TLS certificate.
 	// Empty for non-TLS connections.
 	TLSServerCertSubject string
+	// TLSClientJA3 is the JA3 (MD5) fingerprint of the client's TLS
+	// ClientHello, captured by the MITM ClientHello peek (USK-1015). Empty
+	// for non-TLS connections or when the ClientHello could not be observed
+	// / parsed (e.g. it exceeded the peek cap).
+	TLSClientJA3 string
+	// TLSClientJA4 is the JA4 (TLS client) fingerprint of the client's TLS
+	// ClientHello. Same population/empty semantics as TLSClientJA3.
+	TLSClientJA4 string
 }
 
 // Flow represents a single directional message within a stream.
@@ -239,6 +247,12 @@ type StreamUpdate struct {
 	// TLSServerCertSubject sets the upstream server TLS certificate subject in ConnInfo.
 	// Only applied when non-empty.
 	TLSServerCertSubject string
+	// TLSClientJA3 sets the client ClientHello JA3 fingerprint in ConnInfo
+	// (USK-1015). Only applied when non-empty.
+	TLSClientJA3 string
+	// TLSClientJA4 sets the client ClientHello JA4 fingerprint in ConnInfo
+	// (USK-1015). Only applied when non-empty.
+	TLSClientJA4 string
 	// SendMs sets the request send time in milliseconds.
 	// Only applied when non-nil.
 	SendMs *int64

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -112,6 +112,10 @@ type connInfoResult struct {
 	TLSALPN string `json:"tls_alpn,omitempty"`
 	// TLSServerCertSubject is the subject DN of the upstream server certificate.
 	TLSServerCertSubject string `json:"tls_server_cert_subject,omitempty"`
+	// TLSClientJA3 is the JA3 fingerprint of the client's TLS ClientHello.
+	TLSClientJA3 string `json:"tls_client_ja3,omitempty"`
+	// TLSClientJA4 is the JA4 fingerprint of the client's TLS ClientHello.
+	TLSClientJA4 string `json:"tls_client_ja4,omitempty"`
 }
 
 // checkTargetScopeURL checks a URL against the target scope rules.

--- a/internal/mcp/query_tool.go
+++ b/internal/mcp/query_tool.go
@@ -1779,6 +1779,8 @@ func buildConnInfoResult(ci *flow.ConnectionInfo) *connInfoResult {
 		TLSCipher:            ci.TLSCipher,
 		TLSALPN:              ci.TLSALPN,
 		TLSServerCertSubject: ci.TLSServerCertSubject,
+		TLSClientJA3:         ci.TLSClientJA3,
+		TLSClientJA4:         ci.TLSClientJA4,
 	}
 }
 

--- a/internal/pipeline/record_step.go
+++ b/internal/pipeline/record_step.go
@@ -614,6 +614,17 @@ func (s *RecordStep) Process(ctx context.Context, env *envelope.Envelope) Result
 		s.updateStreamTLS(ctx, env)
 	}
 
+	// USK-1015: project the client's ClientHello JA3/JA4 into ConnInfo. These
+	// live on the CLIENT-facing MITM snapshot, which is stamped on Send
+	// envelopes (the upstream Receive snapshot never carries them), so the
+	// projection is gated on the fingerprint fields being present rather than
+	// on direction. Idempotent — repeated Send envelopes rewrite the same
+	// two columns without clobbering the upstream TLS columns (empty fields
+	// are skipped by buildStreamUpdateSets).
+	if env.Context.TLS != nil && (env.Context.TLS.ClientJA3 != "" || env.Context.TLS.ClientJA4 != "") {
+		s.updateStreamClientFingerprint(ctx, env)
+	}
+
 	// USK-802: per-Stream record cap gate for streaming protocols
 	// (gRPC GRPCDataMessage / SSE SSEMessage). Wire forwarding has
 	// already happened by the time this Step runs in the Pipeline; the
@@ -783,6 +794,26 @@ func (s *RecordStep) updateStreamTLS(ctx context.Context, env *envelope.Envelope
 	}
 	if err := s.store.UpdateStream(ctx, env.StreamID, update); err != nil {
 		s.logger.Error("record step: TLS snapshot update failed",
+			"stream_id", env.StreamID,
+			"error", err,
+		)
+	}
+}
+
+// updateStreamClientFingerprint projects the client's ClientHello JA3/JA4
+// fingerprints (USK-1015) from env.Context.TLS into Stream.ConnInfo. Fires
+// on any envelope whose snapshot carries a non-empty fingerprint — in
+// practice the Send-direction client-facing snapshot. Only the two
+// tls_client_ja* columns are set so the per-Receive upstream TLS projection
+// is never clobbered (empty StreamUpdate fields are skipped downstream).
+func (s *RecordStep) updateStreamClientFingerprint(ctx context.Context, env *envelope.Envelope) {
+	tls := env.Context.TLS
+	update := flow.StreamUpdate{
+		TLSClientJA3: tls.ClientJA3,
+		TLSClientJA4: tls.ClientJA4,
+	}
+	if err := s.store.UpdateStream(ctx, env.StreamID, update); err != nil {
+		s.logger.Error("record step: client fingerprint update failed",
 			"stream_id", env.StreamID,
 			"error", err,
 		)
@@ -1138,6 +1169,12 @@ func (s *RecordStep) envelopeToFlow(ctx context.Context, env *envelope.Envelope)
 func projectTLSHandshake(m *envelope.TLSHandshakeMessage, fl *flow.Flow) {
 	if m.SNI != "" {
 		fl.Metadata["sni"] = m.SNI
+	}
+	if m.ClientJA3 != "" {
+		fl.Metadata["client_ja3"] = m.ClientJA3
+	}
+	if m.ClientJA4 != "" {
+		fl.Metadata["client_ja4"] = m.ClientJA4
 	}
 	if m.LocalAddr != "" {
 		fl.Metadata["local_addr"] = m.LocalAddr

--- a/internal/pipeline/record_step_test.go
+++ b/internal/pipeline/record_step_test.go
@@ -282,6 +282,51 @@ func TestRecordStep_SendDoesNotProjectClientMITMToConnInfo(t *testing.T) {
 	}
 }
 
+// TestRecordStep_SendProjectsClientFingerprint verifies that a Send envelope
+// whose client-facing snapshot carries JA3/JA4 fingerprints (USK-1015)
+// triggers an UpdateStream that sets ONLY the tls_client_ja* fields — never
+// the synthetic MITM cert / version columns.
+func TestRecordStep_SendProjectsClientFingerprint(t *testing.T) {
+	w := &mockWriter{}
+	step := NewRecordStep(w, nil)
+
+	clientSnap := &envelope.TLSSnapshot{
+		Version:   tls.VersionTLS13,
+		ClientJA3: "4b808534aaed88ea8efee030f1b46c4d",
+		ClientJA4: "t13d0508h2_e133e205ac38_4e31876e0826",
+		PeerCertificate: &x509.Certificate{
+			Subject: pkix.Name{CommonName: "synthetic-mitm-cert"},
+		},
+	}
+	env := &envelope.Envelope{
+		StreamID:  "stream-1",
+		FlowID:    "flow-send",
+		Direction: envelope.Send,
+		Sequence:  0,
+		Protocol:  envelope.ProtocolHTTP,
+		Message:   &envelope.HTTPMessage{Method: "GET"},
+		Context: envelope.EnvelopeContext{
+			ConnID: "conn-1",
+			TLS:    clientSnap,
+		},
+	}
+	step.Process(context.Background(), env)
+
+	if len(w.updates) != 1 {
+		t.Fatalf("expected 1 UpdateStream call, got %d", len(w.updates))
+	}
+	got := w.updates[0].update
+	if got.TLSClientJA3 != clientSnap.ClientJA3 || got.TLSClientJA4 != clientSnap.ClientJA4 {
+		t.Errorf("fingerprint update = (%q, %q), want (%q, %q)",
+			got.TLSClientJA3, got.TLSClientJA4, clientSnap.ClientJA3, clientSnap.ClientJA4)
+	}
+	// The synthetic MITM cert / version must NOT leak into ConnInfo.
+	if got.TLSServerCertSubject != "" || got.TLSVersion != "" {
+		t.Errorf("synthetic MITM data leaked: subject=%q version=%q",
+			got.TLSServerCertSubject, got.TLSVersion)
+	}
+}
+
 // TestRecordStep_ReceiveWithoutTLSSkipsUpdate verifies that Receive envelopes
 // without a TLS snapshot (e.g., cleartext h2c) do not fire a no-op
 // UpdateStream.

--- a/internal/pluginv2/ctx.go
+++ b/internal/pluginv2/ctx.go
@@ -269,13 +269,15 @@ func tlsSnapshotValue(s *envelope.TLSSnapshot) starlark.Value {
 	if s == nil {
 		return starlark.None
 	}
-	d := starlark.NewDict(6)
+	d := starlark.NewDict(8)
 	_ = d.SetKey(starlark.String("sni"), starlark.String(s.SNI))
 	_ = d.SetKey(starlark.String("alpn"), starlark.String(s.ALPN))
 	_ = d.SetKey(starlark.String("version_name"), starlark.String(s.VersionName()))
 	_ = d.SetKey(starlark.String("cipher_name"), starlark.String(s.CipherName()))
 	_ = d.SetKey(starlark.String("peer_cert_subject"), starlark.String(s.PeerCertSubject()))
 	_ = d.SetKey(starlark.String("client_fingerprint"), starlark.String(s.ClientFingerprint))
+	_ = d.SetKey(starlark.String("ja3"), starlark.String(s.ClientJA3))
+	_ = d.SetKey(starlark.String("ja4"), starlark.String(s.ClientJA4))
 	d.Freeze()
 	return d
 }

--- a/internal/pluginv2/lifecycle.go
+++ b/internal/pluginv2/lifecycle.go
@@ -197,7 +197,7 @@ func BuildSOCKS5ConnectDict(connID, clientAddr, targetAddr string) *starlark.Dic
 // (USK-670) so plugin authors see one shape across ctx.tls and the
 // lifecycle dict.
 func BuildTLSHandshakeDict(side string, snap *envelope.TLSSnapshot) *starlark.Dict {
-	d := starlark.NewDict(7)
+	d := starlark.NewDict(9)
 	_ = d.SetKey(starlark.String("side"), starlark.String(side))
 	if snap != nil {
 		_ = d.SetKey(starlark.String("sni"), starlark.String(snap.SNI))
@@ -206,6 +206,8 @@ func BuildTLSHandshakeDict(side string, snap *envelope.TLSSnapshot) *starlark.Di
 		_ = d.SetKey(starlark.String("cipher_name"), starlark.String(snap.CipherName()))
 		_ = d.SetKey(starlark.String("peer_cert_subject"), starlark.String(snap.PeerCertSubject()))
 		_ = d.SetKey(starlark.String("client_fingerprint"), starlark.String(snap.ClientFingerprint))
+		_ = d.SetKey(starlark.String("ja3"), starlark.String(snap.ClientJA3))
+		_ = d.SetKey(starlark.String("ja4"), starlark.String(snap.ClientJA4))
 	} else {
 		_ = d.SetKey(starlark.String("sni"), starlark.String(""))
 		_ = d.SetKey(starlark.String("alpn"), starlark.String(""))
@@ -213,6 +215,8 @@ func BuildTLSHandshakeDict(side string, snap *envelope.TLSSnapshot) *starlark.Di
 		_ = d.SetKey(starlark.String("cipher_name"), starlark.String(""))
 		_ = d.SetKey(starlark.String("peer_cert_subject"), starlark.String(""))
 		_ = d.SetKey(starlark.String("client_fingerprint"), starlark.String(""))
+		_ = d.SetKey(starlark.String("ja3"), starlark.String(""))
+		_ = d.SetKey(starlark.String("ja4"), starlark.String(""))
 	}
 	d.Freeze()
 	return d

--- a/internal/pluginv2/lifecycle_test.go
+++ b/internal/pluginv2/lifecycle_test.go
@@ -313,6 +313,31 @@ func TestBuildTLSHandshakeDict_NilSnapshot(t *testing.T) {
 	}
 }
 
+// TestBuildTLSHandshakeDict_Fingerprints verifies the ja3 / ja4 / legacy
+// client_fingerprint keys are populated from the snapshot (USK-1015).
+func TestBuildTLSHandshakeDict_Fingerprints(t *testing.T) {
+	snap := &envelope.TLSSnapshot{
+		SNI:               "example.com",
+		ClientJA3:         "4b808534aaed88ea8efee030f1b46c4d",
+		ClientJA4:         "t13d0508h2_e133e205ac38_4e31876e0826",
+		ClientFingerprint: "t13d0508h2_e133e205ac38_4e31876e0826",
+	}
+	d := BuildTLSHandshakeDict("server", snap)
+	for key, want := range map[string]string{
+		"ja3":                snap.ClientJA3,
+		"ja4":                snap.ClientJA4,
+		"client_fingerprint": snap.ClientFingerprint,
+	} {
+		v, ok, err := d.Get(starlark.String(key))
+		if err != nil || !ok {
+			t.Fatalf("Get(%s): ok=%v err=%v", key, ok, err)
+		}
+		if s := string(v.(starlark.String)); s != want {
+			t.Errorf("%s = %q, want %q", key, s, want)
+		}
+	}
+}
+
 func TestBuildWSCloseDict_NilMessage(t *testing.T) {
 	d := BuildWSCloseDict(nil)
 	if err := d.SetKey(starlark.String("__probe__"), starlark.None); err == nil {

--- a/internal/proxybuild/passthrough_recorder.go
+++ b/internal/proxybuild/passthrough_recorder.go
@@ -284,6 +284,8 @@ func (r *passthroughRecorder) envelopeForScope(streamID string, obs connector.Pa
 		Protocol:  envelope.ProtocolTLSHandshake,
 		Message: &envelope.TLSHandshakeMessage{
 			SNI:          obs.SNI,
+			ClientJA3:    obs.ClientJA3,
+			ClientJA4:    obs.ClientJA4,
 			LocalAddr:    obs.LocalAddr,
 			RemoteAddr:   obs.RemoteAddr,
 			UpstreamAddr: obs.UpstreamAddr,
@@ -292,8 +294,13 @@ func (r *passthroughRecorder) envelopeForScope(streamID string, obs connector.Pa
 			TargetHost: obs.TargetHost,
 		},
 	}
-	if obs.SNI != "" {
-		env.Context.TLS = &envelope.TLSSnapshot{SNI: obs.SNI}
+	if obs.SNI != "" || obs.ClientJA3 != "" || obs.ClientJA4 != "" {
+		env.Context.TLS = &envelope.TLSSnapshot{
+			SNI:               obs.SNI,
+			ClientJA3:         obs.ClientJA3,
+			ClientJA4:         obs.ClientJA4,
+			ClientFingerprint: obs.ClientJA4,
+		}
 	}
 	return env
 }
@@ -307,6 +314,12 @@ func passthroughMetadata(obs connector.PassthroughObservation) map[string]string
 	}
 	if obs.SNI != "" {
 		m["sni"] = obs.SNI
+	}
+	if obs.ClientJA3 != "" {
+		m["client_ja3"] = obs.ClientJA3
+	}
+	if obs.ClientJA4 != "" {
+		m["client_ja4"] = obs.ClientJA4
 	}
 	if obs.LocalAddr != "" {
 		m["local_addr"] = obs.LocalAddr

--- a/internal/tlsfingerprint/fingerprint.go
+++ b/internal/tlsfingerprint/fingerprint.go
@@ -1,0 +1,481 @@
+// Package tlsfingerprint computes JA3 and JA4 client fingerprints from a
+// raw TLS ClientHello record.
+//
+// The package is deliberately self-contained and stdlib-only (crypto/md5,
+// crypto/sha256, encoding/hex): it parses the ClientHello independently of
+// the connector's SNI/ALPN peek parser so it can be unit-tested against
+// captured wire bytes and reused from any data-path peek site.
+//
+// Wire-fidelity contract (CLAUDE.md MITM Principle #3): the input byte
+// slice is never mutated. JA3 preserves the wire order of ciphers,
+// extensions, curves, and point formats. JA4's internal SORTING of ciphers
+// and extensions is part of the published JA4 definition and produces
+// derived data only — the caller's raw bytes and the JA3 view are untouched.
+//
+// Fail-soft contract (MITM Principle #5): a truncated or malformed
+// ClientHello yields empty fingerprints ("", "") rather than a panic or a
+// hard error. Callers treat an empty result as "no fingerprint observed",
+// consistent with the connector's SNI/ALPN fallback behaviour.
+//
+// References:
+//   - JA3: https://github.com/salesforce/ja3 (SSLVersion,Ciphers,Extensions,
+//     EllipticCurves,EllipticCurvePointFormats — decimal, GREASE removed,
+//     wire order; MD5 of the joined string).
+//   - JA4 (TLS client): https://github.com/FoxIO-LLC/ja4 (JA4_a metadata,
+//     JA4_b = truncated SHA256 of the sorted cipher list, JA4_c = truncated
+//     SHA256 of the sorted extension list (SNI + ALPN excluded) plus the
+//     signature-algorithm list in wire order). Hand-rolled here; the FoxIO
+//     reference library is not imported because its JA4+ suite carries the
+//     FoxIO-1.1 licence.
+package tlsfingerprint
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// TLS record / handshake framing constants.
+const (
+	recordHeaderLen        = 5
+	contentTypeHandshake   = 0x16
+	handshakeTypeClientHi  = 0x01
+	handshakeHeaderLen     = 4
+	legacyVersionRandomLen = 2 + 32
+)
+
+// Extension type constants relevant to fingerprinting (IANA-assigned).
+const (
+	extServerName          = 0x0000 // RFC 6066
+	extSupportedGroups     = 0x000a // RFC 8422 (a.k.a. elliptic_curves)
+	extECPointFormats      = 0x000b // RFC 8422
+	extSignatureAlgorithms = 0x000d // RFC 8446
+	extALPN                = 0x0010 // RFC 7301
+	extSupportedVersions   = 0x002b // RFC 8446
+)
+
+// Compute parses a raw TLS ClientHello record (including the 5-byte TLS
+// record header) and returns the client's JA3 and JA4 fingerprints.
+//
+// On any truncation or malformation both return values are empty strings;
+// Compute never panics on attacker-controlled input.
+func Compute(record []byte) (ja3, ja4 string) {
+	hello, ok := clientHelloBody(record)
+	if !ok {
+		return "", ""
+	}
+	f, ok := parseClientHello(hello)
+	if !ok {
+		return "", ""
+	}
+	return f.ja3(), f.ja4()
+}
+
+// isGREASE reports whether v is one of the 16 GREASE values defined by
+// RFC 8701 (0x0a0a, 0x1a1a, ... 0xfafa): the high byte equals the low byte
+// and each nibble of the low byte is 0xA.
+func isGREASE(v uint16) bool {
+	hi := byte(v >> 8)
+	lo := byte(v)
+	return hi == lo && lo&0x0f == 0x0a
+}
+
+// clientHelloBody validates the TLS record and Handshake headers and returns
+// the ClientHello body (the bytes after the 4-byte Handshake header, sized by
+// the Handshake length field). ok is false on any framing truncation or when
+// the record is not a Handshake/ClientHello.
+func clientHelloBody(record []byte) (hello []byte, ok bool) {
+	if len(record) < recordHeaderLen {
+		return nil, false
+	}
+	if record[0] != contentTypeHandshake {
+		return nil, false
+	}
+	recordLen := int(record[3])<<8 | int(record[4])
+	body := record[recordHeaderLen:]
+	if recordLen <= 0 || len(body) < recordLen {
+		return nil, false
+	}
+	body = body[:recordLen]
+
+	if len(body) < handshakeHeaderLen {
+		return nil, false
+	}
+	if body[0] != handshakeTypeClientHi {
+		return nil, false
+	}
+	hsLen := int(body[1])<<16 | int(body[2])<<8 | int(body[3])
+	hs := body[handshakeHeaderLen:]
+	if hsLen <= 0 || len(hs) < hsLen {
+		return nil, false
+	}
+	return hs[:hsLen], true
+}
+
+// fields holds the decoded ClientHello values needed for JA3 / JA4.
+type fields struct {
+	legacyVersion uint16
+	ciphers       []uint16 // GREASE removed, wire order
+	extensions    []uint16 // GREASE removed, wire order
+	curves        []uint16 // supported_groups, GREASE removed, wire order
+	pointFormats  []uint16 // ec_point_formats, wire order
+	sigAlgs       []uint16 // signature_algorithms, GREASE removed, wire order
+	highestVer    uint16   // from supported_versions, else legacyVersion
+	hasSNI        bool
+	firstALPN     string
+}
+
+// parseClientHello decodes the ClientHello body into fields. ok is false when
+// the fixed structure (version, session_id, cipher_suites, compression,
+// extensions block) is truncated. Individual extension internals are parsed
+// fail-soft: a malformed inner extension contributes no values rather than
+// aborting the whole fingerprint.
+func parseClientHello(hello []byte) (fields, bool) {
+	var f fields
+	c := cursor{b: hello}
+
+	ver, ok := c.uint16()
+	if !ok {
+		return f, false
+	}
+	f.legacyVersion = ver
+	f.highestVer = ver
+
+	if !c.skip(32) { // Random
+		return f, false
+	}
+	if _, ok := c.vector(1); !ok { // legacy_session_id
+		return f, false
+	}
+	cipherBytes, ok := c.vector(2) // cipher_suites
+	if !ok {
+		return f, false
+	}
+	f.ciphers = filterGREASE(uint16List(cipherBytes))
+	if _, ok := c.vector(1); !ok { // legacy_compression_methods
+		return f, false
+	}
+
+	// Extensions block is optional (legal for very old ClientHellos). When
+	// absent we still produce a fingerprint from the fields gathered so far.
+	extBlock, ok := c.vector(2)
+	if !ok {
+		if c.remaining() == 0 {
+			return f, true
+		}
+		return f, false
+	}
+	if !parseExtensions(extBlock, &f) {
+		return f, false
+	}
+	return f, true
+}
+
+// parseExtensions walks the extensions block, recording extension types in
+// wire order (GREASE removed) and decoding the extensions relevant to the
+// fingerprint. Returns false only when the extension framing itself is
+// truncated (an extension claims more data than remains).
+func parseExtensions(block []byte, f *fields) bool {
+	c := cursor{b: block}
+	for c.remaining() > 0 {
+		extType, ok := c.uint16()
+		if !ok {
+			return false
+		}
+		data, ok := c.vector(2)
+		if !ok {
+			return false
+		}
+		if isGREASE(extType) {
+			continue
+		}
+		f.extensions = append(f.extensions, extType)
+
+		switch extType {
+		case extServerName:
+			f.hasSNI = true
+		case extSupportedGroups:
+			f.curves = filterGREASE(uint16Vector(data, 2))
+		case extECPointFormats:
+			f.pointFormats = uint16Bytes(vectorPayload(data, 1))
+		case extSignatureAlgorithms:
+			f.sigAlgs = filterGREASE(uint16Vector(data, 2))
+		case extALPN:
+			f.firstALPN = firstALPNProtocol(data)
+		case extSupportedVersions:
+			if hv, ok := highestVersion(data); ok {
+				f.highestVer = hv
+			}
+		}
+	}
+	return true
+}
+
+// ja3 builds the JA3 string and returns its MD5 hex digest. Returns "" when
+// no cipher/extension data was observed at all (an all-empty ClientHello is
+// not a meaningful fingerprint).
+func (f fields) ja3() string {
+	if len(f.ciphers) == 0 && len(f.extensions) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(int(f.legacyVersion)))
+	sb.WriteByte(',')
+	sb.WriteString(joinDecimal(f.ciphers))
+	sb.WriteByte(',')
+	sb.WriteString(joinDecimal(f.extensions))
+	sb.WriteByte(',')
+	sb.WriteString(joinDecimal(f.curves))
+	sb.WriteByte(',')
+	sb.WriteString(joinDecimal(f.pointFormats))
+
+	sum := md5.Sum([]byte(sb.String())) //nolint:gosec // JA3 is defined as MD5
+	return hex.EncodeToString(sum[:])
+}
+
+// ja4 builds the JA4 (TLS client) fingerprint: JA4_a_JA4_b_JA4_c.
+func (f fields) ja4() string {
+	if len(f.ciphers) == 0 && len(f.extensions) == 0 {
+		return ""
+	}
+	return f.ja4a() + "_" + f.ja4b() + "_" + f.ja4c()
+}
+
+// ja4a builds the human-readable JA4_a section.
+func (f fields) ja4a() string {
+	sni := "i"
+	if f.hasSNI {
+		sni = "d"
+	}
+	alpn := "00"
+	if f.firstALPN != "" {
+		first := f.firstALPN[0]
+		last := f.firstALPN[len(f.firstALPN)-1]
+		alpn = string([]byte{first, last})
+	}
+	return fmt.Sprintf("t%s%s%s%s%s",
+		ja4Version(f.highestVer),
+		sni,
+		count2(len(f.ciphers)),
+		count2(len(f.extensions)),
+		alpn,
+	)
+}
+
+// ja4b builds the JA4_b section: truncated SHA256 of the SORTED cipher list.
+func (f fields) ja4b() string {
+	if len(f.ciphers) == 0 {
+		return "000000000000"
+	}
+	return sha256Trunc12(strings.Join(sortedHex(f.ciphers), ","))
+}
+
+// ja4c builds the JA4_c section: truncated SHA256 of the SORTED extension
+// list (SNI 0x0000 and ALPN 0x0010 excluded) joined with an underscore to
+// the signature-algorithm list in wire order.
+func (f fields) ja4c() string {
+	extsForC := make([]uint16, 0, len(f.extensions))
+	for _, e := range f.extensions {
+		if e == extServerName || e == extALPN {
+			continue
+		}
+		extsForC = append(extsForC, e)
+	}
+	raw := strings.Join(sortedHex(extsForC), ",") + "_" + strings.Join(hexList(f.sigAlgs), ",")
+	return sha256Trunc12(raw)
+}
+
+// ---- small helpers ----
+
+// cursor is a bounds-checked forward reader over a byte slice.
+type cursor struct {
+	b   []byte
+	pos int
+}
+
+func (c *cursor) remaining() int { return len(c.b) - c.pos }
+
+func (c *cursor) skip(n int) bool {
+	if n < 0 || c.remaining() < n {
+		return false
+	}
+	c.pos += n
+	return true
+}
+
+func (c *cursor) uint16() (uint16, bool) {
+	if c.remaining() < 2 {
+		return 0, false
+	}
+	v := uint16(c.b[c.pos])<<8 | uint16(c.b[c.pos+1])
+	c.pos += 2
+	return v, true
+}
+
+// vector reads a length-prefixed region (prefixLen is 1 or 2 bytes) and
+// returns its payload, advancing past it.
+func (c *cursor) vector(prefixLen int) ([]byte, bool) {
+	if c.remaining() < prefixLen {
+		return nil, false
+	}
+	var n int
+	switch prefixLen {
+	case 1:
+		n = int(c.b[c.pos])
+	case 2:
+		n = int(c.b[c.pos])<<8 | int(c.b[c.pos+1])
+	default:
+		return nil, false
+	}
+	start := c.pos + prefixLen
+	if start+n > len(c.b) {
+		return nil, false
+	}
+	c.pos = start + n
+	return c.b[start : start+n], true
+}
+
+// uint16List interprets b as a packed sequence of big-endian uint16 values.
+// Trailing odd bytes are ignored (fail-soft).
+func uint16List(b []byte) []uint16 {
+	out := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		out = append(out, uint16(b[i])<<8|uint16(b[i+1]))
+	}
+	return out
+}
+
+// uint16Bytes interprets b as a packed sequence of single bytes widened to
+// uint16 (used for ec_point_formats which are 1-byte enums).
+func uint16Bytes(b []byte) []uint16 {
+	out := make([]uint16, 0, len(b))
+	for _, x := range b {
+		out = append(out, uint16(x))
+	}
+	return out
+}
+
+// vectorPayload returns the payload of a length-prefixed region at the start
+// of b, or nil when truncated (fail-soft).
+func vectorPayload(b []byte, prefixLen int) []byte {
+	c := cursor{b: b}
+	p, ok := c.vector(prefixLen)
+	if !ok {
+		return nil
+	}
+	return p
+}
+
+// uint16Vector returns the uint16 list carried in a length-prefixed region at
+// the start of b (e.g. supported_groups: 2-byte list length then uint16s).
+func uint16Vector(b []byte, prefixLen int) []uint16 {
+	return uint16List(vectorPayload(b, prefixLen))
+}
+
+// firstALPNProtocol returns the first ProtocolName from an ALPN extension's
+// data, or "" when absent/malformed. ALPN data: 2-byte list length, then
+// entries of 1-byte name length + name bytes.
+func firstALPNProtocol(data []byte) string {
+	list := vectorPayload(data, 2)
+	c := cursor{b: list}
+	name, ok := c.vector(1)
+	if !ok || len(name) == 0 {
+		return ""
+	}
+	return string(name)
+}
+
+// highestVersion returns the highest non-GREASE version from a
+// supported_versions extension (1-byte list length, then uint16 versions).
+func highestVersion(data []byte) (uint16, bool) {
+	vers := filterGREASE(uint16Vector(data, 1))
+	best := uint16(0)
+	for _, v := range vers {
+		if v > best {
+			best = v
+		}
+	}
+	if best == 0 {
+		return 0, false
+	}
+	return best, true
+}
+
+// filterGREASE returns a new slice with RFC 8701 GREASE values removed,
+// preserving order. The input slice is never mutated.
+func filterGREASE(in []uint16) []uint16 {
+	out := make([]uint16, 0, len(in))
+	for _, v := range in {
+		if isGREASE(v) {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// joinDecimal joins values as decimal integers separated by '-'.
+func joinDecimal(vals []uint16) string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = strconv.Itoa(int(v))
+	}
+	return strings.Join(parts, "-")
+}
+
+// hexList formats values as 4-digit lowercase hex, preserving order.
+func hexList(vals []uint16) []string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = fmt.Sprintf("%04x", v)
+	}
+	return parts
+}
+
+// sortedHex formats values as 4-digit lowercase hex and sorts them ascending
+// (lexicographic == numeric for zero-padded hex). Input order is preserved
+// in the caller's slice; sorting happens on the derived hex copy only.
+func sortedHex(vals []uint16) []string {
+	parts := hexList(vals)
+	sort.Strings(parts)
+	return parts
+}
+
+// sha256Trunc12 returns the first 12 hex chars of the SHA256 of s.
+func sha256Trunc12(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// count2 formats n as a zero-padded 2-digit decimal, capped at 99 per the
+// JA4 spec.
+func count2(n int) string {
+	if n > 99 {
+		n = 99
+	}
+	return fmt.Sprintf("%02d", n)
+}
+
+// ja4Version maps a TLS version to its 2-character JA4 code.
+func ja4Version(v uint16) string {
+	switch v {
+	case 0x0304:
+		return "13"
+	case 0x0303:
+		return "12"
+	case 0x0302:
+		return "11"
+	case 0x0301:
+		return "10"
+	case 0x0300:
+		return "s3"
+	case 0x0002:
+		return "s2"
+	default:
+		return "00"
+	}
+}

--- a/internal/tlsfingerprint/fingerprint_test.go
+++ b/internal/tlsfingerprint/fingerprint_test.go
@@ -1,0 +1,240 @@
+package tlsfingerprint
+
+import (
+	"crypto/tls"
+	"net"
+	"strings"
+	"testing"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+// ---- ClientHello builder helpers ----
+
+func u16(v uint16) []byte { return []byte{byte(v >> 8), byte(v)} }
+
+func u24(n int) []byte { return []byte{byte(n >> 16), byte(n >> 8), byte(n)} }
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// vec8 / vec16 prepend a 1- / 2-byte big-endian length prefix.
+func vec8(payload []byte) []byte  { return append([]byte{byte(len(payload))}, payload...) }
+func vec16(payload []byte) []byte { return append(u16(uint16(len(payload))), payload...) }
+
+// ext builds an extension: type(2) + length-prefixed data(2).
+func ext(t uint16, data []byte) []byte { return concat(u16(t), vec16(data)) }
+
+// helloOpts configures the synthetic ClientHello builder.
+type helloOpts struct {
+	includeSNI  bool
+	includeALPN bool
+	ciphers     []uint16 // raw list (may include GREASE)
+	omitCiphers bool
+}
+
+// buildClientHello assembles a full TLS ClientHello record (with the 5-byte
+// record header) shaped to match the hand-computed golden vectors.
+func buildClientHello(o helloOpts) []byte {
+	ciphers := o.ciphers
+	if ciphers == nil && !o.omitCiphers {
+		ciphers = []uint16{0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f}
+	}
+	var cipherBytes []byte
+	for _, c := range ciphers {
+		cipherBytes = append(cipherBytes, u16(c)...)
+	}
+
+	sniData := vec16(concat([]byte{0x00}, vec16([]byte("a")))) // one host_name entry "a"
+	sgData := vec16(concat(u16(0x0a0a), u16(0x001d), u16(0x0017), u16(0x0018)))
+	ecData := vec8([]byte{0x00})
+	saData := vec16(concat(u16(0x0403), u16(0x0804), u16(0x0401)))
+	alpnData := vec16(concat(vec8([]byte("h2")), vec8([]byte("http/1.1"))))
+	svData := vec8(concat(u16(0x0a0a), u16(0x0304), u16(0x0303)))
+
+	var exts []byte
+	exts = append(exts, ext(0x1a1a, nil)...) // GREASE
+	if o.includeSNI {
+		exts = append(exts, ext(0x0000, sniData)...)
+	}
+	exts = append(exts, ext(0x000a, sgData)...)
+	exts = append(exts, ext(0x000b, ecData)...)
+	exts = append(exts, ext(0x000d, saData)...)
+	if o.includeALPN {
+		exts = append(exts, ext(0x0010, alpnData)...)
+	}
+	exts = append(exts, ext(0x0012, nil)...) // signed_certificate_timestamp
+	exts = append(exts, ext(0x002b, svData)...)
+	exts = append(exts, ext(0x0033, nil)...) // key_share (empty)
+
+	helloBody := concat(
+		u16(0x0303),        // legacy_version
+		make([]byte, 32),   // Random
+		vec8(nil),          // legacy_session_id (empty)
+		vec16(cipherBytes), // cipher_suites
+		vec8([]byte{0x00}), // legacy_compression_methods (null)
+		vec16(exts),        // extensions
+	)
+
+	handshake := concat([]byte{0x01}, u24(len(helloBody)), helloBody)
+	return concat([]byte{0x16, 0x03, 0x01}, u16(uint16(len(handshake))), handshake)
+}
+
+func TestComputeGoldenVector(t *testing.T) {
+	// Golden JA3/JA4 computed independently (Python hashlib) from the exact
+	// wire fields the builder emits:
+	//   JA3 string: 771,4865-4866-4867-49195-49199,0-10-11-13-16-18-43-51,29-23-24,0
+	//   JA4_a:      t13d0508h2   (TCP, TLS1.3, SNI present, 5 ciphers, 8 exts, alpn h2)
+	//   JA4_b:      sha256("1301,1302,1303,c02b,c02f")[:12]
+	//   JA4_c:      sha256("000a,000b,000d,0012,002b,0033_0403,0804,0401")[:12]
+	const (
+		wantJA3 = "4b808534aaed88ea8efee030f1b46c4d"
+		wantJA4 = "t13d0508h2_e133e205ac38_4e31876e0826"
+	)
+	record := buildClientHello(helloOpts{includeSNI: true, includeALPN: true})
+	ja3, ja4 := Compute(record)
+	if ja3 != wantJA3 {
+		t.Errorf("JA3 = %q, want %q", ja3, wantJA3)
+	}
+	if ja4 != wantJA4 {
+		t.Errorf("JA4 = %q, want %q", ja4, wantJA4)
+	}
+}
+
+func TestComputeNoSNI(t *testing.T) {
+	record := buildClientHello(helloOpts{includeSNI: false, includeALPN: true})
+	_, ja4 := Compute(record)
+	// SNI absent → JA4_a SNI flag 'i'; ext count drops from 8 to 7.
+	if !strings.HasPrefix(ja4, "t13i0507h2_") {
+		t.Errorf("JA4 = %q, want prefix t13i0507h2_", ja4)
+	}
+}
+
+func TestComputeNoALPN(t *testing.T) {
+	record := buildClientHello(helloOpts{includeSNI: true, includeALPN: false})
+	_, ja4 := Compute(record)
+	// ALPN absent → JA4_a alpn chars "00"; ext count drops to 7.
+	if !strings.HasPrefix(ja4, "t13d050700_") {
+		t.Errorf("JA4 = %q, want prefix t13d050700_", ja4)
+	}
+}
+
+func TestComputeGREASEExcluded(t *testing.T) {
+	// The builder always injects GREASE cipher 0x0a0a and GREASE extension
+	// 0x1a1a plus GREASE entries in supported_groups / supported_versions.
+	// The golden vector already proves they are stripped (5 ciphers, 8 exts,
+	// curves 29-23-24). Here assert isGREASE directly on the RFC 8701 set.
+	for _, g := range []uint16{0x0a0a, 0x1a1a, 0x2a2a, 0x3a3a, 0xfafa} {
+		if !isGREASE(g) {
+			t.Errorf("isGREASE(%#04x) = false, want true", g)
+		}
+	}
+	for _, n := range []uint16{0x1301, 0x0000, 0x000a, 0x0a0b, 0x1a2a} {
+		if isGREASE(n) {
+			t.Errorf("isGREASE(%#04x) = true, want false", n)
+		}
+	}
+}
+
+func TestComputeEmptyCipherList(t *testing.T) {
+	// A ClientHello with zero cipher suites → JA4_b sentinel.
+	record := buildClientHello(helloOpts{includeSNI: true, includeALPN: true, ciphers: []uint16{}})
+	_, ja4 := Compute(record)
+	parts := strings.Split(ja4, "_")
+	if len(parts) != 3 {
+		t.Fatalf("JA4 = %q, want 3 underscore-separated sections", ja4)
+	}
+	if parts[1] != "000000000000" {
+		t.Errorf("JA4_b = %q, want 000000000000 for empty cipher list", parts[1])
+	}
+	if !strings.HasPrefix(parts[0], "t13d00") {
+		t.Errorf("JA4_a = %q, want cipher count 00", parts[0])
+	}
+}
+
+func TestComputeMalformed(t *testing.T) {
+	full := buildClientHello(helloOpts{includeSNI: true, includeALPN: true})
+	tests := []struct {
+		name   string
+		record []byte
+	}{
+		{"nil", nil},
+		{"short header", []byte{0x16, 0x03}},
+		{"not handshake", []byte{0x17, 0x03, 0x01, 0x00, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05}},
+		{"truncated body", full[:len(full)-40]},
+		{"truncated mid extensions", full[:60]},
+		{"handshake type not clienthello", func() []byte {
+			c := append([]byte(nil), full...)
+			c[recordHeaderLen] = 0x02 // ServerHello
+			return c
+		}()},
+		{"zero record length", []byte{0x16, 0x03, 0x01, 0x00, 0x00}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ja3, ja4 := Compute(tt.record)
+			if ja3 != "" || ja4 != "" {
+				t.Errorf("Compute(%s) = (%q, %q), want empty", tt.name, ja3, ja4)
+			}
+		})
+	}
+}
+
+func TestComputeDeterministic(t *testing.T) {
+	record := buildClientHello(helloOpts{includeSNI: true, includeALPN: true})
+	ja3a, ja4a := Compute(record)
+	ja3b, ja4b := Compute(record)
+	if ja3a != ja3b || ja4a != ja4b {
+		t.Errorf("non-deterministic: (%q,%q) vs (%q,%q)", ja3a, ja4a, ja3b, ja4b)
+	}
+	// Input must not be mutated by Compute (wire-fidelity).
+	before := append([]byte(nil), record...)
+	Compute(record)
+	if string(before) != string(record) {
+		t.Error("Compute mutated its input slice")
+	}
+}
+
+// TestComputeRealFirefoxHello runs the parser against a genuine
+// utls-generated Firefox ClientHello. It asserts the JA4_a metadata prefix
+// (t = TCP, 13 = TLS 1.3, d = SNI present) and that both fingerprints are
+// non-empty and stable — a realism check beyond the synthetic golden vector.
+func TestComputeRealFirefoxHello(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	uConn := utls.UClient(c1, &utls.Config{
+		ServerName: "example.com",
+		MinVersion: tls.VersionTLS12,
+	}, utls.HelloFirefox_Auto)
+	if err := uConn.BuildHandshakeState(); err != nil {
+		t.Fatalf("BuildHandshakeState: %v", err)
+	}
+	raw := uConn.HandshakeState.Hello.Raw // handshake message (type+len+body)
+	if len(raw) == 0 {
+		t.Fatal("empty ClientHello raw")
+	}
+	record := concat([]byte{0x16, 0x03, 0x01}, u16(uint16(len(raw))), raw)
+
+	ja3, ja4 := Compute(record)
+	if ja3 == "" || ja4 == "" {
+		t.Fatalf("empty fingerprints for real Firefox hello: ja3=%q ja4=%q", ja3, ja4)
+	}
+	if len(ja3) != 32 {
+		t.Errorf("JA3 = %q, want 32-char md5 hex", ja3)
+	}
+	if !strings.HasPrefix(ja4, "t13d") {
+		t.Errorf("JA4 = %q, want t13d prefix (TCP/TLS1.3/SNI)", ja4)
+	}
+	// JA4 shape: t<ver><sni><cc><ec><alpn>_<12hex>_<12hex>
+	parts := strings.Split(ja4, "_")
+	if len(parts) != 3 || len(parts[0]) != 10 || len(parts[1]) != 12 || len(parts[2]) != 12 {
+		t.Errorf("JA4 = %q, malformed section lengths", ja4)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the dead `EnvelopeContext.TLS.ClientFingerprint` field (USK-1015). The MITM ClientHello peek already buffers the full hello but discarded everything past SNI+ALPN; this computes the client's **JA3** (MD5) and **JA4** (TLS client) fingerprints from the same buffer and surfaces them to plugins, the `query` MCP tool, and flow recording.

Wire fidelity is preserved: fingerprints are pure observation overlay — `env.Raw` and the peeked bytes are never mutated, and JA3 preserves wire order (JA4's internal cipher/extension sort is derived data only). Fail-soft on malformed/truncated input (empty result, never a panic).

### What changed
- **`internal/tlsfingerprint`** (new): stdlib-only (`crypto/md5`, `crypto/sha256`), self-contained JA3/JA4 computation. No new dependency; the FoxIO JA4 library is deliberately not imported (FoxIO-1.1 licence).
- **connector**: `ClientHelloPeek` carries `ClientJA3/ClientJA4`; both the sniff-first peek and the passthrough SNI peek compute them from the buffered hello. `performClientMITM` stamps them onto the client-facing `TLSSnapshot` for **every** MITM build branch (sniff / cache-hit / cache-miss / pool-hit / fallback), decoupled from the `peeked.ALPN` gate so ALPN-less / HTTP/1.1-only clients still get fingerprints.
- **envelope**: `TLSSnapshot` gains `ClientJA3/ClientJA4`; `ClientFingerprint` is set to `ClientJA4` for back-compat. `TLSHandshakeMessage` gains the fields for the passthrough audit flow.
- **pluginv2**: `ctx.tls` and `tls.on_handshake` dicts gain `ja3` / `ja4` keys (existing `client_fingerprint` key now populated).
- **flow**: `ConnectionInfo` + `StreamUpdate` + **schemaV18** columns `tls_client_ja3` / `tls_client_ja4`, wired through sqlite insert/scan/update, export, and import. `RecordStep` projects the client fingerprint from the Send-side snapshot without clobbering the upstream TLS columns.
- **mcp**: `query` `conn_info` surfaces `tls_client_ja3` / `tls_client_ja4`.

### Out of scope (deferred)
- Mirroring/replaying the client fingerprint to the upstream dial (capture only; noted "unimplemented" at the seam).
- ClientHellos larger than the 4 KiB peek cap are not fingerprinted — matches the existing SNI/ALPN silent fallback.
- Raw `raw_passthrough` (TLS-terminate + bytechunk) mode is not wired (its bytechunk layer does not stamp EnvelopeContext, so it has no flow surface today).

## Test plan
- `internal/tlsfingerprint`: table-driven golden vectors (JA3 MD5 + JA4 sections computed independently via Python), GREASE exclusion, no-SNI / no-ALPN, empty-cipher JA4_b sentinel, malformed/truncated no-panic, input-immutability, and a **real utls Firefox ClientHello** realism check.
- connector: sniff-first + passthrough peek fingerprint tests.
- flow: `ConnInfo` column round-trip (Save→Get), `UpdateStream` no-clobber, export/import round-trip.
- pluginv2: `ja3`/`ja4`/`client_fingerprint` dict keys.
- pipeline: Send-side projection sets only the fingerprint columns.
- `make lint` / `make build` / `make test` all green (49 packages, `-race`).

Resolves USK-1015

Linear: https://linear.app/usk6666/issue/USK-1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)