### PR TITLE
fix(tls): resolve "none" fingerprint sentinel at the uTLS dial seam

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,19 +339,23 @@ func ResolveDBPath(value string) (string, error) {
 // Chrome parity remains available via explicit configuration.
 const DefaultTLSFingerprint = "firefox"
 
-// ResolveTLSFingerprint returns the effective upstream TLS ClientHello
-// fingerprint profile name, applying the precedence:
+// ResolveTLSFingerprint returns the fingerprint *identity* the proxy claims
+// for upstream connections, applying the precedence:
 //
 //  1. proxyCfg.TLSFingerprint (per-listener config / `-tls-fingerprint` flag)
 //  2. cfg.TLSFingerprint (top-level config; pass a nil cfg to skip this tier
 //     and preserve the live-dial path's proxyCfg-only contract)
 //  3. DefaultTLSFingerprint ("firefox")
 //
-// The opt-out sentinel "none" (case-insensitive) resolves to "" so the caller
-// dials with the standard crypto/tls stack (no uTLS spoofing). Any other value
-// passes through unchanged for downstream profile validation. This is the
-// single source of truth for the firefox default and the "none" escape hatch;
-// call it from every boot-time fingerprint resolution site (USK-1013).
+// The returned value is identity-preserving: the opt-out sentinel "none" is
+// returned verbatim rather than flattened to "", so the reporting surfaces
+// (query config / configure results) and the HTTP/2 send-shape selection can
+// distinguish "operator explicitly opted out" from "nothing configured".
+// Mapping the sentinel to the uTLS parrot name is the separate job of
+// UTLSProfileFor, which must be applied at the dial seam.
+//
+// This is the single source of truth for the firefox default (USK-1013);
+// call it from every boot-time fingerprint resolution site.
 func ResolveTLSFingerprint(cfg *Config, proxyCfg *ProxyConfig) string {
 	fingerprint := ""
 	if proxyCfg != nil && proxyCfg.TLSFingerprint != "" {
@@ -362,6 +366,22 @@ func ResolveTLSFingerprint(cfg *Config, proxyCfg *ProxyConfig) string {
 	if fingerprint == "" {
 		fingerprint = DefaultTLSFingerprint
 	}
+	return fingerprint
+}
+
+// UTLSProfileFor maps a fingerprint identity to the uTLS parrot profile name
+// the dial path should instantiate. The opt-out sentinel "none"
+// (case-insensitive, surrounding whitespace trimmed) maps to "", which every
+// dial seam reads as "use the standard crypto/tls stack, no uTLS spoofing".
+// Every other value — including "" itself — passes through unchanged so the
+// downstream profile lookup keeps its fail-hard-on-typo property: a
+// misspelled "firefx" must error loudly rather than silently degrade to a
+// Go-native ClientHello (USK-1021).
+//
+// This is the single source of truth for the "none" escape hatch. Apply it at
+// the uTLS-profile consumption seam only; the identity carried through config,
+// runtime overrides, and reporting stays unresolved.
+func UTLSProfileFor(fingerprint string) string {
 	if strings.EqualFold(strings.TrimSpace(fingerprint), "none") {
 		return ""
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -349,10 +349,12 @@ const DefaultTLSFingerprint = "firefox"
 //
 // The returned value is identity-preserving: the opt-out sentinel "none" is
 // returned verbatim rather than flattened to "", so the reporting surfaces
-// (query config / configure results) and the HTTP/2 send-shape selection can
-// distinguish "operator explicitly opted out" from "nothing configured".
-// Mapping the sentinel to the uTLS parrot name is the separate job of
-// UTLSProfileFor, which must be applied at the dial seam.
+// (query config / configure results) can distinguish "operator explicitly
+// opted out" from "nothing configured". The HTTP/2 send-shape selection is
+// only sentinel-tolerant — it accepts the raw identity but maps both "none"
+// and "" to the default shape. Mapping the sentinel to the uTLS parrot name
+// is the separate job of UTLSProfileFor, which must be applied at the dial
+// seam.
 //
 // This is the single source of truth for the firefox default (USK-1013);
 // call it from every boot-time fingerprint resolution site.

--- a/internal/config/config_tls_test.go
+++ b/internal/config/config_tls_test.go
@@ -55,8 +55,12 @@ func TestLoadFile_TLSFingerprint(t *testing.T) {
 }
 
 // TestResolveTLSFingerprint covers the boot-time fingerprint resolution
-// precedence (proxyCfg > cfg > firefox default) and the "none" opt-out
-// sentinel that maps to "" (standard crypto/tls) — USK-1013.
+// precedence (proxyCfg > cfg > firefox default) — USK-1013.
+//
+// USK-1021: the resolver is identity-preserving. The "none" opt-out sentinel
+// is returned verbatim so reporting can distinguish "explicitly opted out"
+// from "nothing configured"; mapping it to the uTLS parrot name ("") is
+// UTLSProfileFor's job and happens at the dial seam.
 func TestResolveTLSFingerprint(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -95,22 +99,22 @@ func TestResolveTLSFingerprint(t *testing.T) {
 			want:     "firefox",
 		},
 		{
-			name:     "explicit none maps to empty (standard TLS)",
+			name:     "explicit none is preserved as an identity",
 			cfg:      &Config{},
 			proxyCfg: &ProxyConfig{TLSFingerprint: "none"},
-			want:     "",
+			want:     "none",
 		},
 		{
-			name:     "none is case-insensitive and trimmed",
+			name:     "none spelling is preserved verbatim (no fold/trim)",
 			cfg:      &Config{},
 			proxyCfg: &ProxyConfig{TLSFingerprint: "  NONE  "},
-			want:     "",
+			want:     "  NONE  ",
 		},
 		{
-			name:     "top-level none also opts out",
+			name:     "top-level none is preserved as an identity",
 			cfg:      &Config{TLSFingerprint: "none"},
 			proxyCfg: &ProxyConfig{},
-			want:     "",
+			want:     "none",
 		},
 		{
 			name:     "explicit firefox passes through",
@@ -123,6 +127,36 @@ func TestResolveTLSFingerprint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ResolveTLSFingerprint(tt.cfg, tt.proxyCfg); got != tt.want {
 				t.Errorf("ResolveTLSFingerprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUTLSProfileFor covers the "none" opt-out sentinel mapping applied at
+// the uTLS dial seam (USK-1021). Only "none" (case-insensitive, trimmed)
+// collapses to ""; every other value — including a typo — passes through
+// unchanged so the tlslayer profile lookup keeps its fail-hard property
+// rather than silently degrading to a Go-native ClientHello.
+func TestUTLSProfileFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		want        string
+	}{
+		{"none opts out", "none", ""},
+		{"none is case-insensitive", "NONE", ""},
+		{"none is trimmed", "  none  ", ""},
+		{"none is trimmed and folded", "  NoNe  ", ""},
+		{"firefox passes through", "firefox", "firefox"},
+		{"chrome passes through", "chrome", "chrome"},
+		{"empty passes through", "", ""},
+		{"unknown profile passes through for downstream validation", "firefx", "firefx"},
+		{"substring of none is not the sentinel", "nonexistent", "nonexistent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UTLSProfileFor(tt.fingerprint); got != tt.want {
+				t.Errorf("UTLSProfileFor(%q) = %q, want %q", tt.fingerprint, got, tt.want)
 			}
 		})
 	}

--- a/internal/connector/alpn_routing.go
+++ b/internal/connector/alpn_routing.go
@@ -217,14 +217,17 @@ func canonicalRedialALPNOffer(clientALPN string) []string {
 
 // ALPNCacheKeyFromConfig constructs an ALPNCacheKey for the given target
 // using the TLS configuration from BuildConfig. The fingerprint
-// component reads via EffectiveTLSFingerprint so a runtime
+// component reads via EffectiveUTLSProfile so a runtime
 // proxy_start / configure fingerprint switch produces a distinct cache
 // key — ALPN learned under the previous fingerprint is not reused for
-// dials that should now use a different uTLS profile (USK-809).
+// dials that should now use a different uTLS profile (USK-809). The
+// resolved (dial-identity) form is used so a boot-time "none" and a
+// runtime "none" share one keyspace, matching the handshakes they
+// actually key (USK-1021).
 func ALPNCacheKeyFromConfig(target string, cfg *BuildConfig) ALPNCacheKey {
 	key := ALPNCacheKey{
 		HostPort:    target,
-		Fingerprint: cfg.EffectiveTLSFingerprint(),
+		Fingerprint: cfg.EffectiveUTLSProfile(),
 	}
 	if cfg.ClientCert != nil {
 		key.ClientCertHash = hashCert(cfg.ClientCert)

--- a/internal/connector/h2_pool.go
+++ b/internal/connector/h2_pool.go
@@ -71,13 +71,16 @@ func poolKeyForH2(ctx context.Context, target string, cfg *BuildConfig, hostTLS 
 
 	writeField(&buf, "ca", caHash)
 
-	// Use EffectiveTLSFingerprint so a runtime proxy_start / configure
+	// Use EffectiveUTLSProfile so a runtime proxy_start / configure
 	// fingerprint switch produces a distinct pool key — pooled h2 Layers
 	// established under the previous fingerprint must not be reused for
-	// dials that should now use a different uTLS profile (USK-809).
+	// dials that should now use a different uTLS profile (USK-809). The
+	// resolved (dial-identity) form is used so a boot-time "none" and a
+	// runtime "none" share one keyspace, matching the connections they
+	// actually key (USK-1021).
 	profile := ""
 	if cfg != nil {
-		profile = cfg.EffectiveTLSFingerprint()
+		profile = cfg.EffectiveUTLSProfile()
 	}
 	writeField(&buf, "utls", profile)
 

--- a/internal/connector/stack_builder.go
+++ b/internal/connector/stack_builder.go
@@ -564,6 +564,29 @@ func (c *BuildConfig) EffectiveTLSFingerprint() string {
 	return c.TLSFingerprint
 }
 
+// EffectiveUTLSProfile returns the uTLS parrot profile the next upstream
+// dial should instantiate, derived from EffectiveTLSFingerprint by
+// resolving the "none" opt-out sentinel to "" (standard crypto/tls, no
+// uTLS spoofing) — see config.UTLSProfileFor.
+//
+// The two accessors carry different meanings and are NOT interchangeable
+// (USK-1021):
+//
+//   - EffectiveTLSFingerprint is the fingerprint *identity* the proxy
+//     claims. It feeds the reporting surfaces (query config / configure)
+//     and the HTTP/2 send-shape selection, both of which are already
+//     sentinel-aware.
+//   - EffectiveUTLSProfile is the *dial* value. Use it wherever a profile
+//     name reaches tlslayer (DialRawOpts.UTLSProfile) or keys a cache
+//     whose entries are discriminated by the actual dial identity.
+//
+// Passing the raw identity to the dial path is the USK-1021 bug: tlslayer
+// fail-hards on any profile name outside its parrot table, so a live
+// "none" override aborted every MITM upstream dial.
+func (c *BuildConfig) EffectiveUTLSProfile() string {
+	return config.UTLSProfileFor(c.EffectiveTLSFingerprint())
+}
+
 // SetTLSFingerprint installs a runtime override for the uTLS browser
 // fingerprint profile. Subsequent calls to EffectiveTLSFingerprint
 // return profile (or fall back to the static TLSFingerprint field when
@@ -1586,7 +1609,7 @@ func dialUpstreamWithALPN(
 	conn, snap, err := DialUpstreamRaw(ctx, target, DialRawOpts{
 		TLSConfig:          upstreamTLSCfg,
 		InsecureSkipVerify: insecureSkip,
-		UTLSProfile:        cfg.EffectiveTLSFingerprint(),
+		UTLSProfile:        cfg.EffectiveUTLSProfile(),
 		ClientCert:         clientCert,
 		OfferALPN:          offerALPN,
 		UpstreamProxy:      upstreamProxy,
@@ -1984,7 +2007,7 @@ func buildRawPassthroughStack(
 	upstreamConn, upstreamSnap, err := DialUpstreamRaw(ctx, target, DialRawOpts{
 		TLSConfig:          upstreamTLSCfg,
 		InsecureSkipVerify: insecureSkip,
-		UTLSProfile:        cfg.EffectiveTLSFingerprint(),
+		UTLSProfile:        cfg.EffectiveUTLSProfile(),
 		ClientCert:         clientCert,
 		OfferALPN:          []string{"http/1.1"},
 		UpstreamProxy:      upstreamProxy,

--- a/internal/connector/stack_builder.go
+++ b/internal/connector/stack_builder.go
@@ -49,12 +49,14 @@ type BuildConfig struct {
 	// InsecureSkipVerify disables TLS certificate verification on upstream.
 	InsecureSkipVerify bool
 
-	// TLSFingerprint selects the uTLS browser fingerprint profile for upstream.
-	// This is the static (init-time) value; runtime updates from
-	// proxy_start / configure flow through SetTLSFingerprint and
-	// EffectiveTLSFingerprint. Live data-path readers MUST call
-	// EffectiveTLSFingerprint() — direct field reads observe only the
-	// boot-time value (USK-809).
+	// TLSFingerprint is the upstream TLS fingerprint *identity* the proxy
+	// claims, including the "none" opt-out sentinel. This is the static
+	// (init-time) value; runtime updates from proxy_start / configure flow
+	// through SetTLSFingerprint and EffectiveTLSFingerprint. Readers MUST
+	// NOT read this field directly — it observes only the boot-time value
+	// (USK-809). Call EffectiveTLSFingerprint() for the claimed identity
+	// (reporting surfaces, HTTP/2 send-shape selection) and
+	// EffectiveUTLSProfile() for the value handed to a dial (USK-1021).
 	TLSFingerprint string
 
 	// tlsFingerprintDynamic stores the runtime-mutable TLS fingerprint
@@ -546,14 +548,20 @@ func (c *BuildConfig) EffectiveUpstreamProxyForCtxErr(ctx context.Context) (*url
 	return c.EffectiveUpstreamProxy(), nil
 }
 
-// EffectiveTLSFingerprint returns the uTLS browser fingerprint profile
-// the live data path should use for the next upstream dial. Runtime
-// updates installed via SetTLSFingerprint take precedence over the
-// static TLSFingerprint field set at boot. Returns the empty string when
-// neither is configured (the dial path then falls back to standard TLS).
-// This is the canonical accessor for live dial-path code (USK-809);
-// callers MUST NOT read the TLSFingerprint field directly because it
-// observes only the boot-time value.
+// EffectiveTLSFingerprint returns the TLS fingerprint *identity* the
+// proxy currently claims for upstream connections — the "none" opt-out
+// sentinel included, returned verbatim. Runtime updates installed via
+// SetTLSFingerprint take precedence over the static TLSFingerprint field
+// set at boot. Returns the empty string when neither is configured.
+//
+// This is the canonical accessor for reporting surfaces (query config /
+// configure) and for the HTTP/2 send-shape selection, both of which are
+// sentinel-aware; callers MUST NOT read the TLSFingerprint field
+// directly because it observes only the boot-time value (USK-809).
+//
+// It is NOT the dial accessor: code that hands a profile name to
+// tlslayer (DialRawOpts.UTLSProfile) must call EffectiveUTLSProfile
+// instead, which resolves the sentinel (USK-1021).
 func (c *BuildConfig) EffectiveTLSFingerprint() string {
 	if c == nil {
 		return ""
@@ -573,9 +581,11 @@ func (c *BuildConfig) EffectiveTLSFingerprint() string {
 // (USK-1021):
 //
 //   - EffectiveTLSFingerprint is the fingerprint *identity* the proxy
-//     claims. It feeds the reporting surfaces (query config / configure)
-//     and the HTTP/2 send-shape selection, both of which are already
-//     sentinel-aware.
+//     claims. It feeds the reporting surfaces (query config / configure),
+//     which distinguish an explicit "none" opt-out from an unconfigured
+//     "", and the HTTP/2 send-shape selection, which is merely
+//     sentinel-tolerant (resolveH2Fingerprint maps both "none" and "" to
+//     the default shape).
 //   - EffectiveUTLSProfile is the *dial* value. Use it wherever a profile
 //     name reaches tlslayer (DialRawOpts.UTLSProfile) or keys a cache
 //     whose entries are discriminated by the actual dial identity.
@@ -583,18 +593,33 @@ func (c *BuildConfig) EffectiveTLSFingerprint() string {
 // Passing the raw identity to the dial path is the USK-1021 bug: tlslayer
 // fail-hards on any profile name outside its parrot table, so a live
 // "none" override aborted every MITM upstream dial.
+//
+// Load-bearing invariant for the cache keys derived from this accessor
+// (poolKeyForH2, ALPNCacheKeyFromConfig): config.UTLSProfileFor must
+// never merge two identities that http2.resolveH2Fingerprint
+// distinguishes. A pooled h2 connection's SETTINGS / WINDOW_UPDATE /
+// pseudo-header send-shape is fixed at creation from the *identity*,
+// while the pool key derives from the *dial* value — so merging a pair
+// the H2 selection separates would let a connection be reused under the
+// wrong send-shape, a silent fingerprint incoherence. Today the only
+// merged set is the "none" spellings plus "", which all share both the
+// standard-crypto/tls handshake and the default H2 shape. Re-check this
+// when adding a second sentinel/alias to UTLSProfileFor, or when
+// resolveH2Fingerprint starts discriminating beyond "firefox".
 func (c *BuildConfig) EffectiveUTLSProfile() string {
 	return config.UTLSProfileFor(c.EffectiveTLSFingerprint())
 }
 
-// SetTLSFingerprint installs a runtime override for the uTLS browser
-// fingerprint profile. Subsequent calls to EffectiveTLSFingerprint
-// return profile (or fall back to the static TLSFingerprint field when
-// profile is empty). The runtime override is the wire-up consumed by
-// proxy_start / configure to make the fingerprint change reach the
-// live dial path (USK-809); writes are atomic with respect to
-// concurrent dial-path reads. Passing the empty string clears the
-// override.
+// SetTLSFingerprint installs a runtime override for the claimed TLS
+// fingerprint identity, stored unresolved — an override of "none" is
+// kept verbatim and resolved to "" only at the dial seam by
+// EffectiveUTLSProfile (USK-1021). Subsequent calls to
+// EffectiveTLSFingerprint return profile (or fall back to the static
+// TLSFingerprint field when profile is empty). The runtime override is
+// the wire-up consumed by proxy_start / configure to make the
+// fingerprint change reach the live dial path (USK-809); writes are
+// atomic with respect to concurrent dial-path reads. Passing the empty
+// string clears the override.
 func (c *BuildConfig) SetTLSFingerprint(profile string) {
 	if c == nil {
 		return

--- a/internal/connector/stack_builder_target_override.go
+++ b/internal/connector/stack_builder_target_override.go
@@ -752,9 +752,12 @@ func PerformClientMITM(
 //     cfg.ResolvePerHostTLS(target) — which remains private until a
 //     downstream Issue (USK-915) needs it.
 //
-//   - cfg.EffectiveTLSFingerprint and cfg.EffectiveUpstreamProxyForCtx
+//   - cfg.EffectiveUTLSProfile and cfg.EffectiveUpstreamProxyForCtx
 //     continue to govern uTLS profile selection and upstream-proxy
 //     traversal exactly as in the BuildConnectionStack callsite.
+//     EffectiveUTLSProfile — not EffectiveTLSFingerprint — is the dial
+//     accessor: it resolves the "none" opt-out sentinel that tlslayer
+//     would otherwise reject as an unknown parrot name (USK-1021).
 //
 //   - Observability: the (tls, on_handshake) hook fires for the "client"
 //     side (proxy dialing upstream) when snap is non-nil. Forward callers

--- a/internal/connector/stack_builder_test.go
+++ b/internal/connector/stack_builder_test.go
@@ -1072,6 +1072,183 @@ func TestBuildConfig_TLSFingerprint_NilSafe(t *testing.T) {
 	cfg.SetTLSFingerprint("chrome")
 }
 
+// TestBuildConfig_EffectiveUTLSProfile is the USK-1021 regression: the dial
+// seam must resolve the "none" opt-out sentinel to "" (standard crypto/tls)
+// while EffectiveTLSFingerprint keeps reporting the claimed identity. Before
+// the fix the raw sentinel reached DialRawOpts.UTLSProfile and tlslayer
+// hard-errored with `unsupported uTLS profile "none"`, aborting every MITM
+// upstream dial.
+//
+// The (static firefox, runtime "none") row is Case B: an explicit runtime
+// opt-out on top of a spoofing boot value must actually stop spoofing, not
+// silently keep dialing Firefox.
+func TestBuildConfig_EffectiveUTLSProfile(t *testing.T) {
+	tests := []struct {
+		name       string
+		static     string
+		override   string // "" → do not call SetTLSFingerprint
+		wantUTLS   string
+		wantIdent  string
+		nilReceive bool
+	}{
+		{name: "boot none opts out (Case A)", static: "none", wantUTLS: "", wantIdent: "none"},
+		{name: "runtime none over boot firefox opts out (Case B)", static: "firefox", override: "none", wantUTLS: "", wantIdent: "none"},
+		{name: "boot firefox dials firefox", static: "firefox", wantUTLS: "firefox", wantIdent: "firefox"},
+		{name: "runtime chrome over unset static", static: "", override: "chrome", wantUTLS: "chrome", wantIdent: "chrome"},
+		{name: "runtime firefox over boot none re-enables spoofing", static: "none", override: "firefox", wantUTLS: "firefox", wantIdent: "firefox"},
+		{name: "unset static is standard TLS", static: "", wantUTLS: "", wantIdent: ""},
+		{name: "none is case-insensitive", static: "NONE", wantUTLS: "", wantIdent: "NONE"},
+		{name: "none is trimmed", static: "  none  ", wantUTLS: "", wantIdent: "  none  "},
+		{name: "runtime none spelling variant opts out", static: "chrome", override: " None ", wantUTLS: "", wantIdent: " None "},
+		{name: "unknown profile is not silently downgraded", static: "firefx", wantUTLS: "firefx", wantIdent: "firefx"},
+		{name: "nil receiver", nilReceive: true, wantUTLS: "", wantIdent: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg *BuildConfig
+			if !tt.nilReceive {
+				cfg = &BuildConfig{TLSFingerprint: tt.static}
+				if tt.override != "" {
+					cfg.SetTLSFingerprint(tt.override)
+				}
+			}
+
+			if got := cfg.EffectiveUTLSProfile(); got != tt.wantUTLS {
+				t.Errorf("EffectiveUTLSProfile() = %q, want %q (dial value)", got, tt.wantUTLS)
+			}
+			// The claimed identity must be untouched by the resolution —
+			// reporting a bare "" for an explicit opt-out is the USK-809
+			// lying-reporter class.
+			if got := cfg.EffectiveTLSFingerprint(); got != tt.wantIdent {
+				t.Errorf("EffectiveTLSFingerprint() = %q, want %q (claimed identity)", got, tt.wantIdent)
+			}
+		})
+	}
+}
+
+// TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS pins the USK-1021
+// fix at the seam that actually matters: the MITM upstream dial. Asserting
+// EffectiveUTLSProfile() alone would not catch a regression that reverts the
+// DialRawOpts.UTLSProfile call sites to EffectiveTLSFingerprint, so this test
+// performs a real handshake against a local TLS server.
+//
+// Pre-fix, the "none" rows produced
+// `tlslayer: unsupported uTLS profile "none"` and the client leg EOF'd; the
+// firefox row is the positive control proving the seam still routes real
+// profile names into uTLS.
+func TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		static   string
+		override string // "" → do not call SetTLSFingerprint
+	}{
+		{name: "boot none (Case A)", static: "none"},
+		{name: "runtime none over boot firefox (Case B)", static: "firefox", override: "none"},
+		{name: "runtime none spelling variant", static: "chrome", override: "  NONE  "},
+		{name: "firefox still uses uTLS (positive control)", static: "firefox"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverCfg, err := newSelfSignedTLSConfig("localhost")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln.Close()
+
+			go func() {
+				conn, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				io.Copy(conn, conn)
+			}()
+
+			cfg := &BuildConfig{TLSFingerprint: tt.static}
+			if tt.override != "" {
+				cfg.SetTLSFingerprint(tt.override)
+			}
+
+			conn, snap, err := dialUpstreamWithALPN(
+				context.Background(),
+				ln.Addr().String(),
+				"localhost",
+				[]string{"http/1.1"},
+				true, // insecureSkip — self-signed test cert
+				nil,  // clientCert
+				nil,  // rootCAsConfig
+				cfg,
+			)
+			if err != nil {
+				t.Fatalf("dialUpstreamWithALPN: %v (dial seam must resolve the fingerprint identity to a uTLS profile before it reaches tlslayer)", err)
+			}
+			defer conn.Close()
+
+			if snap == nil {
+				t.Fatal("expected non-nil TLSSnapshot after a successful handshake")
+			}
+			if snap.Version == 0 {
+				t.Error("expected non-zero TLS version")
+			}
+		})
+	}
+}
+
+// TestALPNCacheKeyFromConfig_NoneResolvesToDialIdentity pins the ALPN cache
+// key to the resolved dial identity (USK-1021 D13) so a boot-time "none" and
+// a runtime "none" share one keyspace — they produce byte-identical
+// ClientHellos, so splitting them would be a pure cache miss.
+func TestALPNCacheKeyFromConfig_NoneResolvesToDialIdentity(t *testing.T) {
+	const target = "example.com:443"
+
+	bootNone := &BuildConfig{TLSFingerprint: "none"}
+	runtimeNone := &BuildConfig{TLSFingerprint: "firefox"}
+	runtimeNone.SetTLSFingerprint("none")
+
+	bootKey := ALPNCacheKeyFromConfig(target, bootNone)
+	runtimeKey := ALPNCacheKeyFromConfig(target, runtimeNone)
+
+	if bootKey.Fingerprint != "" {
+		t.Errorf("boot none Fingerprint = %q, want %q (resolved dial identity)", bootKey.Fingerprint, "")
+	}
+	if bootKey != runtimeKey {
+		t.Errorf("boot none key %+v != runtime none key %+v; identical dials must share one keyspace", bootKey, runtimeKey)
+	}
+
+	// A real profile must still key distinctly from the opt-out.
+	firefox := &BuildConfig{TLSFingerprint: "firefox"}
+	if ALPNCacheKeyFromConfig(target, firefox) == bootKey {
+		t.Error("firefox and none produced identical ALPN cache keys; ALPN learned under a uTLS parrot must not be reused for a standard-TLS dial")
+	}
+}
+
+// TestPoolKeyForH2_NoneResolvesToDialIdentity is the h2-pool counterpart of
+// TestALPNCacheKeyFromConfig_NoneResolvesToDialIdentity (USK-1021 D13).
+func TestPoolKeyForH2_NoneResolvesToDialIdentity(t *testing.T) {
+	const target = "example.com:443"
+	ctx := context.Background()
+
+	bootNone := &BuildConfig{TLSFingerprint: "none"}
+	runtimeNone := &BuildConfig{TLSFingerprint: "firefox"}
+	runtimeNone.SetTLSFingerprint("none")
+
+	bootKey := poolKeyForH2(ctx, target, bootNone, nil)
+	if bootKey != poolKeyForH2(ctx, target, runtimeNone, nil) {
+		t.Error("boot none and runtime none produced different h2 pool keys; identical dials must share one keyspace")
+	}
+
+	firefox := &BuildConfig{TLSFingerprint: "firefox"}
+	if poolKeyForH2(ctx, target, firefox, nil) == bootKey {
+		t.Error("firefox and none produced identical h2 pool keys; a pooled uTLS-parrot connection must not be reused for a standard-TLS dial")
+	}
+}
+
 // TestBuildConfig_MaxConcurrentStreamsRoundTrip verifies the new field
 // is a simple value carrier on BuildConfig (USK-713).
 func TestBuildConfig_MaxConcurrentStreamsRoundTrip(t *testing.T) {

--- a/internal/connector/stack_builder_test.go
+++ b/internal/connector/stack_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"io"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -18,7 +19,31 @@ import (
 	"github.com/usk6666/yorishiro-proxy/internal/layer/http2/pool"
 )
 
+// TestBuildConnectionStack_RawPassthrough exercises the raw-passthrough
+// branch of BuildConnectionStack, which owns the second (and only other)
+// DialRawOpts.UTLSProfile call site besides dialUpstreamWithALPN.
+//
+// The "none" row is the USK-1021 regression for this site: reverting it to
+// EffectiveTLSFingerprint would leave the bug live for the
+// tls_fingerprint=none + raw_passthrough_hosts combination, where the raw
+// sentinel reaches tlslayer and hard-errors the upstream dial.
 func TestBuildConnectionStack_RawPassthrough(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		tlsFingerprint string
+	}{
+		{name: "unset fingerprint", tlsFingerprint: ""},
+		{name: "none opts out of uTLS (USK-1021)", tlsFingerprint: "none"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runRawPassthroughStack(t, tt.tlsFingerprint)
+		})
+	}
+}
+
+func runRawPassthroughStack(t *testing.T, tlsFingerprint string) {
+	t.Helper()
+
 	// --- Setup: upstream TLS server that echoes data ---
 	serverCfg, err := newSelfSignedTLSConfig("target.example.com")
 	if err != nil {
@@ -57,6 +82,7 @@ func TestBuildConnectionStack_RawPassthrough(t *testing.T) {
 		ProxyConfig:        proxyCfg,
 		Issuer:             issuer,
 		InsecureSkipVerify: true,
+		TLSFingerprint:     tlsFingerprint,
 	}
 
 	// Use a TCP listener instead of net.Pipe to avoid TLS handshake
@@ -1084,12 +1110,12 @@ func TestBuildConfig_TLSFingerprint_NilSafe(t *testing.T) {
 // silently keep dialing Firefox.
 func TestBuildConfig_EffectiveUTLSProfile(t *testing.T) {
 	tests := []struct {
-		name       string
-		static     string
-		override   string // "" → do not call SetTLSFingerprint
-		wantUTLS   string
-		wantIdent  string
-		nilReceive bool
+		name        string
+		static      string
+		override    string // "" → do not call SetTLSFingerprint
+		wantUTLS    string
+		wantIdent   string
+		nilReceiver bool
 	}{
 		{name: "boot none opts out (Case A)", static: "none", wantUTLS: "", wantIdent: "none"},
 		{name: "runtime none over boot firefox opts out (Case B)", static: "firefox", override: "none", wantUTLS: "", wantIdent: "none"},
@@ -1101,13 +1127,13 @@ func TestBuildConfig_EffectiveUTLSProfile(t *testing.T) {
 		{name: "none is trimmed", static: "  none  ", wantUTLS: "", wantIdent: "  none  "},
 		{name: "runtime none spelling variant opts out", static: "chrome", override: " None ", wantUTLS: "", wantIdent: " None "},
 		{name: "unknown profile is not silently downgraded", static: "firefx", wantUTLS: "firefx", wantIdent: "firefx"},
-		{name: "nil receiver", nilReceive: true, wantUTLS: "", wantIdent: ""},
+		{name: "nil receiver", nilReceiver: true, wantUTLS: "", wantIdent: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var cfg *BuildConfig
-			if !tt.nilReceive {
+			if !tt.nilReceiver {
 				cfg = &BuildConfig{TLSFingerprint: tt.static}
 				if tt.override != "" {
 					cfg.SetTLSFingerprint(tt.override)
@@ -1127,27 +1153,48 @@ func TestBuildConfig_EffectiveUTLSProfile(t *testing.T) {
 	}
 }
 
+// Row names for TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS,
+// declared as constants because the post-loop positive control looks the
+// captured ClientHellos back up by row name.
+const (
+	rowDialBootNone = "boot none (Case A)"
+	rowDialFirefox  = "firefox still uses uTLS (positive control)"
+)
+
 // TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS pins the USK-1021
 // fix at the seam that actually matters: the MITM upstream dial. Asserting
 // EffectiveUTLSProfile() alone would not catch a regression that reverts the
-// DialRawOpts.UTLSProfile call sites to EffectiveTLSFingerprint, so this test
-// performs a real handshake against a local TLS server.
+// DialRawOpts.UTLSProfile call site in dialUpstreamWithALPN to
+// EffectiveTLSFingerprint, so this test performs a real handshake against a
+// local TLS server. (The sibling DialRawOpts.UTLSProfile site in
+// buildRawPassthroughStack is covered by
+// TestBuildConnectionStack_RawPassthrough's "none" row.)
 //
 // Pre-fix, the "none" rows produced
-// `tlslayer: unsupported uTLS profile "none"` and the client leg EOF'd; the
-// firefox row is the positive control proving the seam still routes real
-// profile names into uTLS.
+// `tlslayer: unsupported uTLS profile "none"` and the client leg EOF'd.
+//
+// The firefox row is the positive control. "Handshake did not error" alone
+// would not prove uTLS was engaged — a regression mapping every profile to
+// "" dials standard crypto/tls successfully — so the ClientHello is captured
+// server-side via GetConfigForClient and the firefox row's offered cipher
+// list is asserted to differ from the opt-out row's. Full JA3/JA4 coherence
+// is the e2e harness's job (internal/mcptest); this only needs to
+// discriminate uTLS-on from uTLS-off.
 func TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS(t *testing.T) {
 	tests := []struct {
 		name     string
 		static   string
 		override string // "" → do not call SetTLSFingerprint
 	}{
-		{name: "boot none (Case A)", static: "none"},
+		{name: rowDialBootNone, static: "none"},
 		{name: "runtime none over boot firefox (Case B)", static: "firefox", override: "none"},
 		{name: "runtime none spelling variant", static: "chrome", override: "  NONE  "},
-		{name: "firefox still uses uTLS (positive control)", static: "firefox"},
+		{name: rowDialFirefox, static: "firefox"},
 	}
+
+	// offeredCiphers records the cipher-suite list each row actually put on
+	// the wire, keyed by row name.
+	offeredCiphers := make(map[string][]uint16, len(tests))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1155,6 +1202,21 @@ func TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Capture the ClientHello server-side. Returning (nil, nil)
+			// keeps the original config. The channel is buffered so the
+			// handshake never blocks on the test goroutine, and it is a
+			// channel rather than a plain variable so the read below is
+			// race-free under -race.
+			helloCh := make(chan []uint16, 1)
+			serverCfg.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+				select {
+				case helloCh <- append([]uint16(nil), chi.CipherSuites...):
+				default:
+				}
+				return nil, nil
+			}
+
 			ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
 			if err != nil {
 				t.Fatal(err)
@@ -1196,7 +1258,31 @@ func TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS(t *testing.T) {
 			if snap.Version == 0 {
 				t.Error("expected non-zero TLS version")
 			}
+
+			select {
+			case suites := <-helloCh:
+				if len(suites) == 0 {
+					t.Fatal("captured ClientHello carried no cipher suites")
+				}
+				offeredCiphers[tt.name] = suites
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for the server-side ClientHello capture")
+			}
 		})
+	}
+
+	firefoxSuites, ok := offeredCiphers[rowDialFirefox]
+	if !ok {
+		t.Fatalf("no ClientHello captured for row %q", rowDialFirefox)
+	}
+	noneSuites, ok := offeredCiphers[rowDialBootNone]
+	if !ok {
+		t.Fatalf("no ClientHello captured for row %q", rowDialBootNone)
+	}
+	if slices.Equal(firefoxSuites, noneSuites) {
+		t.Errorf("firefox and none offered identical ClientHello cipher suites %v; "+
+			"the firefox row must dial through the uTLS parrot, not the Go-native stack "+
+			"(a regression resolving every profile to \"\" would look like this)", firefoxSuites)
 	}
 }
 

--- a/internal/layer/tlslayer/tlslayer_test.go
+++ b/internal/layer/tlslayer/tlslayer_test.go
@@ -367,18 +367,34 @@ func TestClient_NilTLSConfig(t *testing.T) {
 	}
 }
 
+// TestClient_UnsupportedUTLSProfile pins the fail-hard contract: any
+// UTLSProfile outside the parrot table must error rather than silently
+// degrade to a Go-native ClientHello — a silent downgrade is exactly the
+// fingerprint lie M47 exists to prevent.
+//
+// The "none" row documents the resolution boundary (USK-1021): the config
+// opt-out sentinel is resolved to "" upstream, at
+// connector.BuildConfig.EffectiveUTLSProfile. This layer knows nothing about
+// it and must keep erroring, so the boundary is not allowed to migrate down
+// into internal/layer/.
 func TestClient_UnsupportedUTLSProfile(t *testing.T) {
-	plain, server := net.Pipe()
-	defer plain.Close()
-	defer server.Close()
+	profiles := []string{"nonexistent", "none"}
 
-	opts := ClientOpts{
-		TLSConfig:   &tls.Config{ServerName: "test"},
-		UTLSProfile: "nonexistent",
-	}
+	for _, profile := range profiles {
+		t.Run(profile, func(t *testing.T) {
+			plain, server := net.Pipe()
+			defer plain.Close()
+			defer server.Close()
 
-	_, _, err := Client(context.Background(), plain, opts)
-	if err == nil {
-		t.Fatal("expected error with unsupported uTLS profile")
+			opts := ClientOpts{
+				TLSConfig:   &tls.Config{ServerName: "test"},
+				UTLSProfile: profile,
+			}
+
+			_, _, err := Client(context.Background(), plain, opts)
+			if err == nil {
+				t.Fatalf("expected error with unsupported uTLS profile %q", profile)
+			}
+		})
 	}
 }

--- a/internal/mcp/configure_tls_fingerprint_test.go
+++ b/internal/mcp/configure_tls_fingerprint_test.go
@@ -7,6 +7,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/usk6666/yorishiro-proxy/internal/config"
+	"github.com/usk6666/yorishiro-proxy/internal/connector"
 	"github.com/usk6666/yorishiro-proxy/internal/connector/transport"
 	"github.com/usk6666/yorishiro-proxy/internal/flow"
 	"github.com/usk6666/yorishiro-proxy/internal/proxybuild"
@@ -511,6 +512,124 @@ func TestResetSettingsToDefaults_RebuildsTLSTransport(t *testing.T) {
 	}
 	if !ut.InsecureSkipVerify {
 		t.Error("InsecureSkipVerify should be inherited from initial transport")
+	}
+}
+
+// setupLiveBuildConfigSession wires an MCP session to a proxybuild.Manager
+// bound to buildCfg. Unlike setupTLSFingerprintTestSession (which passes a
+// nil manager and only observes the test-only tlsFingerprintSetter), this
+// harness exercises the production path: proxy_start / configure install
+// their runtime override on a real *connector.BuildConfig, so the test can
+// assert what the LIVE MITM upstream dial would actually do.
+func setupLiveBuildConfigSession(t *testing.T, buildCfg *connector.BuildConfig, opts ...ServerOption) *gomcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+
+	manager := newTestProxybuildManagerWithBuildConfig(t, buildCfg)
+	ca := newTestCA(t)
+	s := newServer(ctx, ca, nil, manager, opts...)
+
+	ct, st := gomcp.NewInMemoryTransports()
+	ss, err := s.server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { ss.Close() })
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	return cs
+}
+
+// assertLiveDialOptsOut is the shared assertion for the USK-1021 fix: the
+// live dial must select the standard crypto/tls stack (empty uTLS profile)
+// while the reported identity still says "none". Reporting "" here would be
+// the USK-809 lying-reporter class; dialing "none" is the USK-1021 crash.
+func assertLiveDialOptsOut(t *testing.T, buildCfg *connector.BuildConfig) {
+	t.Helper()
+	if got := buildCfg.EffectiveUTLSProfile(); got != "" {
+		t.Errorf("EffectiveUTLSProfile() = %q, want %q — tlslayer hard-errors on any name outside its parrot table, so the live MITM dial fails", got, "")
+	}
+	if got := buildCfg.EffectiveTLSFingerprint(); got != "none" {
+		t.Errorf("EffectiveTLSFingerprint() = %q, want %q (claimed identity must survive the dial-seam resolution)", got, "none")
+	}
+}
+
+// TestProxyStart_TLSFingerprint_NoneFromConfigDefault_LiveDialUsesStandardTLS
+// is the USK-1021 Case A regression through the real MCP surface: a server
+// booted with `-tls-fingerprint none` and then hit with a plain proxy_start
+// (no explicit tls_fingerprint) used to install the raw "none" sentinel as
+// the live-dial override, so every MITM upstream dial failed with
+// `tlslayer: unsupported uTLS profile "none"`.
+func TestProxyStart_TLSFingerprint_NoneFromConfigDefault_LiveDialUsesStandardTLS(t *testing.T) {
+	buildCfg := &connector.BuildConfig{TLSFingerprint: "none"}
+	cs := setupLiveBuildConfigSession(t, buildCfg,
+		WithProxyDefaults(&config.ProxyConfig{TLSFingerprint: "none"}),
+	)
+
+	result, err := callProxyStart(t, cs, map[string]any{"listen_addr": "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	assertLiveDialOptsOut(t, buildCfg)
+}
+
+// TestProxyStart_TLSFingerprint_NoneOverBootFirefox_LiveDialUsesStandardTLS
+// is the USK-1021 Case B regression: an explicit runtime opt-out layered on
+// top of a spoofing boot value must actually stop spoofing. The naive fix
+// (mapping "none" to "" before Manager.SetTLSFingerprint) would CLEAR the
+// override instead, silently falling back to the boot-time firefox parrot.
+func TestProxyStart_TLSFingerprint_NoneOverBootFirefox_LiveDialUsesStandardTLS(t *testing.T) {
+	buildCfg := &connector.BuildConfig{TLSFingerprint: "firefox"}
+	cs := setupLiveBuildConfigSession(t, buildCfg)
+
+	result, err := callProxyStart(t, cs, map[string]any{
+		"listen_addr":     "127.0.0.1:0",
+		"tls_fingerprint": "none",
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	assertLiveDialOptsOut(t, buildCfg)
+}
+
+// TestConfigure_TLSFingerprint_NoneOverBootFirefox_LiveDialUsesStandardTLS
+// is Case B through the configure tool, plus the positive control: switching
+// back to firefox must re-enable the uTLS parrot on the live dial path.
+func TestConfigure_TLSFingerprint_NoneOverBootFirefox_LiveDialUsesStandardTLS(t *testing.T) {
+	buildCfg := &connector.BuildConfig{TLSFingerprint: "firefox"}
+	cs := setupLiveBuildConfigSession(t, buildCfg)
+
+	none := "none"
+	if result := callConfigure(t, cs, configureInput{TLSFingerprint: &none}); result.IsError {
+		t.Fatalf("configure none: expected success, got error: %v", result.Content)
+	}
+	assertLiveDialOptsOut(t, buildCfg)
+
+	// Positive control: the opt-out is not sticky — a later firefox
+	// selection must reach the dial path as a real uTLS parrot.
+	firefox := "firefox"
+	if result := callConfigure(t, cs, configureInput{TLSFingerprint: &firefox}); result.IsError {
+		t.Fatalf("configure firefox: expected success, got error: %v", result.Content)
+	}
+	if got := buildCfg.EffectiveUTLSProfile(); got != "firefox" {
+		t.Errorf("EffectiveUTLSProfile() = %q, want firefox after switching back", got)
+	}
+	if got := buildCfg.EffectiveTLSFingerprint(); got != "firefox" {
+		t.Errorf("EffectiveTLSFingerprint() = %q, want firefox after switching back", got)
 	}
 }
 

--- a/internal/mcpserver/init.go
+++ b/internal/mcpserver/init.go
@@ -525,10 +525,14 @@ func NewLiveBuildConfig(
 	// USK-1013: default the upstream TLS fingerprint to firefox (camoufox
 	// coherence). Pass a nil cfg so the live-dial path keeps its proxyCfg-only
 	// contract (it has historically not consulted top-level cfg.TLSFingerprint,
-	// unlike the resend axis in InitTLSTransport). The resolver maps the "none"
-	// opt-out sentinel to "" so bc.EffectiveTLSFingerprint() selects the
-	// standard crypto/tls stack (clientStandard) rather than hard-erroring the
-	// dial on an unknown uTLS profile.
+	// unlike the resend axis in InitTLSTransport).
+	//
+	// USK-1021: the stored value is the fingerprint *identity*, so an explicit
+	// "none" is kept verbatim rather than flattened to "" — that keeps the
+	// reporting surfaces able to distinguish "operator opted out" from
+	// "nothing configured", and matches what a runtime proxy_start / configure
+	// override installs. The sentinel is resolved to the standard crypto/tls
+	// stack at the dial seam by bc.EffectiveUTLSProfile().
 	bc.TLSFingerprint = config.ResolveTLSFingerprint(nil, proxyCfg)
 
 	return bc
@@ -743,10 +747,10 @@ func applyHostTLSEntries(reg *transport.HostTLSRegistry, entries map[string]*con
 //     `tls_fingerprint`. Kept for backward compatibility.
 //  3. "firefox" — the default when both are empty (camoufox coherence).
 //
-// The "none" opt-out sentinel resolves to "" (via config.ResolveTLSFingerprint)
-// and falls back to StandardTransport.
+// The "none" opt-out sentinel resolves to "" (via config.UTLSProfileFor) and
+// falls back to StandardTransport.
 func InitTLSTransport(cfg *config.Config, proxyCfg *config.ProxyConfig, reg *transport.HostTLSRegistry, logger *slog.Logger) transport.TLSTransport {
-	fingerprint := config.ResolveTLSFingerprint(cfg, proxyCfg)
+	fingerprint := config.UTLSProfileFor(config.ResolveTLSFingerprint(cfg, proxyCfg))
 
 	if fingerprint != "" {
 		profile, err := transport.ParseBrowserProfile(fingerprint)

--- a/internal/mcpserver/init_test.go
+++ b/internal/mcpserver/init_test.go
@@ -539,21 +539,29 @@ func TestInitTLSTransport_InvalidProfileFallback(t *testing.T) {
 
 // TestNewLiveBuildConfig_TLSFingerprintDefault verifies the live-dial boot
 // path (USK-1013): an unset fingerprint is pinned to the firefox default,
-// "none" opts out to standard TLS (empty EffectiveTLSFingerprint → clientStandard),
-// and an explicit profile passes through. The live path is proxyCfg-only, so
-// a top-level cfg.TLSFingerprint must NOT leak in when proxyCfg is empty.
+// "none" opts out to standard TLS, and an explicit profile passes through.
+// The live path is proxyCfg-only, so a top-level cfg.TLSFingerprint must NOT
+// leak in when proxyCfg is empty.
+//
+// USK-1021 contract change: an explicit "none" is now STORED verbatim (it was
+// flattened to "" before) so the reporting surfaces can distinguish "operator
+// opted out" from "nothing configured", matching what a runtime
+// proxy_start / configure "none" override installs. The opt-out is applied at
+// the dial seam instead — bc.EffectiveUTLSProfile() is "" and therefore
+// selects clientStandard.
 func TestNewLiveBuildConfig_TLSFingerprintDefault(t *testing.T) {
 	tests := []struct {
 		name       string
 		proxyFP    string
 		topLevelFP string
 		wantStored string // bc.TLSFingerprint
-		wantEffect string // bc.EffectiveTLSFingerprint()
+		wantEffect string // bc.EffectiveTLSFingerprint() — claimed identity
+		wantUTLS   string // bc.EffectiveUTLSProfile() — dial value
 	}{
-		{"unset defaults to firefox", "", "", "firefox", "firefox"},
-		{"none opts out to standard TLS", "none", "", "", ""},
-		{"explicit chrome passes through", "chrome", "", "chrome", "chrome"},
-		{"live path ignores top-level cfg", "", "safari", "firefox", "firefox"},
+		{"unset defaults to firefox", "", "", "firefox", "firefox", "firefox"},
+		{"none opts out to standard TLS at the dial seam", "none", "", "none", "none", ""},
+		{"explicit chrome passes through", "chrome", "", "chrome", "chrome", "chrome"},
+		{"live path ignores top-level cfg", "", "safari", "firefox", "firefox", "firefox"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -566,7 +574,10 @@ func TestNewLiveBuildConfig_TLSFingerprintDefault(t *testing.T) {
 				t.Errorf("bc.TLSFingerprint = %q, want %q", bc.TLSFingerprint, tt.wantStored)
 			}
 			if got := bc.EffectiveTLSFingerprint(); got != tt.wantEffect {
-				t.Errorf("bc.EffectiveTLSFingerprint() = %q, want %q (selects clientStandard when empty)", got, tt.wantEffect)
+				t.Errorf("bc.EffectiveTLSFingerprint() = %q, want %q (claimed identity)", got, tt.wantEffect)
+			}
+			if got := bc.EffectiveUTLSProfile(); got != tt.wantUTLS {
+				t.Errorf("bc.EffectiveUTLSProfile() = %q, want %q (selects clientStandard when empty)", got, tt.wantUTLS)
 			}
 		})
 	}

--- a/internal/mcptest/fingerprint_coherence_integration_test.go
+++ b/internal/mcptest/fingerprint_coherence_integration_test.go
@@ -71,12 +71,17 @@ var firefoxH2Shape = fpH2Shape{
 	pseudo:     []string{":method", ":path", ":authority", ":scheme"},
 }
 
-// chromeH2Shape is the default (Chrome-ish) baseline every non-firefox
-// profile — including "none" — resolves to: SETTINGS 1:4096, 2:0, 3:500,
-// 4:16777216, 5:16384 (MAX_CONCURRENT_STREAMS present), a 16 MiB - 65535
-// connection-window bump, and pseudo-header order :method :scheme :authority
-// :path.
-var chromeH2Shape = fpH2Shape{
+// defaultH2Shape is the proxy's historical (Chrome-ish) baseline that every
+// non-firefox profile — including "none" — resolves to via
+// resolveH2Fingerprint: SETTINGS 1:4096, 2:0, 3:500, 4:16777216, 5:16384
+// (MAX_CONCURRENT_STREAMS present), a 16 MiB - 65535 connection-window bump,
+// and pseudo-header order :method :scheme :authority :path.
+//
+// It is named "default", not "chrome", because it is the proxy's own
+// pre-USK-1007 send-shape rather than a real Chrome 120 capture; the chrome
+// sub-test asserts it as a baseline, and the none sub-test asserts it because
+// a profile claiming no browser identity has nothing to be coherent with.
+var defaultH2Shape = fpH2Shape{
 	settings: []frame.Setting{
 		{ID: frame.SettingHeaderTableSize, Value: 4096},
 		{ID: frame.SettingEnablePush, Value: 0},
@@ -105,25 +110,20 @@ func TestE2E_FingerprintCoherence_UpstreamShape(t *testing.T) {
 		fingerprint string
 		helloID     *utls.ClientHelloID // nil for "none" (standard crypto/tls)
 		wantH2      fpH2Shape
-		skip        string // non-empty → t.Skip referencing the blocking Issue
 	}{
-		{"firefox", "firefox", &utls.HelloFirefox_Auto, firefoxH2Shape, ""},
-		{"chrome", "chrome", &utls.HelloChrome_Auto, chromeH2Shape, ""},
-		// USK-1021: proxy_start installs the raw "none" sentinel as the
-		// live-dial override instead of resolving it to "" (standard TLS),
-		// so the MITM upstream dial fails with `unsupported uTLS profile
-		// "none"`. This sub-case is the regression test — un-skip once the
-		// fix lands. Do NOT weaken the assertions to make it pass
-		// (MITM-diagnostic test philosophy).
-		{"none", "none", nil, chromeH2Shape, "not yet implemented: USK-1021 (proxy_start none→standard-TLS override)"},
+		{"firefox", "firefox", &utls.HelloFirefox_Auto, firefoxH2Shape},
+		{"chrome", "chrome", &utls.HelloChrome_Auto, defaultH2Shape},
+		// USK-1021 regression: proxy_start used to install the raw "none"
+		// sentinel as the live-dial override instead of resolving it to ""
+		// (standard TLS) at the dial seam, so the MITM upstream dial failed
+		// with `unsupported uTLS profile "none"`. Do NOT weaken the
+		// assertions (MITM-diagnostic test philosophy).
+		{"none", "none", nil, defaultH2Shape},
 	}
 
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.skip != "" {
-				t.Skip(tc.skip)
-			}
 			// ResolveTLSFingerprint defaults unset → firefox, so every
 			// sub-test MUST set -tls-fingerprint explicitly.
 			h := mcptest.StartHarness(t, mcptest.HarnessOptions{

--- a/internal/proxybuild/manager.go
+++ b/internal/proxybuild/manager.go
@@ -942,14 +942,20 @@ func (m *Manager) MaxConcurrentStreams() uint32 {
 	return bc.EffectiveMaxConcurrentStreams()
 }
 
-// TLSFingerprint returns the effective uTLS browser fingerprint profile
-// from the bound BuildConfig (USK-809). The returned value reflects any
-// runtime override installed via SetTLSFingerprint and falls back to
-// the boot-time BuildConfig.TLSFingerprint when no override is in
-// effect. Returns the empty string when no BuildConfig is bound — the
-// caller is responsible for translating empty into a user-facing
-// representation if desired (this accessor does NOT substitute the
-// "firefox" boot default — empty stays empty).
+// TLSFingerprint returns the claimed TLS fingerprint *identity* from the
+// bound BuildConfig (USK-809) — the "none" opt-out sentinel included,
+// returned verbatim rather than resolved to a uTLS parrot name. The
+// returned value reflects any runtime override installed via
+// SetTLSFingerprint and falls back to the boot-time
+// BuildConfig.TLSFingerprint when no override is in effect. Returns the
+// empty string when no BuildConfig is bound — the caller is responsible
+// for translating empty into a user-facing representation if desired
+// (this accessor does NOT substitute the "firefox" boot default — empty
+// stays empty).
+//
+// This is a reporting accessor, not a dial value: every consumer feeds a
+// user-facing surface. Dial-path code calls
+// BuildConfig.EffectiveUTLSProfile instead (USK-1021).
 func (m *Manager) TLSFingerprint() string {
 	m.mu.Lock()
 	bc := m.buildCfg


### PR DESCRIPTION
## Summary
- `config.ResolveTLSFingerprint` is now **identity-preserving**: it still owns the `firefox` default and the proxyCfg → cfg → default precedence, but returns the `"none"` opt-out sentinel verbatim instead of flattening it to `""`.
- New `config.UTLSProfileFor(fingerprint) string` owns the `"none"` escape hatch (case-insensitive, trimmed). Only that sentinel maps to `""`; everything else passes through, so `tlslayer`'s fail-hard-on-typo property survives (a `"firefx"` typo must never silently degrade to a Go-native ClientHello).
- New `connector.BuildConfig.EffectiveUTLSProfile()` derives the **dial** value from `EffectiveTLSFingerprint()`. The two `DialRawOpts.UTLSProfile` sites (`stack_builder.go`) and the two cache-key sites (`h2_pool.go`, `alpn_routing.go`) switch to it.
- The four `WithH2Fingerprint` sites intentionally keep reading `EffectiveTLSFingerprint()` — `resolveH2Fingerprint` is already sentinel-aware and the resulting wire is byte-identical either way.
- `InitTLSTransport` (resend axis) becomes `UTLSProfileFor(ResolveTLSFingerprint(...))`, preserving its current end behavior.

**Root cause**: `-tls-fingerprint none` resolved correctly at boot but was re-broken by `proxy_start`. `applyProxyDefaultTLSStrings` copied the raw `"none"` into the input, `applyTLSFingerprint` installed it as the dynamic live-dial override, and `tlslayer` hard-errored on every MITM upstream dial with `unsupported uTLS profile "none"` (the client leg then EOF'd).

**Why not resolve `"none"` → `""` before `manager.SetTLSFingerprint`** (the originally-filed fix direction): `BuildConfig.SetTLSFingerprint("")` *clears* the override, so an explicit runtime `none` on top of a boot-time `firefox` would have silently fallen back to spoofing Firefox. Putting the resolution at the dial seam instead makes that failure mode structurally unreachable, keeps the two-state override channel consistent with its two sibling knobs (`upstreamProxyDynamic`, `maxConcurrentStreamsDynamic`), and changes **zero lines** in `internal/mcp/` production code and `internal/layer/`.

**Invariant after this change**: `EffectiveTLSFingerprint()` = the identity the proxy claims (reporting, H2 shape); `EffectiveUTLSProfile()` = the uTLS parrot to dial, with `""` meaning standard crypto/tls.

## Behavior change (intentional)
`NewLiveBuildConfig` now **stores** `"none"` rather than flattening it to `""`. A server booted with `-tls-fingerprint none` therefore reports `tls_fingerprint: "none"` from `query config` / `query status` instead of `""`.

This closes a pre-existing reporting asymmetry: boot-`none` reported `""` while a runtime `configure{tls_fingerprint:"none"}` reported `"none"`. `""` is already pinned as "no fingerprint configured" (`query_tool_test.go`), and the `"none"` round-trip is pinned by two existing fast tests, so `"none"` is the correct spelling for an explicit opt-out. Reporting `""` for an explicit opt-out would be the USK-809 lying-reporter class.

## Test plan
- [x] `internal/config/config_tls_test.go` — new `TestUTLSProfileFor` (9 rows: `none`/`NONE`/`  none  `/`  NoNe  ` → `""`; `firefox`/`chrome`/`""`/`firefx`/`nonexistent` passthrough). `TestResolveTLSFingerprint`'s three `none` rows updated to the identity-preserving expectation.
- [x] `internal/connector/stack_builder_test.go` — new `TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS` performs a **real TLS handshake** through `dialUpstreamWithALPN` against a local server, so a regression at the `DialRawOpts.UTLSProfile` call sites (not just the accessor) fails the fast tier. Covers Case A (boot `none`), Case B (runtime `none` over boot `firefox`), a spelling variant, and a `firefox` positive control.
- [x] `internal/connector/stack_builder_test.go` — new `TestBuildConfig_EffectiveUTLSProfile` (11 rows) asserting both the dial value **and** that the claimed identity is untouched; plus `TestALPNCacheKeyFromConfig_NoneResolvesToDialIdentity` and `TestPoolKeyForH2_NoneResolvesToDialIdentity` for cache-key coherence.
- [x] `TestBuildConfig_TLSFingerprint_DynamicOverride` left **unchanged** — it proves the two-state clear semantics survives.
- [x] `internal/mcp/configure_tls_fingerprint_test.go` — Case A and Case B through the **real MCP surface** with a bound `connector.BuildConfig`: `proxy_start` inheriting `proxyDefaults{TLSFingerprint:"none"}`, `proxy_start{tls_fingerprint:"none"}` over boot-`firefox`, and `configure{tls_fingerprint:"none"}` over boot-`firefox` (with a switch-back-to-firefox positive control). Existing `"none"` round-trip assertions untouched and green.
- [x] `internal/mcp/query_config_resource_test.go` — existing `{"none","none"}` and clear-semantics cases green **unchanged** (regression guard against a fix that flattens the reported value).
- [x] `internal/mcpserver/init_test.go` — `TestNewLiveBuildConfig_TLSFingerprintDefault`'s `none` row updated to `wantStored:"none"` / `wantEffect:"none"` and a new `wantUTLS:""` column added across all rows.
- [x] `internal/layer/tlslayer/tlslayer_test.go` — `TestClient_UnsupportedUTLSProfile` table-ised with a `"none"` row documenting that this layer must **keep** erroring, so the resolution boundary cannot migrate down into `internal/layer/`.
- [x] `internal/mcptest/fingerprint_coherence_integration_test.go` — the `none` sub-case is un-skipped with all assertions unweakened (JA4 ≠ firefox-ref, JA4 ≠ chrome-ref, zero GREASE ciphers, default H2 shape) and the `//go:build e2e && !e2e_smoke` tag preserved. Cosmetic: `chromeH2Shape` → `defaultH2Shape` (it is the proxy's historical send-shape, not a real Chrome 120 capture).
- [x] Negative control verified: temporarily reverting `EffectiveUTLSProfile` to return the raw identity fails `TestDialUpstreamWithALPN_NoneFingerprintDialsStandardTLS`, `TestBuildConfig_EffectiveUTLSProfile`, and `TestALPNCacheKeyFromConfig_NoneResolvesToDialIdentity`.
- [x] `make lint`, `make build`, `make test` (fast tier) all pass; `go vet` clean under `-tags e2e` and `-tags 'e2e e2e_smoke'`.

## Not executed
The un-skipped `none` e2e sub-case was **not run** — the full tier needs network and a live capture upstream. It compiles clean under `-tags e2e` and `-tags 'e2e e2e_smoke'`; the fast-tier tests above lock Case A and Case B deterministically. It will first execute in the nightly full-tier run.

Resolves USK-1021
Linear: https://linear.app/usk6666/issue/USK-1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013th9oiLKhMcQCNf3eQmsYR
