### PR TITLE
fix(config): default tls_fingerprint to firefox and fix none escape hatch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,10 +194,12 @@ type Config struct {
 	TLSPassthrough []string `json:"tls_passthrough"`
 
 	// TLSFingerprint selects the TLS ClientHello fingerprint profile for
-	// upstream HTTPS connections. When set, uTLS is used to mimic a browser's
-	// TLS fingerprint, evading JA3/JA4-based bot detection.
-	// Valid values: "chrome", "firefox", "safari", "edge", "random".
-	// Empty or unset means Go's default TLS stack is used (no fingerprint spoofing).
+	// upstream HTTPS connections. uTLS is used to mimic a browser's TLS
+	// fingerprint, evading JA3/JA4-based bot detection.
+	// Valid values: "firefox" (default), "chrome", "safari", "edge", "random",
+	// "none" (standard crypto/tls, no fingerprint spoofing).
+	// Empty or unset resolves to "firefox" (see config.ResolveTLSFingerprint,
+	// USK-1013); use "none" to opt out of uTLS spoofing.
 	TLSFingerprint string `json:"tls_fingerprint"`
 
 	// ClientCertPath is the path to the PEM-encoded client certificate file
@@ -328,6 +330,42 @@ func ResolveDBPath(value string) (string, error) {
 
 	// Otherwise treat as a CWD-relative path (backward compatible).
 	return value, nil
+}
+
+// DefaultTLSFingerprint is the upstream TLS ClientHello fingerprint profile
+// used when neither the proxy config nor the top-level config selects one.
+// Firefox is the default so the proxy's own TLS fingerprint stays coherent
+// with the camoufox anti-detect browser pairing (M47/M48) out of the box.
+// Chrome parity remains available via explicit configuration.
+const DefaultTLSFingerprint = "firefox"
+
+// ResolveTLSFingerprint returns the effective upstream TLS ClientHello
+// fingerprint profile name, applying the precedence:
+//
+//  1. proxyCfg.TLSFingerprint (per-listener config / `-tls-fingerprint` flag)
+//  2. cfg.TLSFingerprint (top-level config; pass a nil cfg to skip this tier
+//     and preserve the live-dial path's proxyCfg-only contract)
+//  3. DefaultTLSFingerprint ("firefox")
+//
+// The opt-out sentinel "none" (case-insensitive) resolves to "" so the caller
+// dials with the standard crypto/tls stack (no uTLS spoofing). Any other value
+// passes through unchanged for downstream profile validation. This is the
+// single source of truth for the firefox default and the "none" escape hatch;
+// call it from every boot-time fingerprint resolution site (USK-1013).
+func ResolveTLSFingerprint(cfg *Config, proxyCfg *ProxyConfig) string {
+	fingerprint := ""
+	if proxyCfg != nil && proxyCfg.TLSFingerprint != "" {
+		fingerprint = proxyCfg.TLSFingerprint
+	} else if cfg != nil && cfg.TLSFingerprint != "" {
+		fingerprint = cfg.TLSFingerprint
+	}
+	if fingerprint == "" {
+		fingerprint = DefaultTLSFingerprint
+	}
+	if strings.EqualFold(strings.TrimSpace(fingerprint), "none") {
+		return ""
+	}
+	return fingerprint
 }
 
 // validateProjectName checks that a project name contains only safe characters.
@@ -639,7 +677,8 @@ type ProxyConfig struct {
 	UpstreamProxyStruct *UpstreamProxyConfig `json:"-"`
 
 	// TLSFingerprint selects the TLS ClientHello fingerprint profile for upstream connections.
-	// Valid values: "chrome" (default), "firefox", "safari", "edge", "random", "none" (standard crypto/tls).
+	// Valid values: "firefox" (default), "chrome", "safari", "edge", "random", "none" (standard crypto/tls).
+	// Empty or unset resolves to "firefox" (config.ResolveTLSFingerprint, USK-1013).
 	TLSFingerprint string `json:"tls_fingerprint,omitempty"`
 
 	// ClientCertPath is the path to a PEM-encoded client certificate for mTLS (global).

--- a/internal/config/config_tls_test.go
+++ b/internal/config/config_tls_test.go
@@ -53,3 +53,77 @@ func TestLoadFile_TLSFingerprint(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveTLSFingerprint covers the boot-time fingerprint resolution
+// precedence (proxyCfg > cfg > firefox default) and the "none" opt-out
+// sentinel that maps to "" (standard crypto/tls) — USK-1013.
+func TestResolveTLSFingerprint(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *Config
+		proxyCfg *ProxyConfig
+		want     string
+	}{
+		{
+			name:     "both empty defaults to firefox",
+			cfg:      &Config{},
+			proxyCfg: &ProxyConfig{},
+			want:     "firefox",
+		},
+		{
+			name:     "nil both defaults to firefox",
+			cfg:      nil,
+			proxyCfg: nil,
+			want:     "firefox",
+		},
+		{
+			name:     "proxyCfg wins over cfg",
+			cfg:      &Config{TLSFingerprint: "safari"},
+			proxyCfg: &ProxyConfig{TLSFingerprint: "chrome"},
+			want:     "chrome",
+		},
+		{
+			name:     "cfg used when proxyCfg empty",
+			cfg:      &Config{TLSFingerprint: "edge"},
+			proxyCfg: &ProxyConfig{},
+			want:     "edge",
+		},
+		{
+			name:     "nil cfg skips top-level tier (live-path contract)",
+			cfg:      nil,
+			proxyCfg: &ProxyConfig{},
+			want:     "firefox",
+		},
+		{
+			name:     "explicit none maps to empty (standard TLS)",
+			cfg:      &Config{},
+			proxyCfg: &ProxyConfig{TLSFingerprint: "none"},
+			want:     "",
+		},
+		{
+			name:     "none is case-insensitive and trimmed",
+			cfg:      &Config{},
+			proxyCfg: &ProxyConfig{TLSFingerprint: "  NONE  "},
+			want:     "",
+		},
+		{
+			name:     "top-level none also opts out",
+			cfg:      &Config{TLSFingerprint: "none"},
+			proxyCfg: &ProxyConfig{},
+			want:     "",
+		},
+		{
+			name:     "explicit firefox passes through",
+			cfg:      &Config{},
+			proxyCfg: &ProxyConfig{TLSFingerprint: "firefox"},
+			want:     "firefox",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveTLSFingerprint(tt.cfg, tt.proxyCfg); got != tt.want {
+				t.Errorf("ResolveTLSFingerprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/components.go
+++ b/internal/mcp/components.go
@@ -185,7 +185,7 @@ type proxyManager interface {
 	// profile reflecting any runtime SetTLSFingerprint override on top
 	// of the boot-time BuildConfig.TLSFingerprint (USK-809). Returns
 	// the empty string when no BuildConfig is bound. Callers must NOT
-	// substitute a "chrome" default — empty is the canonical "no
+	// substitute the "firefox" boot default — empty is the canonical "no
 	// fingerprint configured" sentinel.
 	TLSFingerprint() string
 	// SetMaxConcurrentStreams installs a runtime override for the

--- a/internal/mcp/configure_tls_fingerprint_test.go
+++ b/internal/mcp/configure_tls_fingerprint_test.go
@@ -474,9 +474,12 @@ func TestProxyStart_TLSFingerprint_NoneUsesStandardTransport(t *testing.T) {
 }
 
 func TestResetSettingsToDefaults_RebuildsTLSTransport(t *testing.T) {
-	setter := &mockTLSFingerprintSetter{profile: "firefox"}
+	// USK-1013: the boot default is firefox, so resetSettingsToDefaults must
+	// restore firefox (not chrome). Start from chrome to prove the reset moves
+	// the profile back to the firefox default.
+	setter := &mockTLSFingerprintSetter{profile: "chrome"}
 	initialTransport := &transport.UTLSTransport{
-		Profile:            transport.ProfileFirefox,
+		Profile:            transport.ProfileChrome,
 		InsecureSkipVerify: true,
 	}
 
@@ -490,12 +493,12 @@ func TestResetSettingsToDefaults_RebuildsTLSTransport(t *testing.T) {
 	// Reset to defaults.
 	s.resetSettingsToDefaults(proxybuild.DefaultListenerName)
 
-	// Profile should be reset to "chrome".
-	if setter.profile != "chrome" {
-		t.Errorf("setter.profile = %q, want chrome", setter.profile)
+	// Profile should be reset to "firefox".
+	if setter.profile != "firefox" {
+		t.Errorf("setter.profile = %q, want firefox", setter.profile)
 	}
 
-	// Transport should be rebuilt as UTLSTransport with Chrome profile.
+	// Transport should be rebuilt as UTLSTransport with Firefox profile.
 	if setter.transport == nil {
 		t.Fatal("transport was not set after reset")
 	}
@@ -503,8 +506,8 @@ func TestResetSettingsToDefaults_RebuildsTLSTransport(t *testing.T) {
 	if !ok {
 		t.Fatalf("transport type = %T, want *transport.UTLSTransport", setter.transport)
 	}
-	if ut.Profile != transport.ProfileChrome {
-		t.Errorf("transport profile = %v, want ProfileChrome", ut.Profile)
+	if ut.Profile != transport.ProfileFirefox {
+		t.Errorf("transport profile = %v, want ProfileFirefox", ut.Profile)
 	}
 	if !ut.InsecureSkipVerify {
 		t.Error("InsecureSkipVerify should be inherited from initial transport")

--- a/internal/mcp/prompts/capture-traffic.md
+++ b/internal/mcp/prompts/capture-traffic.md
@@ -43,7 +43,7 @@ If `listen_addr` was not provided, default to `127.0.0.1:8080`.
 Scope tips:
 - Use `capture_scope` (recording filter) to keep the flow store focused.
 - Use `tls_passthrough` for services with certificate pinning — TLS interception is what breaks pinning, not recording.
-- For Cloudflare-style WAF detection issues, configure `tls_fingerprint` on `proxy_start` (default `chrome`).
+- For Cloudflare-style WAF detection issues, configure `tls_fingerprint` on `proxy_start` (default `firefox`).
 - Only use `security set_target_scope` (the transmission gate) if you must hard-block third-party requests — it typically breaks browser-driven flows because pages depend on third-party assets.
 
 ### 2. Drive the browser via playwright-cli

--- a/internal/mcp/proxy_start_tool.go
+++ b/internal/mcp/proxy_start_tool.go
@@ -119,9 +119,9 @@ type proxyStartInput struct {
 	SOCKS5Password string `json:"socks5_password,omitempty" jsonschema:"password for SOCKS5 password authentication"`
 
 	// TLSFingerprint selects the TLS ClientHello fingerprint profile for upstream connections.
-	// Valid values: "chrome" (default), "firefox", "safari", "edge", "random", "none" (standard crypto/tls).
-	// If omitted, defaults to "chrome".
-	TLSFingerprint string `json:"tls_fingerprint,omitempty" jsonschema:"TLS fingerprint profile: chrome (default), firefox, safari, edge, random, none"`
+	// Valid values: "firefox" (default), "chrome", "safari", "edge", "random", "none" (standard crypto/tls).
+	// If omitted, defaults to "firefox" (camoufox coherence, USK-1013).
+	TLSFingerprint string `json:"tls_fingerprint,omitempty" jsonschema:"TLS fingerprint profile: firefox (default), chrome, safari, edge, random, none"`
 
 	// ClientCertPath is the path to a PEM-encoded client certificate for mTLS with upstream servers (global).
 	// Must be used together with client_key. If omitted, no client certificate is presented.
@@ -430,9 +430,10 @@ func (s *Server) resetSettingsToDefaults(listenerName string) {
 		setter.SetUpstreamProxy(nil)
 	}
 
-	// Reset TLS fingerprint to default ("chrome"), including transport rebuild.
+	// Reset TLS fingerprint to default ("firefox"), including transport rebuild.
 	// Use applyTLSFingerprint to ensure transport is reconstructed (USK-467).
-	_ = s.applyTLSFingerprint("chrome")
+	// firefox is the boot default (config.DefaultTLSFingerprint, USK-1013).
+	_ = s.applyTLSFingerprint(config.DefaultTLSFingerprint)
 
 	// Reset global client certificate.
 	if s.connector.hostTLSRegistry != nil {

--- a/internal/mcp/proxy_start_tool_test.go
+++ b/internal/mcp/proxy_start_tool_test.go
@@ -1617,7 +1617,9 @@ func TestProxyStart_ResetsLimitsAndTimeoutsOnRestart(t *testing.T) {
 }
 
 // TestProxyStart_ResetsTLSFingerprintOnRestart verifies that TLS fingerprint
-// is reset to "chrome" (default) when proxy_start omits tls_fingerprint.
+// is reset to "firefox" (default, USK-1013) when proxy_start omits
+// tls_fingerprint. Start from chrome to prove the reset moves the profile back
+// to the firefox default.
 func TestProxyStart_ResetsTLSFingerprintOnRestart(t *testing.T) {
 	manager := newTestProxybuildManager(t)
 
@@ -1630,7 +1632,7 @@ func TestProxyStart_ResetsTLSFingerprintOnRestart(t *testing.T) {
 	// Step 1: Start proxy with custom fingerprint.
 	result, err := callProxyStart(t, cs, map[string]any{
 		"listen_addr":     "127.0.0.1:0",
-		"tls_fingerprint": "firefox",
+		"tls_fingerprint": "chrome",
 	})
 	if err != nil {
 		t.Fatalf("CallTool (first start): %v", err)
@@ -1638,8 +1640,8 @@ func TestProxyStart_ResetsTLSFingerprintOnRestart(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error on first start: %v", result.Content)
 	}
-	if mockFP.profile != "firefox" {
-		t.Errorf("tls_fingerprint after first start = %q, want %q", mockFP.profile, "firefox")
+	if mockFP.profile != "chrome" {
+		t.Errorf("tls_fingerprint after first start = %q, want %q", mockFP.profile, "chrome")
 	}
 
 	// Step 2: Stop and restart without fingerprint.
@@ -1664,8 +1666,8 @@ func TestProxyStart_ResetsTLSFingerprintOnRestart(t *testing.T) {
 	}
 
 	// Verify fingerprint was reset to default.
-	if mockFP.profile != "chrome" {
-		t.Errorf("tls_fingerprint after restart = %q, want %q (default)", mockFP.profile, "chrome")
+	if mockFP.profile != "firefox" {
+		t.Errorf("tls_fingerprint after restart = %q, want %q (default)", mockFP.profile, "firefox")
 	}
 }
 

--- a/internal/mcp/resources/help_proxy_start.md
+++ b/internal/mcp/resources/help_proxy_start.md
@@ -73,8 +73,8 @@ Each entry maps a local port number (string key) to either:
 
 ### tls_fingerprint (string, optional)
 TLS ClientHello fingerprint profile for upstream connections.
-- `"chrome"` (default): Mimic Chrome browser TLS fingerprint.
-- `"firefox"`: Mimic Firefox browser TLS fingerprint.
+- `"firefox"` (default): Mimic Firefox browser TLS fingerprint (camoufox coherence).
+- `"chrome"`: Mimic Chrome browser TLS fingerprint.
 - `"safari"`: Mimic Safari browser TLS fingerprint.
 - `"edge"`: Mimic Edge browser TLS fingerprint.
 - `"random"`: Select a random browser fingerprint per connection.

--- a/internal/mcpserver/init.go
+++ b/internal/mcpserver/init.go
@@ -522,9 +522,14 @@ func NewLiveBuildConfig(
 	bc.GRPCMaxMessagesPerStream = config.ResolveGRPCMaxMessagesPerStream(proxyCfg.GRPC)
 	bc.SSEMaxEventsPerStream = config.ResolveSSEMaxEventsPerStream(proxyCfg.SSE)
 	bc.MaxBodySize = config.ResolveMaxBodySize(proxyCfg)
-	if proxyCfg.TLSFingerprint != "" {
-		bc.TLSFingerprint = proxyCfg.TLSFingerprint
-	}
+	// USK-1013: default the upstream TLS fingerprint to firefox (camoufox
+	// coherence). Pass a nil cfg so the live-dial path keeps its proxyCfg-only
+	// contract (it has historically not consulted top-level cfg.TLSFingerprint,
+	// unlike the resend axis in InitTLSTransport). The resolver maps the "none"
+	// opt-out sentinel to "" so bc.EffectiveTLSFingerprint() selects the
+	// standard crypto/tls stack (clientStandard) rather than hard-erroring the
+	// dial on an unknown uTLS profile.
+	bc.TLSFingerprint = config.ResolveTLSFingerprint(nil, proxyCfg)
 
 	return bc
 }
@@ -729,21 +734,19 @@ func applyHostTLSEntries(reg *transport.HostTLSRegistry, entries map[string]*con
 // standard transport is used otherwise. The HostTLSRegistry threaded in
 // here applies per-host mTLS / verify overrides.
 //
-// TLSFingerprint resolution order (USK-719):
+// TLSFingerprint resolution order (USK-719, default firefox per USK-1013):
 //
 //  1. proxyCfg.TLSFingerprint — populated by `-tls-fingerprint` CLI flag
 //     and by the proxy-config file's `tls_fingerprint`. This is the
 //     surface most users discover first.
 //  2. cfg.TLSFingerprint — populated by the top-level config file's
 //     `tls_fingerprint`. Kept for backward compatibility.
-//  3. empty — falls back to StandardTransport.
+//  3. "firefox" — the default when both are empty (camoufox coherence).
+//
+// The "none" opt-out sentinel resolves to "" (via config.ResolveTLSFingerprint)
+// and falls back to StandardTransport.
 func InitTLSTransport(cfg *config.Config, proxyCfg *config.ProxyConfig, reg *transport.HostTLSRegistry, logger *slog.Logger) transport.TLSTransport {
-	fingerprint := ""
-	if proxyCfg.TLSFingerprint != "" {
-		fingerprint = proxyCfg.TLSFingerprint
-	} else if cfg.TLSFingerprint != "" {
-		fingerprint = cfg.TLSFingerprint
-	}
+	fingerprint := config.ResolveTLSFingerprint(cfg, proxyCfg)
 
 	if fingerprint != "" {
 		profile, err := transport.ParseBrowserProfile(fingerprint)

--- a/internal/mcpserver/init_test.go
+++ b/internal/mcpserver/init_test.go
@@ -435,15 +435,35 @@ func TestInitHostTLSRegistry_PerHostFromProxyConfig(t *testing.T) {
 
 // --- InitTLSTransport tests (USK-719) ---
 
-// TestInitTLSTransport_Default verifies the no-fingerprint case yields a
-// StandardTransport.
+// TestInitTLSTransport_Default verifies that the no-fingerprint case now
+// resolves to the firefox default (USK-1013), yielding a UTLSTransport with
+// ProfileFirefox rather than a StandardTransport.
 func TestInitTLSTransport_Default(t *testing.T) {
 	logger := testLogger(t)
 	cfg := config.Default()
 
 	got := InitTLSTransport(cfg, &config.ProxyConfig{}, nil, logger)
+	utls, ok := got.(*transport.UTLSTransport)
+	if !ok {
+		t.Fatalf("got %T, want *UTLSTransport (firefox default)", got)
+	}
+	if utls.Profile != transport.ProfileFirefox {
+		t.Errorf("Profile = %v, want ProfileFirefox (default)", utls.Profile)
+	}
+}
+
+// TestInitTLSTransport_NoneOptsOut verifies the "none" escape hatch: an
+// explicit "none" resolves to "" (config.ResolveTLSFingerprint) so the resend
+// axis falls back to StandardTransport instead of the firefox default
+// (USK-1013 U1).
+func TestInitTLSTransport_NoneOptsOut(t *testing.T) {
+	logger := testLogger(t)
+	cfg := config.Default()
+	proxyCfg := &config.ProxyConfig{TLSFingerprint: "none"}
+
+	got := InitTLSTransport(cfg, proxyCfg, nil, logger)
 	if _, ok := got.(*transport.StandardTransport); !ok {
-		t.Errorf("got %T, want *StandardTransport", got)
+		t.Errorf("got %T, want *StandardTransport for none opt-out", got)
 	}
 }
 
@@ -514,6 +534,41 @@ func TestInitTLSTransport_InvalidProfileFallback(t *testing.T) {
 	got := InitTLSTransport(cfg, proxyCfg, nil, logger)
 	if _, ok := got.(*transport.StandardTransport); !ok {
 		t.Errorf("got %T, want *StandardTransport on invalid profile", got)
+	}
+}
+
+// TestNewLiveBuildConfig_TLSFingerprintDefault verifies the live-dial boot
+// path (USK-1013): an unset fingerprint is pinned to the firefox default,
+// "none" opts out to standard TLS (empty EffectiveTLSFingerprint → clientStandard),
+// and an explicit profile passes through. The live path is proxyCfg-only, so
+// a top-level cfg.TLSFingerprint must NOT leak in when proxyCfg is empty.
+func TestNewLiveBuildConfig_TLSFingerprintDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		proxyFP    string
+		topLevelFP string
+		wantStored string // bc.TLSFingerprint
+		wantEffect string // bc.EffectiveTLSFingerprint()
+	}{
+		{"unset defaults to firefox", "", "", "firefox", "firefox"},
+		{"none opts out to standard TLS", "none", "", "", ""},
+		{"explicit chrome passes through", "chrome", "", "chrome", "chrome"},
+		{"live path ignores top-level cfg", "", "safari", "firefox", "firefox"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.TLSFingerprint = tt.topLevelFP
+			proxyCfg := &config.ProxyConfig{TLSFingerprint: tt.proxyFP}
+
+			bc := NewLiveBuildConfig(cfg, proxyCfg, nil, nil, nil)
+			if bc.TLSFingerprint != tt.wantStored {
+				t.Errorf("bc.TLSFingerprint = %q, want %q", bc.TLSFingerprint, tt.wantStored)
+			}
+			if got := bc.EffectiveTLSFingerprint(); got != tt.wantEffect {
+				t.Errorf("bc.EffectiveTLSFingerprint() = %q, want %q (selects clientStandard when empty)", got, tt.wantEffect)
+			}
+		})
 	}
 }
 

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -948,8 +948,8 @@ func (m *Manager) MaxConcurrentStreams() uint32 {
 // the boot-time BuildConfig.TLSFingerprint when no override is in
 // effect. Returns the empty string when no BuildConfig is bound — the
 // caller is responsible for translating empty into a user-facing
-// representation if desired (this accessor does NOT substitute a
-// "chrome" default).
+// representation if desired (this accessor does NOT substitute the
+// "firefox" boot default — empty stays empty).
 func (m *Manager) TLSFingerprint() string {
 	m.mu.Lock()
 	bc := m.buildCfg


### PR DESCRIPTION
## Summary

The documented `"chrome"` default for the upstream TLS fingerprint was **docs-only** — never enforced in the dial path. An empty `tls_fingerprint` resolved to `""` (`EffectiveTLSFingerprint()` returned empty → `clientStandard`), so the proxy dialed upstream with standard Go `crypto/tls` and **no fingerprint spoofing at all**.

This change makes the default resolve to **firefox** at boot so the proxy's own TLS fingerprint is coherent with the camoufox anti-detect browser pairing out of the box (M47 — Firefox Fingerprint Fidelity). Chrome parity stays available via explicit config.

### Changes
- **`config.ResolveTLSFingerprint(cfg, proxyCfg)`** — new single source of truth. Precedence `proxyCfg > cfg > firefox` (`config.DefaultTLSFingerprint`). The `"none"` sentinel (case-insensitive, trimmed) maps to `""` so the caller opts out to standard `crypto/tls`.
- **`NewLiveBuildConfig`** (live dial path) pins the resolved value into `bc.TLSFingerprint`, passing a **nil cfg** to preserve the historical proxyCfg-only contract (does not newly consult top-level `cfg.TLSFingerprint`). `"none"` → `""` so the live dial selects `clientStandard` rather than hard-erroring on an unknown uTLS profile (USK-1013 **U1, Option A**: `internal/layer/tlslayer` data path left untouched).
- **`InitTLSTransport`** (resend axis) shares the resolver for firefox coherence.
- **`resetSettingsToDefaults`** now restores firefox (was chrome).
- Fixed stale `"chrome (default)"` labelling: `ProxyConfig.TLSFingerprint` + top-level `Config.TLSFingerprint` comments, `proxy_start` schema/jsonschema, MCP `help_proxy_start.md` / `capture-traffic.md`, and the USK-809 sentinel comments in `components.go` / `manager.go`.

### Not in scope (deferred)
- FF120-vs-FF150 uTLS version gap → USK-1014.
- `auto = mirror client` → USK-1015.
- `ProxyConfig.Validate()` fingerprint validation → follow-up.
- The live-path/`cfg.TLSFingerprint` asymmetry is intentionally **preserved** (nil cfg on the live path), not unified.

The USK-809 empty-sentinel contract is preserved: `bc.TLSFingerprint` holds a genuine stored value, accessors do not substitute a literal for empty, and runtime overrides still win.

## Test plan
- New `TestResolveTLSFingerprint` (config): table-driven precedence + `"none"` → `""` + nil-cfg live-path skip + case-insensitive `none`.
- New `TestNewLiveBuildConfig_TLSFingerprintDefault` (mcpserver): firefox pinned when unset; `"none"` → empty `EffectiveTLSFingerprint()` (selects `clientStandard`); explicit chrome passthrough; top-level cfg ignored on the live path.
- New `TestInitTLSTransport_NoneOptsOut` + updated `TestInitTLSTransport_Default` (firefox default → `UTLSTransport`).
- Updated `TestResetSettingsToDefaults_RebuildsTLSTransport` and `TestProxyStart_ResetsTLSFingerprintOnRestart` to expect firefox (start from chrome to prove the reset moves the profile).
- `make lint`, `make build`, `make test` all green (48 packages ok, race enabled).

Resolves USK-1013
Linear: https://linear.app/usk6666/issue/USK-1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)