### PR TITLE
test(e2e): fingerprint coherence harness (JA3/JA4 + H2 = Firefox)

### DIFF
--- a/internal/mcptest/fingerprint_coherence_integration_test.go
+++ b/internal/mcptest/fingerprint_coherence_integration_test.go
@@ -1,0 +1,564 @@
+//go:build e2e && !e2e_smoke
+
+// Package mcptest_test holds USK-1011's capstone verification for the M47
+// Firefox Fingerprint Fidelity milestone: when tls_fingerprint=firefox is
+// selected, the fingerprint the UPSTREAM observes coming FROM THE PROXY must
+// be Firefox-coherent on BOTH axes —
+//
+//   - TLS: the proxy→upstream ClientHello's JA4 equals a uTLS
+//     HelloFirefox_Auto reference (exact), and its cipher set matches
+//     (structural, order-independent — the "JA3 structural" check per the
+//     design review's U1: uTLS may shuffle extensions per handshake, so an
+//     exact JA3 wire-order hash would be flaky, whereas JA4's sorted form is
+//     shuffle- and GREASE-immune and therefore deterministic).
+//   - HTTP/2: the proxy's upstream SETTINGS (wire order + values), the
+//     stream-0 WINDOW_UPDATE increment, and the request pseudo-header order
+//     match the Firefox FF120 goldens (USK-1007).
+//
+// The chrome sub-test asserts the Chrome-shape baseline (both axes) and the
+// none sub-test asserts the standard-TLS / not-a-browser baseline, so an
+// accidental profile bleed (e.g. "none" silently dialing Firefox) is caught
+// as a regression rather than passing silently.
+//
+// Wiring: this drives a real HTTP/2 data-plane request through the proxy via
+// a CONNECT tunnel + client-offered ALPN h2, so the MITM'd upstream leg
+// negotiates h2 and the capture upstream (mcptest UpstreamProto="capture")
+// records the proxy's real on-wire ClientHello + H2 frames. It runs in the
+// exhaustive (non-smoke) e2e tier.
+package mcptest_test
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	gohttp "net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	utls "github.com/refraction-networking/utls"
+	"golang.org/x/net/http2"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/frame"
+	"github.com/usk6666/yorishiro-proxy/internal/mcptest"
+	"github.com/usk6666/yorishiro-proxy/internal/tlsfingerprint"
+)
+
+// fpH2Shape is the expected HTTP/2 send-shape for one browser profile.
+type fpH2Shape struct {
+	settings   []frame.Setting
+	connWindow uint32
+	pseudo     []string
+}
+
+// firefoxH2Shape pins the Firefox FF120 goldens (USK-1007): SETTINGS
+// 1:65536, 2:0, 4:131072, 5:16384 in wire order (no MAX_CONCURRENT_STREAMS),
+// a stream-0 WINDOW_UPDATE increment of 12517377, and pseudo-header order
+// :method :path :authority :scheme.
+var firefoxH2Shape = fpH2Shape{
+	settings: []frame.Setting{
+		{ID: frame.SettingHeaderTableSize, Value: 65536},
+		{ID: frame.SettingEnablePush, Value: 0},
+		{ID: frame.SettingInitialWindowSize, Value: 131072},
+		{ID: frame.SettingMaxFrameSize, Value: 16384},
+	},
+	connWindow: 12517377,
+	pseudo:     []string{":method", ":path", ":authority", ":scheme"},
+}
+
+// chromeH2Shape is the default (Chrome-ish) baseline every non-firefox
+// profile — including "none" — resolves to: SETTINGS 1:4096, 2:0, 3:500,
+// 4:16777216, 5:16384 (MAX_CONCURRENT_STREAMS present), a 16 MiB - 65535
+// connection-window bump, and pseudo-header order :method :scheme :authority
+// :path.
+var chromeH2Shape = fpH2Shape{
+	settings: []frame.Setting{
+		{ID: frame.SettingHeaderTableSize, Value: 4096},
+		{ID: frame.SettingEnablePush, Value: 0},
+		{ID: frame.SettingMaxConcurrentStreams, Value: 500},
+		{ID: frame.SettingInitialWindowSize, Value: 16777216},
+		{ID: frame.SettingMaxFrameSize, Value: 16384},
+	},
+	connWindow: 16777216 - 65535, // 16711681
+	pseudo:     []string{":method", ":scheme", ":authority", ":path"},
+}
+
+// fpDataPlaneALPN is the ALPN offer list the data-plane client presents to
+// the proxy. The MITM sniff-first path (USK-997) forwards it byte-identical
+// to the upstream leg, so the offline uTLS reference must use the same list
+// to produce a matching JA4.
+var fpDataPlaneALPN = []string{"h2", "http/1.1"}
+
+// TestE2E_FingerprintCoherence_UpstreamShape is the USK-1011 capstone. For
+// each profile it drives one h2 request through the proxy and asserts the
+// upstream-observed TLS + H2 fingerprint coherence, plus the recording
+// outcomes (Stream/Flow/env.Raw) per the e2e Subsystem Verification
+// Checklist.
+func TestE2E_FingerprintCoherence_UpstreamShape(t *testing.T) {
+	cases := []struct {
+		name        string
+		fingerprint string
+		helloID     *utls.ClientHelloID // nil for "none" (standard crypto/tls)
+		wantH2      fpH2Shape
+		skip        string // non-empty → t.Skip referencing the blocking Issue
+	}{
+		{"firefox", "firefox", &utls.HelloFirefox_Auto, firefoxH2Shape, ""},
+		{"chrome", "chrome", &utls.HelloChrome_Auto, chromeH2Shape, ""},
+		// USK-1021: proxy_start installs the raw "none" sentinel as the
+		// live-dial override instead of resolving it to "" (standard TLS),
+		// so the MITM upstream dial fails with `unsupported uTLS profile
+		// "none"`. This sub-case is the regression test — un-skip once the
+		// fix lands. Do NOT weaken the assertions to make it pass
+		// (MITM-diagnostic test philosophy).
+		{"none", "none", nil, chromeH2Shape, "not yet implemented: USK-1021 (proxy_start none→standard-TLS override)"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+			// ResolveTLSFingerprint defaults unset → firefox, so every
+			// sub-test MUST set -tls-fingerprint explicitly.
+			h := mcptest.StartHarness(t, mcptest.HarnessOptions{
+				TLSFingerprint: tc.fingerprint,
+				UpstreamProto:  "capture",
+			})
+			if h.UpstreamCapture == nil {
+				t.Fatal("UpstreamCapture is nil; harness wiring regressed")
+			}
+
+			startRes := h.MustOK(t, "proxy_start", map[string]any{"listen_addr": "127.0.0.1:0"})
+			proxyAddr, _ := startRes.Decoded["listen_addr"].(string)
+			if proxyAddr == "" {
+				t.Fatalf("proxy_start: missing listen_addr in result: %s", startRes.Text)
+			}
+
+			// The capture listens on 127.0.0.1:PORT; address it as
+			// localhost:PORT so the proxy sends a DNS-name SNI (matching
+			// the reference build) rather than an IP literal (which
+			// suppresses the SNI extension entirely).
+			_, port, err := net.SplitHostPort(h.UpstreamCapture.Addr())
+			if err != nil {
+				t.Fatalf("split capture addr %q: %v", h.UpstreamCapture.Addr(), err)
+			}
+			const serverName = "localhost"
+			connectTarget := net.JoinHostPort(serverName, port)
+			path := "/fingerprint-" + tc.name
+			url := "https://" + connectTarget + path
+
+			// Drive one h2 request through the proxy.
+			client := fpH2ClientThroughProxy(proxyAddr, connectTarget, serverName)
+			resp, err := client.Get(url)
+			if err != nil {
+				snap := h.UpstreamCapture.Snapshot()
+				t.Fatalf("h2-over-CONNECT GET failed: %v (upstream ALPN observed=%q)", err, snap.ALPN)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != gohttp.StatusOK {
+				t.Errorf("status = %d, want 200", resp.StatusCode)
+			}
+			if !strings.Contains(string(body), "fingerprint-coherence-ok") {
+				t.Errorf("body = %q, want contains %q", string(body), "fingerprint-coherence-ok")
+			}
+
+			captured := h.UpstreamCapture.WaitH2(10 * time.Second)
+			snap := h.UpstreamCapture.Snapshot()
+
+			// ALPN guard (design review U3): the capture advertises h2
+			// ONLY; if the upstream leg did not negotiate h2 the H2
+			// assertions would have nothing to check, so fail loudly
+			// rather than silently skip.
+			if snap.ALPN != "h2" {
+				t.Fatalf("upstream leg ALPN = %q, want %q — the proxy did not offer/negotiate h2 upstream",
+					snap.ALPN, "h2")
+			}
+			if !captured {
+				t.Fatalf("did not capture full H2 shape within deadline: settings=%v window=%d pseudo=%v",
+					snap.Settings, snap.ConnWindowIncrement, snap.PseudoOrder)
+			}
+
+			assertTLSCoherence(t, tc.name, tc.helloID, serverName, snap.ClientHelloRecord)
+			assertH2Coherence(t, tc.wantH2, snap)
+			assertRecording(t, h, path)
+		})
+	}
+}
+
+// assertTLSCoherence checks the proxy→upstream ClientHello fingerprint.
+//
+// For a browser profile: JA4 must equal the uTLS reference exactly, and the
+// GREASE-stripped cipher set must match (order-independent — the structural
+// stand-in for JA3, which is flaky under uTLS extension shuffle). For "none"
+// (helloID nil): the ClientHello must be a standard crypto/tls hello — no
+// GREASE ciphers, and a JA4 distinct from both browser references.
+func assertTLSCoherence(t *testing.T, profile string, helloID *utls.ClientHelloID, serverName string, observed []byte) {
+	t.Helper()
+	if len(observed) == 0 {
+		t.Fatal("no ClientHello record captured")
+	}
+	obsJA3, obsJA4 := tlsfingerprint.Compute(observed)
+	if obsJA3 == "" || obsJA4 == "" {
+		t.Fatalf("observed ClientHello produced empty fingerprints: ja3=%q ja4=%q", obsJA3, obsJA4)
+	}
+
+	if helloID != nil {
+		refRecord := fpReferenceHello(t, *helloID, serverName, fpDataPlaneALPN)
+		_, refJA4 := tlsfingerprint.Compute(refRecord)
+		if refJA4 == "" {
+			t.Fatal("reference ClientHello produced empty JA4")
+		}
+		// JA4: exact (sorted ciphers + sorted extensions + metadata →
+		// shuffle- and GREASE-immune).
+		if obsJA4 != refJA4 {
+			t.Errorf("%s JA4 mismatch:\n observed = %q\n reference= %q", profile, obsJA4, refJA4)
+		}
+		// JA3 structural: cipher-set membership, order-independent.
+		obsCiphers := fpCipherSet(observed)
+		refCiphers := fpCipherSet(refRecord)
+		if !fpUint16SliceEqual(obsCiphers, refCiphers) {
+			t.Errorf("%s cipher set mismatch (structural JA3):\n observed = %v\n reference= %v",
+				profile, obsCiphers, refCiphers)
+		}
+		return
+	}
+
+	// "none": standard crypto/tls. Assert it is NOT a browser fingerprint.
+	_, ffJA4 := tlsfingerprint.Compute(fpReferenceHello(t, utls.HelloFirefox_Auto, serverName, fpDataPlaneALPN))
+	_, chJA4 := tlsfingerprint.Compute(fpReferenceHello(t, utls.HelloChrome_Auto, serverName, fpDataPlaneALPN))
+	if obsJA4 == ffJA4 {
+		t.Errorf("none JA4 == firefox reference JA4 (%q); tls_fingerprint=none must NOT dial a browser profile", obsJA4)
+	}
+	if obsJA4 == chJA4 {
+		t.Errorf("none JA4 == chrome reference JA4 (%q); tls_fingerprint=none must NOT dial a browser profile", obsJA4)
+	}
+	// Standard crypto/tls never emits GREASE (RFC 8701) — the "not a
+	// browser" signal.
+	if greased := fpGREASECiphers(observed); len(greased) > 0 {
+		t.Errorf("none ClientHello contains GREASE ciphers %v; standard crypto/tls must not emit GREASE", greased)
+	}
+}
+
+// assertH2Coherence checks the proxy's upstream HTTP/2 send-shape against the
+// expected profile goldens.
+func assertH2Coherence(t *testing.T, want fpH2Shape, snap mcptest.CaptureResult) {
+	t.Helper()
+	fpAssertSettingsEqual(t, snap.Settings, want.settings)
+	if snap.ConnWindowIncrement != want.connWindow {
+		t.Errorf("conn WINDOW_UPDATE increment = %d, want %d", snap.ConnWindowIncrement, want.connWindow)
+	}
+	if !fpStringSliceEqual(snap.PseudoOrder, want.pseudo) {
+		t.Errorf("pseudo-header order = %v, want %v", snap.PseudoOrder, want.pseudo)
+	}
+}
+
+// assertRecording verifies the Subsystem Checklist recording outcomes: the
+// flow records with Protocol=http, Scheme=https, State=complete, and a
+// non-empty raw_request (env.Raw preserved end-to-end through the MCP
+// boundary — the L4-capable principle).
+func assertRecording(t *testing.T, h *mcptest.Harness, pathSubstring string) {
+	t.Helper()
+	flow := fpWaitForFlow(t, h, pathSubstring, 5*time.Second)
+	if flow.Protocol != "http" {
+		t.Errorf("flow.protocol = %q, want %q", flow.Protocol, "http")
+	}
+	if flow.Scheme != "https" {
+		t.Errorf("flow.scheme = %q, want %q", flow.Scheme, "https")
+	}
+	if flow.State != "complete" {
+		t.Errorf("flow.state = %q, want %q", flow.State, "complete")
+	}
+	fpAssertRawRequestNonEmpty(t, h, flow.ID)
+}
+
+// ---------------------------------------------------------------------------
+// TLS reference + fingerprint helpers
+// ---------------------------------------------------------------------------
+
+// fpReferenceHello builds a uTLS ClientHello for helloID with its ALPN
+// extension overridden to alpn, mirroring exactly what the proxy's uTLS
+// transport does (BuildHandshakeState → replace ALPNExtension →
+// MarshalClientHello). It returns the full TLS record (5-byte header
+// prepended) ready for tlsfingerprint.Compute.
+func fpReferenceHello(t *testing.T, helloID utls.ClientHelloID, serverName string, alpn []string) []byte {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+
+	u := utls.UClient(c1, &utls.Config{ServerName: serverName, MinVersion: tls.VersionTLS12}, helloID)
+	if err := u.BuildHandshakeState(); err != nil {
+		t.Fatalf("uTLS BuildHandshakeState: %v", err)
+	}
+	for _, ext := range u.Extensions {
+		if a, ok := ext.(*utls.ALPNExtension); ok {
+			a.AlpnProtocols = append([]string(nil), alpn...)
+			break
+		}
+	}
+	if err := u.MarshalClientHello(); err != nil {
+		t.Fatalf("uTLS MarshalClientHello: %v", err)
+	}
+	raw := u.HandshakeState.Hello.Raw
+	if len(raw) == 0 {
+		t.Fatal("empty reference ClientHello raw")
+	}
+	rec := []byte{0x16, 0x03, 0x01, byte(len(raw) >> 8), byte(len(raw))}
+	return append(rec, raw...)
+}
+
+// fpCipherSet extracts the GREASE-stripped, ascending-sorted cipher suite
+// list from a raw ClientHello record. Fail-soft: returns nil on any
+// truncation.
+func fpCipherSet(record []byte) []uint16 {
+	// record header(5) + handshake header(4) + client_version(2) +
+	// random(32) = 43, then session_id (1-byte len + id), then
+	// cipher_suites (2-byte len + list).
+	const fixed = 5 + 4 + 2 + 32
+	if len(record) < fixed+1 {
+		return nil
+	}
+	idx := fixed
+	sidLen := int(record[idx])
+	idx++
+	idx += sidLen
+	if idx+2 > len(record) {
+		return nil
+	}
+	clen := int(record[idx])<<8 | int(record[idx+1])
+	idx += 2
+	if clen%2 != 0 || idx+clen > len(record) {
+		return nil
+	}
+	var out []uint16
+	for i := 0; i < clen; i += 2 {
+		c := uint16(record[idx+i])<<8 | uint16(record[idx+i+1])
+		if fpIsGREASE(c) {
+			continue
+		}
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// fpGREASECiphers returns the GREASE cipher values present in a raw
+// ClientHello record (for the "none" not-a-browser assertion).
+func fpGREASECiphers(record []byte) []uint16 {
+	const fixed = 5 + 4 + 2 + 32
+	if len(record) < fixed+1 {
+		return nil
+	}
+	idx := fixed
+	sidLen := int(record[idx])
+	idx++
+	idx += sidLen
+	if idx+2 > len(record) {
+		return nil
+	}
+	clen := int(record[idx])<<8 | int(record[idx+1])
+	idx += 2
+	if clen%2 != 0 || idx+clen > len(record) {
+		return nil
+	}
+	var out []uint16
+	for i := 0; i < clen; i += 2 {
+		c := uint16(record[idx+i])<<8 | uint16(record[idx+i+1])
+		if fpIsGREASE(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// fpIsGREASE reports whether v is an RFC 8701 GREASE value (0x?A?A with equal
+// bytes).
+func fpIsGREASE(v uint16) bool {
+	hi := byte(v >> 8)
+	lo := byte(v)
+	return hi == lo && lo&0x0f == 0x0a
+}
+
+// ---------------------------------------------------------------------------
+// Data-plane client (CONNECT tunnel → TLS(h2) → HTTP/2)
+// ---------------------------------------------------------------------------
+
+// fpH2ClientThroughProxy builds an http.Client that tunnels an HTTP/2
+// request through the proxy: CONNECT to connectTarget, then a TLS handshake
+// (ALPN h2 first) so the proxy MITMs the leg and negotiates h2 with the
+// capture upstream. InsecureSkipVerify accepts the proxy's ephemeral-CA MITM
+// leaf.
+func fpH2ClientThroughProxy(proxyAddr, connectTarget, serverName string) *gohttp.Client {
+	tr := &http2.Transport{
+		DialTLS: func(_, _ string, _ *tls.Config) (net.Conn, error) {
+			raw, err := fpDialCONNECTTunnel(proxyAddr, connectTarget)
+			if err != nil {
+				return nil, err
+			}
+			tconn := tls.Client(raw, &tls.Config{
+				ServerName:         serverName,
+				NextProtos:         fpDataPlaneALPN,
+				InsecureSkipVerify: true, //nolint:gosec // test data-plane client trusts the proxy MITM leaf
+			})
+			if err := tconn.Handshake(); err != nil {
+				_ = raw.Close()
+				return nil, fmt.Errorf("data-plane TLS handshake: %w", err)
+			}
+			if got := tconn.ConnectionState().NegotiatedProtocol; got != "h2" {
+				_ = tconn.Close()
+				return nil, fmt.Errorf("client-proxy leg negotiated ALPN %q, want h2", got)
+			}
+			return tconn, nil
+		},
+	}
+	return &gohttp.Client{Transport: tr, Timeout: 30 * time.Second}
+}
+
+// fpDialCONNECTTunnel opens a CONNECT tunnel to proxyAddr for target and
+// returns the post-200 raw connection. Uniquely named to avoid colliding
+// with connect_modes_smoke's dialCONNECTTunnel (both compile into the same
+// package under -tags e2e).
+func fpDialCONNECTTunnel(proxyAddr, target string) (net.Conn, error) {
+	c, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	if _, err := c.Write([]byte(req)); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	br := bufio.NewReader(c)
+	line, err := br.ReadString('\n')
+	if err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	if !strings.Contains(line, "200") {
+		_ = c.Close()
+		return nil, fmt.Errorf("CONNECT failed: %s", line)
+	}
+	for {
+		l, err := br.ReadString('\n')
+		if err != nil {
+			_ = c.Close()
+			return nil, err
+		}
+		if l == "\r\n" || l == "\n" {
+			break
+		}
+	}
+	if br.Buffered() > 0 {
+		_ = c.Close()
+		return nil, fmt.Errorf("unexpected buffered bytes after CONNECT response")
+	}
+	return c, nil
+}
+
+// ---------------------------------------------------------------------------
+// Recording query helpers
+// ---------------------------------------------------------------------------
+
+// fpFlowEntry is the subset of query("flows") we read. Uniquely named to
+// avoid colliding with connect_modes_smoke's connectModeFlow.
+type fpFlowEntry struct {
+	ID       string `json:"id"`
+	Protocol string `json:"protocol"`
+	Scheme   string `json:"scheme"`
+	State    string `json:"state"`
+	URL      string `json:"url"`
+}
+
+// fpWaitForFlow polls query("flows") until a completed flow whose URL
+// contains pathSubstring appears, or the timeout elapses.
+func fpWaitForFlow(t *testing.T, h *mcptest.Harness, pathSubstring string, timeout time.Duration) fpFlowEntry {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		res := h.MustOK(t, "query", map[string]any{"resource": "flows"})
+		var parsed struct {
+			Flows []fpFlowEntry `json:"flows"`
+		}
+		if err := json.Unmarshal([]byte(res.Text), &parsed); err != nil {
+			t.Fatalf("decode query(flows): %v (text=%q)", err, res.Text)
+		}
+		for _, f := range parsed.Flows {
+			if strings.Contains(f.URL, pathSubstring) && f.State == "complete" {
+				return f
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no completed flow with URL containing %q within %v; flows=%+v",
+				pathSubstring, timeout, parsed.Flows)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+}
+
+// fpAssertRawRequestNonEmpty asserts query("flow", id) returns a non-empty,
+// base64-decodable raw_request — proof env.Raw survived to the MCP boundary
+// unmodified (L4-capable principle; fingerprinting must not touch env.Raw).
+func fpAssertRawRequestNonEmpty(t *testing.T, h *mcptest.Harness, flowID string) {
+	t.Helper()
+	res := h.MustOK(t, "query", map[string]any{"resource": "flow", "id": flowID})
+	rawB64, _ := res.Decoded["raw_request"].(string)
+	if rawB64 == "" {
+		t.Errorf("flow %s raw_request is empty (L4-capable principle violated); response=%s", flowID, res.Text)
+		return
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rawB64)
+	if err != nil {
+		t.Errorf("flow %s raw_request is not valid base64: %v", flowID, err)
+		return
+	}
+	if len(decoded) == 0 {
+		t.Errorf("flow %s raw_request decoded to zero bytes (L4-capable principle violated)", flowID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Small assertion helpers
+// ---------------------------------------------------------------------------
+
+func fpAssertSettingsEqual(t *testing.T, got, want []frame.Setting) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("SETTINGS length = %d, want %d\n got=%+v\nwant=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].ID != want[i].ID || got[i].Value != want[i].Value {
+			t.Fatalf("SETTINGS[%d] = {ID:%d Value:%d}, want {ID:%d Value:%d}\n got=%+v\nwant=%+v",
+				i, got[i].ID, got[i].Value, want[i].ID, want[i].Value, got, want)
+		}
+	}
+}
+
+func fpStringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func fpUint16SliceEqual(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcptest/harness.go
+++ b/internal/mcptest/harness.go
@@ -180,6 +180,14 @@ type Harness struct {
 	// durable assertion that pipeline.SafetyStep enforced its WS arm.
 	WSObservedHits *WSHitCounter
 
+	// UpstreamCapture is the wire-observing upstream populated by the
+	// "capture" UpstreamProto. nil for other protocols. It records the
+	// raw proxy→upstream ClientHello bytes and the proxy's HTTP/2
+	// send-shape (SETTINGS / conn WINDOW_UPDATE / pseudo-header order) so
+	// USK-1011 can assert the configured tls_fingerprint profile produced
+	// a coherent Firefox (or Chrome / standard) fingerprint on the wire.
+	UpstreamCapture *UpstreamCapture
+
 	// Cleanup tears down the harness in this order: client session ->
 	// upstream test server -> MCP server (via context cancel + wait).
 	// Idempotent: calling more than once is a no-op. t.Cleanup is also
@@ -218,7 +226,7 @@ func StartHarness(t *testing.T, opts HarnessOptions) *Harness {
 
 	args := buildRunArgs(t, opts, token)
 	mtlsDir := t.TempDir()
-	upstream, mtls, fpObserver, grpcHits, grpcWebHits, wsHits, err := buildUpstream(opts, mtlsDir)
+	upstream, mtls, fpObserver, grpcHits, grpcWebHits, wsHits, capture, err := buildUpstream(opts, mtlsDir)
 	if err != nil {
 		t.Fatalf("mcptest: build upstream: %v", err)
 	}
@@ -259,6 +267,7 @@ func StartHarness(t *testing.T, opts HarnessOptions) *Harness {
 		GRPCObservedHits:    grpcHits,
 		GRPCWebObservedHits: grpcWebHits,
 		WSObservedHits:      wsHits,
+		UpstreamCapture:     capture,
 		Cleanup:             cleanup,
 	}
 
@@ -318,7 +327,7 @@ func (h *Harness) ExpectError(t *testing.T, name string, args any, errSubstring 
 func validateOptions(t *testing.T, opts HarnessOptions) {
 	t.Helper()
 	switch opts.UpstreamProto {
-	case "", "http/1.1", "grpc", "grpc-web", "ws":
+	case "", "http/1.1", "grpc", "grpc-web", "ws", "capture":
 		// supported
 	case "h2", "h2c":
 		t.Fatalf("mcptest: UpstreamProto=%q not yet implemented (deferred to USK-726)", opts.UpstreamProto)
@@ -387,7 +396,7 @@ func writeConfigFile(path, content string) error {
 }
 
 // buildUpstream constructs the optional upstream test server.
-// Returns (nil, nil, nil, nil, nil, nil) when no upstream is requested.
+// Returns all-nil (with a nil error) when no upstream is requested.
 // When EnableMTLS is set, the returned server is configured with
 // tls.RequireAndVerifyClientCert plus a ClientCAs pool seeded from a
 // freshly-generated test CA, and the corresponding client material is
@@ -417,38 +426,57 @@ func writeConfigFile(path, content string) error {
 //     received. The sixth return value is a WS hit counter incremented
 //     inside the WS serve loop so SafetyFilter tests can assert blocked
 //     frames never reached the upstream. mTLS not supported.
+//   - "capture": TLS (NextProtos=h2 only) upstream that peeks the raw
+//     proxy→upstream ClientHello and parses the proxy's HTTP/2 send-shape.
+//     The seventh return value is the *UpstreamCapture handle USK-1011
+//     asserts fingerprint coherence against. mTLS not supported.
 //
 // validateOptions has already rejected unrecognised variants by the
 // time this is called.
-func buildUpstream(opts HarnessOptions, mtlsDir string) (*httptest.Server, *MTLSMaterial, *FingerprintObserver, *GRPCHitCounter, *GRPCWebHitCounter, *WSHitCounter, error) {
+func buildUpstream(opts HarnessOptions, mtlsDir string) (*httptest.Server, *MTLSMaterial, *FingerprintObserver, *GRPCHitCounter, *GRPCWebHitCounter, *WSHitCounter, *UpstreamCapture, error) {
 	switch opts.UpstreamProto {
 	case "":
-		return nil, nil, nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil, nil, nil
 	case "grpc":
 		srv, fpObs, hits, err := buildGRPCUpstream()
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("build grpc upstream: %w", err)
+			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("build grpc upstream: %w", err)
 		}
-		return srv, nil, fpObs, hits, nil, nil, nil
+		return srv, nil, fpObs, hits, nil, nil, nil, nil
 	case "grpc-web":
 		srv, fpObs, hits, err := buildGRPCWebUpstream()
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("build grpc-web upstream: %w", err)
+			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("build grpc-web upstream: %w", err)
 		}
-		return srv, nil, fpObs, nil, hits, nil, nil
+		return srv, nil, fpObs, nil, hits, nil, nil, nil
 	case "ws":
 		srv, fpObs, hits, err := buildWSUpstream()
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("build ws upstream: %w", err)
+			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("build ws upstream: %w", err)
 		}
-		return srv, nil, fpObs, nil, nil, hits, nil
+		return srv, nil, fpObs, nil, nil, hits, nil, nil
+	case "capture":
+		srv, capture, err := buildCaptureUpstream()
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("build capture upstream: %w", err)
+		}
+		return srv, nil, nil, nil, nil, nil, capture, nil
 	case "http/1.1":
-		// fall through to the HTTP/1.1 implementation below
+		srv, mtls, fpObs, err := buildHTTP1Upstream(opts, mtlsDir)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, err
+		}
+		return srv, mtls, fpObs, nil, nil, nil, nil, nil
 	default:
 		// Should be unreachable: validateOptions already filtered.
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("unsupported UpstreamProto: %q", opts.UpstreamProto)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("unsupported UpstreamProto: %q", opts.UpstreamProto)
 	}
+}
 
+// buildHTTP1Upstream stands up the HTTP/1.1 echo upstream, optionally with
+// mTLS (RequireAndVerifyClientCert seeded from a freshly-generated test CA).
+// Split out of buildUpstream so the top-level dispatch stays flat.
+func buildHTTP1Upstream(opts HarnessOptions, mtlsDir string) (*httptest.Server, *MTLSMaterial, *FingerprintObserver, error) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
@@ -472,17 +500,17 @@ func buildUpstream(opts HarnessOptions, mtlsDir string) (*httptest.Server, *MTLS
 		tlsCfg, fpObs := installFingerprintObserver(nil)
 		srv.TLS = tlsCfg
 		srv.StartTLS()
-		return srv, nil, fpObs, nil, nil, nil, nil
+		return srv, nil, fpObs, nil
 	}
 
 	mtls, err := generateMTLSMaterial(mtlsDir)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("generate mTLS material: %w", err)
+		return nil, nil, nil, fmt.Errorf("generate mTLS material: %w", err)
 	}
 
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(mtls.CACertPEM) {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("append test CA to pool")
+		return nil, nil, nil, fmt.Errorf("append test CA to pool")
 	}
 
 	srv := httptest.NewUnstartedServer(handler)
@@ -493,7 +521,7 @@ func buildUpstream(opts HarnessOptions, mtlsDir string) (*httptest.Server, *MTLS
 	})
 	srv.TLS = tlsCfg
 	srv.StartTLS()
-	return srv, mtls, fpObs, nil, nil, nil, nil
+	return srv, mtls, fpObs, nil
 }
 
 // runMCPServer is the goroutine entry point for the boot path. It

--- a/internal/mcptest/upstream_capture.go
+++ b/internal/mcptest/upstream_capture.go
@@ -1,0 +1,489 @@
+package mcptest
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/frame"
+	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/hpack"
+)
+
+// h2ClientPreface is the fixed 24-byte HTTP/2 connection preface every h2
+// client sends before its first frame (RFC 9113 §3.4). Defined locally so
+// the capture upstream does not import the whole internal/layer/http2 Layer
+// package for a single constant.
+const h2ClientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+// captureConnDeadline bounds every read/write on a captured upstream
+// connection so a stalled proxy dial can never wedge the accept goroutine
+// or a per-connection handler past test teardown (Concurrency Checklist:
+// explicit termination for every goroutine).
+const captureConnDeadline = 10 * time.Second
+
+// UpstreamCapture is the wire-observing upstream stood up by
+// HarnessOptions.UpstreamProto == "capture". Unlike the GREASE-sniffing
+// FingerprintObserver (which only inspects crypto/tls's parsed
+// *tls.ClientHelloInfo), UpstreamCapture records the *raw* proxy→upstream
+// ClientHello record bytes plus the proxy's HTTP/2 send-shape (SETTINGS in
+// wire order, the stream-0 WINDOW_UPDATE increment, and the request
+// pseudo-header order). This is the artifact USK-1011 asserts Firefox
+// coherence against.
+//
+// Capture strategy (USK-1011 design decision #2/#3):
+//   - Peek-then-replay the initial TLS record(s) off the raw net.Conn so
+//     the exact ClientHello bytes are retained (tlsfingerprint.Compute needs
+//     raw bytes; GetConfigForClient only exposes a parsed struct), then hand
+//     a prefix-wrapped conn to tls.Server to finish the handshake.
+//   - After ALPN=h2, read the client preface and parse frames with
+//     internal/layer/http2/frame + hpack, capturing the first non-ACK
+//     SETTINGS, the first stream-0 WINDOW_UPDATE, and the first HEADERS
+//     block's pseudo-header order.
+//   - Send a minimal SETTINGS + HEADERS(:status 200) + DATA(end_stream)
+//     response so the proxy relays a complete response and the flow records
+//     State=complete.
+//
+// Concurrency: all captured fields are guarded by mu. The done channel is
+// closed exactly once (via doneOnce) when every H2 artifact has been
+// captured, so WaitH2 has a single-writer close owner. Close() stops the
+// accept goroutine, force-closes any in-flight connections, and joins every
+// goroutine.
+type UpstreamCapture struct {
+	ln     net.Listener
+	tlsCfg *tls.Config
+
+	mu            sync.Mutex
+	clientHello   []byte
+	alpn          string
+	settings      []frame.Setting
+	haveSettings  bool
+	connWindowInc uint32
+	haveWindow    bool
+	pseudoOrder   []string
+	havePseudo    bool
+
+	done     chan struct{}
+	doneOnce sync.Once
+
+	connMu    sync.Mutex
+	conns     []net.Conn
+	closed    bool
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+// CaptureResult is an atomic snapshot of everything UpstreamCapture has
+// observed at the moment Snapshot is called. Slice fields are deep copies so
+// the caller may read them without holding the capture's lock.
+type CaptureResult struct {
+	// ClientHelloRecord is the raw proxy→upstream TLS ClientHello record,
+	// including the 5-byte TLS record header — ready to hand to
+	// tlsfingerprint.Compute.
+	ClientHelloRecord []byte
+	// ALPN is the protocol the upstream TLS handshake negotiated. The
+	// capture upstream advertises only "h2", so anything else means the
+	// proxy did not offer h2 upstream.
+	ALPN string
+	// Settings is the proxy's first non-ACK SETTINGS frame params in wire
+	// order.
+	Settings []frame.Setting
+	// ConnWindowIncrement is the proxy's first stream-0 WINDOW_UPDATE
+	// increment (the connection-level window bump after the preface).
+	ConnWindowIncrement uint32
+	// PseudoOrder is the request pseudo-header order (":"-prefixed field
+	// names) from the proxy's first HEADERS block, in wire order.
+	PseudoOrder []string
+}
+
+// Addr returns the capture upstream's loopback listen address
+// (127.0.0.1:port). Tests derive the CONNECT target and TLS ServerName from
+// it.
+func (c *UpstreamCapture) Addr() string {
+	return c.ln.Addr().String()
+}
+
+// Snapshot returns an atomic copy of the captured artifacts.
+func (c *UpstreamCapture) Snapshot() CaptureResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	res := CaptureResult{
+		ALPN:                c.alpn,
+		ConnWindowIncrement: c.connWindowInc,
+	}
+	if c.clientHello != nil {
+		res.ClientHelloRecord = append([]byte(nil), c.clientHello...)
+	}
+	if c.settings != nil {
+		res.Settings = append([]frame.Setting(nil), c.settings...)
+	}
+	if c.pseudoOrder != nil {
+		res.PseudoOrder = append([]string(nil), c.pseudoOrder...)
+	}
+	return res
+}
+
+// WaitH2 blocks until every HTTP/2 artifact (ALPN=h2, SETTINGS, conn
+// WINDOW_UPDATE, and the request pseudo-header order) has been captured, or
+// the timeout elapses. It reports whether the full set was captured in time.
+func (c *UpstreamCapture) WaitH2(timeout time.Duration) bool {
+	select {
+	case <-c.done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// Close stops the accept loop, force-closes any in-flight connections, and
+// waits for every goroutine to exit. Idempotent.
+func (c *UpstreamCapture) Close() error {
+	c.closeOnce.Do(func() {
+		c.connMu.Lock()
+		c.closed = true
+		conns := c.conns
+		c.conns = nil
+		c.connMu.Unlock()
+
+		_ = c.ln.Close()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		c.wg.Wait()
+	})
+	return nil
+}
+
+// trackConn registers conn for force-close on teardown. It returns false if
+// the capture is already closing, in which case the caller must abandon the
+// connection immediately.
+func (c *UpstreamCapture) trackConn(conn net.Conn) bool {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	if c.closed {
+		return false
+	}
+	c.conns = append(c.conns, conn)
+	return true
+}
+
+// maybeSignalDone closes done once the full H2 artifact set is present. Must
+// be called with c.mu held.
+func (c *UpstreamCapture) maybeSignalDone() {
+	if c.alpn == "h2" && c.haveSettings && c.haveWindow && c.havePseudo {
+		c.doneOnce.Do(func() { close(c.done) })
+	}
+}
+
+// acceptLoop accepts connections until the listener is closed, handing each
+// to a per-connection handler goroutine.
+func (c *UpstreamCapture) acceptLoop() {
+	defer c.wg.Done()
+	for {
+		conn, err := c.ln.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		if !c.trackConn(conn) {
+			_ = conn.Close()
+			return
+		}
+		c.wg.Add(1)
+		go c.handleConn(conn)
+	}
+}
+
+// handleConn drives one upstream connection: peek+replay the ClientHello,
+// finish the TLS handshake, then (if h2) capture the proxy's H2 send-shape
+// and answer with a minimal response so the proxy's flow completes.
+func (c *UpstreamCapture) handleConn(raw net.Conn) {
+	defer c.wg.Done()
+	defer raw.Close()
+
+	_ = raw.SetDeadline(time.Now().Add(captureConnDeadline))
+
+	record, err := readFirstTLSRecord(raw)
+	if err != nil {
+		return
+	}
+
+	tlsConn := tls.Server(&prefixConn{Conn: raw, prefix: record}, c.tlsCfg)
+	if err := tlsConn.Handshake(); err != nil {
+		return
+	}
+	alpn := tlsConn.ConnectionState().NegotiatedProtocol
+
+	// Commit the ClientHello + ALPN immediately so a non-h2 negotiation is
+	// still observable (the test guards on ALPN and fails loudly rather
+	// than silently skipping the H2 assertions).
+	c.mu.Lock()
+	c.clientHello = record
+	c.alpn = alpn
+	c.mu.Unlock()
+
+	if alpn != "h2" {
+		return
+	}
+	c.serveH2(tlsConn)
+}
+
+// serveH2 reads the proxy's H2 preface + frames, captures the send-shape,
+// and writes a minimal response. It returns when the peer closes or a read
+// deadline fires.
+func (c *UpstreamCapture) serveH2(conn net.Conn) {
+	if err := readClientPreface(conn); err != nil {
+		return
+	}
+
+	rd := frame.NewReader(conn)
+	wr := frame.NewWriter(conn)
+
+	// The server preface SETTINGS must be the first frame we send. An empty
+	// SETTINGS frame is valid and keeps our advertised limits at the RFC
+	// defaults.
+	if err := wr.WriteSettings(nil); err != nil {
+		return
+	}
+
+	responded := false
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(captureConnDeadline))
+		f, err := rd.ReadFrame()
+		if err != nil {
+			return
+		}
+		if !c.handleFrame(f, rd, wr, &responded) {
+			return
+		}
+	}
+}
+
+// handleFrame captures the send-shape carried by one frame and, on the first
+// HEADERS, writes the minimal response. It returns false when the caller
+// should stop serving (a fatal frame error).
+func (c *UpstreamCapture) handleFrame(f *frame.Frame, rd *frame.Reader, wr *frame.Writer, responded *bool) bool {
+	switch f.Header.Type {
+	case frame.TypeSettings:
+		return c.handleSettings(f, rd, wr)
+	case frame.TypeWindowUpdate:
+		return c.handleWindowUpdate(f)
+	case frame.TypeHeaders:
+		return c.handleHeaders(f, wr, responded)
+	default:
+		return true
+	}
+}
+
+// handleSettings records the peer's first non-ACK SETTINGS, applies its
+// MAX_FRAME_SIZE to the reader, and ACKs it.
+func (c *UpstreamCapture) handleSettings(f *frame.Frame, rd *frame.Reader, wr *frame.Writer) bool {
+	if f.Header.Flags.Has(frame.FlagAck) {
+		return true
+	}
+	params, err := f.SettingsParams()
+	if err != nil {
+		return false
+	}
+	c.mu.Lock()
+	c.settings = params
+	c.haveSettings = true
+	c.maybeSignalDone()
+	c.mu.Unlock()
+	for _, s := range params {
+		if s.ID == frame.SettingMaxFrameSize {
+			_ = rd.SetMaxFrameSize(s.Value)
+		}
+	}
+	return wr.WriteSettingsAck() == nil
+}
+
+// handleWindowUpdate records the FIRST stream-0 WINDOW_UPDATE increment —
+// the connection-window bump the client sends right after its preface
+// SETTINGS. Later stream-0 updates (e.g. the proxy replenishing the window
+// after relaying our response body) must not clobber it.
+func (c *UpstreamCapture) handleWindowUpdate(f *frame.Frame) bool {
+	if f.Header.StreamID != 0 {
+		return true
+	}
+	inc, err := f.WindowUpdateIncrement()
+	if err != nil {
+		return false
+	}
+	c.mu.Lock()
+	if !c.haveWindow {
+		c.connWindowInc = inc
+		c.haveWindow = true
+		c.maybeSignalDone()
+	}
+	c.mu.Unlock()
+	return true
+}
+
+// handleHeaders records the first HEADERS block's pseudo-header order and
+// answers the request.
+func (c *UpstreamCapture) handleHeaders(f *frame.Frame, wr *frame.Writer, responded *bool) bool {
+	if *responded {
+		return true
+	}
+	order, ok := decodePseudoOrder(f)
+	if !ok {
+		return false
+	}
+	c.mu.Lock()
+	c.pseudoOrder = order
+	c.havePseudo = true
+	c.maybeSignalDone()
+	c.mu.Unlock()
+	if err := writeMinimalResponse(wr, f.Header.StreamID); err != nil {
+		return false
+	}
+	*responded = true
+	return true
+}
+
+// decodePseudoOrder HPACK-decodes a HEADERS frame's block and returns the
+// leading pseudo-header names (":"-prefixed) in wire order.
+func decodePseudoOrder(f *frame.Frame) ([]string, bool) {
+	block, err := f.HeaderBlockFragment()
+	if err != nil {
+		return nil, false
+	}
+	// A 65536-byte decoder table matches the Firefox encoder's larger table
+	// so a table-size update never trips the decoder.
+	dec := hpack.NewDecoder(65536)
+	fields, err := dec.Decode(block)
+	if err != nil {
+		return nil, false
+	}
+	var out []string
+	for _, hf := range fields {
+		if len(hf.Name) == 0 || hf.Name[0] != ':' {
+			break
+		}
+		out = append(out, hf.Name)
+	}
+	return out, true
+}
+
+// writeMinimalResponse answers streamID with :status 200 and a short
+// end-stream DATA frame so the proxy relays a complete response.
+func writeMinimalResponse(wr *frame.Writer, streamID uint32) error {
+	enc := hpack.NewEncoder(4096, false)
+	block := enc.Encode([]hpack.HeaderField{{Name: ":status", Value: "200"}})
+	if err := wr.WriteHeaders(streamID, false, true, block); err != nil {
+		return err
+	}
+	return wr.WriteData(streamID, true, []byte("fingerprint-coherence-ok"))
+}
+
+// readFirstTLSRecord reads exactly one TLS record (5-byte header + payload)
+// and returns the full record bytes. The proxy's ClientHello fits in the
+// first record for every profile under test, so this is the raw ClientHello
+// record tlsfingerprint.Compute consumes.
+func readFirstTLSRecord(r io.Reader) ([]byte, error) {
+	var hdr [5]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("read TLS record header: %w", err)
+	}
+	recLen := int(hdr[3])<<8 | int(hdr[4])
+	if recLen <= 0 || recLen > 1<<16 {
+		return nil, fmt.Errorf("implausible TLS record length %d", recLen)
+	}
+	rec := make([]byte, 5+recLen)
+	copy(rec, hdr[:])
+	if _, err := io.ReadFull(r, rec[5:]); err != nil {
+		return nil, fmt.Errorf("read TLS record body: %w", err)
+	}
+	return rec, nil
+}
+
+// readClientPreface consumes and validates the 24-byte HTTP/2 client
+// preface.
+func readClientPreface(r io.Reader) error {
+	buf := make([]byte, len(h2ClientPreface))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return fmt.Errorf("read h2 preface: %w", err)
+	}
+	if !bytes.Equal(buf, []byte(h2ClientPreface)) {
+		return fmt.Errorf("bad h2 preface: %q", buf)
+	}
+	return nil
+}
+
+// prefixConn is a net.Conn that first serves buffered prefix bytes (the
+// peeked TLS record) before reading from the underlying conn, so tls.Server
+// re-parses the original ClientHello from the wire bytes we retained.
+type prefixConn struct {
+	net.Conn
+	prefix []byte
+}
+
+func (c *prefixConn) Read(p []byte) (int, error) {
+	if len(c.prefix) > 0 {
+		n := copy(p, c.prefix)
+		c.prefix = c.prefix[n:]
+		return n, nil
+	}
+	return c.Conn.Read(p)
+}
+
+// buildCaptureUpstream stands up the wire-observing upstream and returns a
+// *httptest.Server shell (URL + Listener + Config, matching the gRPC
+// upstream pattern) alongside the *UpstreamCapture handle the test asserts
+// against. The listener advertises ALPN "h2" ONLY so the upstream leg
+// negotiates HTTP/2 (or fails the ALPN guard loudly).
+func buildCaptureUpstream() (*httptest.Server, *UpstreamCapture, error) {
+	leaf, err := newSelfSignedLeaf("localhost", "127.0.0.1")
+	if err != nil {
+		return nil, nil, fmt.Errorf("self-signed leaf: %w", err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{*leaf},
+		NextProtos:   []string{"h2"},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("listen: %w", err)
+	}
+
+	capture := &UpstreamCapture{
+		ln:     ln,
+		tlsCfg: tlsCfg,
+		done:   make(chan struct{}),
+	}
+	capture.wg.Add(1)
+	go capture.acceptLoop()
+
+	srv := &httptest.Server{
+		Listener: &captureListener{cap: capture},
+		Config:   &http.Server{},
+		URL:      "https://" + ln.Addr().String(),
+		TLS:      tlsCfg,
+	}
+	return srv, capture, nil
+}
+
+// captureListener adapts UpstreamCapture to the net.Listener the harness's
+// httptest.Server shell holds: the harness cleanup path calls
+// srv.Listener.Close, which we route to UpstreamCapture.Close for a clean,
+// goroutine-joining teardown. Accept is never called on this adapter (the
+// capture owns its own accept loop); it exists only to satisfy the
+// interface.
+type captureListener struct {
+	cap *UpstreamCapture
+}
+
+func (l *captureListener) Accept() (net.Conn, error) {
+	return nil, fmt.Errorf("captureListener.Accept: not used")
+}
+
+func (l *captureListener) Close() error { return l.cap.Close() }
+
+func (l *captureListener) Addr() net.Addr { return l.cap.ln.Addr() }


### PR DESCRIPTION
## Summary
M47 capstone e2e verification: a fingerprint-coherence harness proving that when a browser `tls_fingerprint` profile is selected, the fingerprint the **upstream observes coming from the proxy** is coherent on both axes — TLS ClientHello (JA4 + cipher set) AND HTTP/2 send-shape (SETTINGS / WINDOW_UPDATE / pseudo-header order).

- **New capturing upstream** (`internal/mcptest/upstream_capture.go`, `UpstreamProto:"capture"`): peek-then-replays the raw proxy→upstream ClientHello off the `net.Conn`, hand-parses the proxy's H2 frames via `internal/layer/http2/frame` + hpack, answers with a minimal `:status 200` end-stream response. Captured artifacts exposed via `Harness.UpstreamCapture`. Single-writer teardown (`sync.Once`), per-conn deadlines, `Close()` joins all goroutines.
- **Test** (`internal/mcptest/fingerprint_coherence_integration_test.go`, `//go:build e2e && !e2e_smoke`): drives a real h2 request through the proxy over a CONNECT tunnel; **fails loudly** if the upstream leg's ALPN != h2. Per profile: JA4 asserted **exact** vs a reference computed dynamically from the same uTLS profile the proxy uses; cipher set asserted **structurally** (GREASE-stripped, order-independent — JA3 exact-match avoided due to uTLS extension shuffle); H2 goldens asserted inline (firefox FF120 vs chrome baseline). Recording verified via MCP `query` (Protocol/Scheme/State=complete, non-empty `raw_request` = env.Raw preserved).

## Test plan
- [x] Runs and passes under `make test-e2e` / `-tags e2e` (3× deterministic)
- [x] Excluded from fast + smoke tiers (`-tags 'e2e e2e_smoke'` → no tests to run)
- [x] `make lint`, `make build`, `make test`, `make test-e2e-smoke` green
- [x] `firefox` and `chrome` sub-cases pass; `none` sub-case `t.Skip`-ped pending USK-1021 (the real bug it caught), ready to un-skip once fixed

Resolves USK-1011
Linear: https://linear.app/usk6666/issue/USK-1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
